### PR TITLE
Fix closing passed sessions

### DIFF
--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -51,7 +51,7 @@ class AqualinkClient(object):
             self._must_clean_session = True
         else:
             self.session = session
-            self._must_clean_session = True
+            self._must_clean_session = False
 
         self.session_id = None
         self.token = None


### PR DESCRIPTION
Sessions passed to the library, should not be closed.
I suspect this to be a typo.

Since this package is used in Home Assistant, and the Home Assistant aiohttp session is passed, this library might actually close Home Assistant' session.
