### PR TITLE
Fix Exo bugs

### DIFF
--- a/src/iaqualink/systems/exo/device.py
+++ b/src/iaqualink/systems/exo/device.py
@@ -68,6 +68,8 @@ class ExoDevice(AqualinkDevice):
             class_ = ExoSensor
         elif data["name"] == "heating":
             class_ = ExoThermostat
+        elif data["name"] == "heater":
+            class_ = ExoHeater
         elif data["name"] in ["production", "boost", "low"]:
             class_ = ExoAttributeSwitch
         else:
@@ -138,11 +140,13 @@ class ExoAttributeSwitch(ExoSwitch):
     def _command(self) -> Callable[[str, int], Coroutine[Any, Any, None]]:
         return self.system.set_toggle
 
+class ExoHeater(ExoDevice):
+    """This device is to seperate the state of the heater from the thermostat to maintain the existing homeassistant API"""
 
 class ExoThermostat(ExoSwitch, AqualinkThermostat):
     @property
     def state(self) -> str:
-        return str(self.data["enabled"])
+        return str(self.data["sp"])
 
     @property
     def unit(self) -> str:
@@ -150,7 +154,11 @@ class ExoThermostat(ExoSwitch, AqualinkThermostat):
 
     @property
     def _sensor(self) -> ExoSensor:
-        return cast(ExoSensor, self.system.devices["water_temp"])
+        return cast(ExoSensor, self.system.devices["sns_3"])
+
+    @property
+    def _heater(self) -> ExoHeater:
+        return cast(ExoSensor, self.system.devices["heater"])
 
     @property
     def current_temperature(self) -> str:

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -32,6 +32,7 @@ class ExoSystem(AqualinkSystem):
         super().__init__(aqualink, data)
         # This lives in the parent class but mypy complains.
         self.last_refresh: int = 0
+        self.temp_unit = "C" #TODO: check if unit can be changed on panel?
 
     def __repr__(self) -> str:
         attrs = ["name", "serial", "data"]
@@ -106,12 +107,20 @@ class ExoSystem(AqualinkSystem):
         # Remove those values, they're not handled properly.
         devices.pop("boost_time", None)
         devices.pop("vsp_speed", None)
+        devices.pop("sn", None)
+        devices.pop("vr", None)
+        devices.pop("version", None)
 
         # Process the heating control attributes
         if "heating" in data["state"]["reported"]:
             name = "heating"
             attrs = {"name": name}
             attrs.update(data["state"]["reported"]["heating"])
+            devices.update({name: attrs})
+            # extract heater state into seperate device to maintain homeassistant API
+            name = "heater"
+            attrs = {"name": name}
+            attrs.update({"state": data["state"]["reported"]["heating"]["state"]})
             devices.update({name: attrs})
 
         LOGGER.debug(f"devices: {devices}")

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -33,6 +33,7 @@ LOGGER = logging.getLogger("iaqualink")
 class AqualinkState(Enum):
     OFF = "0"
     ON = "1"
+    STANDBY = "2"
     ENABLED = "3"
     ABSENT = "absent"
     PRESENT = "present"

--- a/tests/systems/exo/test_device.py
+++ b/tests/systems/exo/test_device.py
@@ -230,7 +230,7 @@ class TestExoThermostat(TestExoDevice, TestBaseThermostat):
             self.pool_set_point,
             self.water_temp,
         ]
-        self.system.devices = {x.name: x for x in devices}
+        self.system.devices = {x.data["name"]: x for x in devices}
 
         self.sut = self.pool_set_point
         self.sut_class = ExoThermostat
@@ -242,7 +242,7 @@ class TestExoThermostat(TestExoDevice, TestBaseThermostat):
         assert self.sut.name == "heating"
 
     def test_property_state(self) -> None:
-        assert self.sut.state == "1"
+        assert self.sut.state == "20"
 
     def test_property_is_on_true(self) -> None:
         self.sut.data["enabled"] = 1


### PR DESCRIPTION
Intent is to maintain existing API compatability with Homeassistant.
- Fix bug referencing incorrect 'Sensor' for temperature PV.
- Add temperature unit
- Ignore serial number and versions (issues parsing strings into floats)
- Extract the heater state feedback into it's own 'device' to align with the iAqua heater control structure, to allow the state property to hold the temperature SP.
- Associated test fixes