### PR TITLE
Support different brands of Colored Lights

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.4
+current_version = 0.3.5
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name="iaqualink",
-    version="0.3.4",
+    version="0.3.5",
     description="Asynchronous library for Jandy iAqualink",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/src/iaqualink/__init__.py
+++ b/src/iaqualink/__init__.py
@@ -15,7 +15,6 @@ from .device import (
     AqualinkDimmableLight,
     AqualinkHeater,
     AqualinkLight,
-    AqualinkLightEffect,
     AqualinkLightToggle,
     AqualinkLightType,
     AqualinkPump,

--- a/src/iaqualink/__init__.py
+++ b/src/iaqualink/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 __author__ = "Florent Thoumie"
 __email__ = "florent@thoumie.net"
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 
 from .client import AqualinkClient, AqualinkLoginException

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -196,14 +196,14 @@ class TestAqualinkColorLight(asynctest.TestCase):
     @asynctest.strict
     async def test_set_effect(self) -> None:
         data = {"aux": "1", "light": "2", "subtype": "5"}
-        await self.obj.set_effect("2")
+        await self.obj.set_effect_by_num("2")
         self.obj.system.set_light.assert_called_once_with(data)
 
     @asynctest.strict
     async def test_set_effect_invalid(self) -> None:
         self.obj.system.set_light = asynctest.CoroutineMock(return_value=None)
         with pytest.raises(Exception):
-            await self.obj.set_effect("42")
+            await self.obj.set_effect_by_name("bad effect name")
 
 
 class TestAqualinkThermostat(asynctest.TestCase):


### PR DESCRIPTION
Change AqualinkLightType from a simple Enum to a full-featured dataclass.
Replace the AqualinkLightEffect Enum with a string to string mapping (so that we can use spaces and punctuation in the display names.)
Add the light types and effect names as retrieved from a REV T.2 AquaLink device.
Allow retrieving the supported light effects for the current device.
Allow setting the light effect by name or by number.
Fix a few type warnings.

Corresponding changes in home-assistant/core: https://github.com/SteveOnorato/core/commit/b84328c7c3eae62cca248f96abdd5c77a8476bb4