### PR TITLE
Adding OneTouch Get and Set

### DIFF
--- a/live_onetouch_test.py
+++ b/live_onetouch_test.py
@@ -1,0 +1,114 @@
+import sys
+import os
+
+# Add the project's src directory to sys.path
+# This ensures that the 'iaqualink' module can be found when running the script directly,
+# especially if the editable install isn't adding it to sys.path as expected.
+_project_root = os.path.dirname(os.path.abspath(__file__))
+_src_path = os.path.join(_project_root, "src")
+if _src_path not in sys.path:
+    sys.path.insert(0, _src_path)
+
+import asyncio
+import logging
+
+from iaqualink import AqualinkClient
+from iaqualink.systems.iaqua.system import IaquaSystem # To ensure isinstance check works
+from iaqualink.exception import AqualinkServiceException
+
+# --- Configuration ---
+# !!! IMPORTANT: Fill these in with your actual credentials and serial number !!!
+USERNAME = "YOUR_EMAIL_HERE"
+PASSWORD = "YOUR_PASSWORD_HERE"
+TARGET_SERIAL = "YOUR_SYSTEM_SERIAL_HERE"
+ONETOUCH_INDEX_TO_TEST = 6
+
+# --- Logging Setup ---
+# You can adjust the logging level if needed (e.g., logging.DEBUG for more detail)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+async def main():
+    logger.info("Starting OneTouch live test script.")
+
+    if USERNAME == "YOUR_EMAIL_HERE" or PASSWORD == "YOUR_PASSWORD_HERE" or TARGET_SERIAL == "YOUR_SYSTEM_SERIAL_HERE":
+        logger.error("Please update USERNAME, PASSWORD, and TARGET_SERIAL in the script before running.")
+        return
+
+    # client = AqualinkClient(username=USERNAME, password=PASSWORD)
+    # Using async context manager for client session handling
+    async with AqualinkClient(username=USERNAME, password=PASSWORD) as client:
+        try:
+            logger.info(f"Attempting to log in as {USERNAME}...")
+            # Login is handled by __aenter__ when using async context manager
+            # await client.login() 
+            if not client.logged:
+                 # This should not happen if __aenter__ succeeds without raising an exception
+                logger.error("Client did not log in successfully through context manager.")
+                return
+            logger.info("Login successful.")
+
+            logger.info("Fetching all available systems...")
+            systems = await client.get_systems()
+            
+            if not systems:
+                logger.warning("No systems found for this account.")
+                return
+
+            logger.info(f"Found {len(systems)} system(s): {list(systems.keys())}")
+
+            target_system = None
+            for serial, system_obj in systems.items():
+                if serial == TARGET_SERIAL:
+                    if isinstance(system_obj, IaquaSystem):
+                        target_system = system_obj
+                        logger.info(f"Found target iAqualink system: {TARGET_SERIAL}")
+                        break
+                    else:
+                        logger.warning(f"System {TARGET_SERIAL} found, but it's not an IaquaSystem (type: {type(system_obj).__name__}). Skipping OneTouch tests.")
+                        return
+            
+            if not target_system:
+                logger.error(f"Target system with serial {TARGET_SERIAL} not found in the account.")
+                return
+
+            logger.info(f"--- Testing OneTouch for system: {target_system.name} ({target_system.serial}) ---")
+
+            logger.info(f"Fetching initial OneTouch state for index {ONETOUCH_INDEX_TO_TEST} (and others)...")
+            initial_onetouch_state = await target_system.get_onetouch()
+            logger.info(f"Initial OneTouch states: {initial_onetouch_state}")
+            
+            initial_switch = next((s for s in initial_onetouch_state if s.get("index") == ONETOUCH_INDEX_TO_TEST), None)
+            if initial_switch:
+                logger.info(f"Initial state of OneTouch {ONETOUCH_INDEX_TO_TEST} ('{initial_switch.get('label')}'): State={initial_switch.get('state')}, Status={initial_switch.get('status')}")
+            else:
+                logger.warning(f"OneTouch index {ONETOUCH_INDEX_TO_TEST} not found in initial state.")
+
+            logger.info(f"Attempting to toggle OneTouch index {ONETOUCH_INDEX_TO_TEST}...")
+            try:
+                updated_onetouch_state_after_set = await target_system.set_onetouch(ONETOUCH_INDEX_TO_TEST)
+                logger.info(f"Successfully called set_onetouch({ONETOUCH_INDEX_TO_TEST}).")
+                logger.info(f"OneTouch states after toggle: {updated_onetouch_state_after_set}")
+
+                final_switch = next((s for s in updated_onetouch_state_after_set if s.get("index") == ONETOUCH_INDEX_TO_TEST), None)
+                if final_switch:
+                    logger.info(f"New state of OneTouch {ONETOUCH_INDEX_TO_TEST} ('{final_switch.get('label')}'): State={final_switch.get('state')}, Status={final_switch.get('status')}")
+                else:
+                    logger.warning(f"OneTouch index {ONETOUCH_INDEX_TO_TEST} not found in state after toggle.")
+
+            except AqualinkServiceException as e_toggle:
+                logger.error(f"Error toggling OneTouch index {ONETOUCH_INDEX_TO_TEST}: {e_toggle}")
+            except Exception as e_toggle_unexpected:
+                logger.error(f"An unexpected error occurred while toggling OneTouch: {e_toggle_unexpected}", exc_info=True)
+
+        except AqualinkServiceException as e_service:
+            logger.error(f"An AqualinkServiceException occurred: {e_service}")
+        except Exception as e_general:
+            logger.error(f"An unexpected error occurred: {e_general}", exc_info=True)
+    # No finally needed here as the async context manager handles client.close()
+    logger.info("Live test script finished.")
+
+if __name__ == "__main__":
+    logger.warning("This script is for live testing and contains placeholder credentials.")
+    logger.warning("Ensure you fill them in and DO NOT commit this file with real credentials.")
+    asyncio.run(main()) 

--- a/src/iaqualink/__init__.py
+++ b/src/iaqualink/__init__.py
@@ -1,0 +1,21 @@
+from .client import AqualinkClient
+from .system import AqualinkSystem
+from .device import AqualinkDevice
+from .exception import (
+    AqualinkServiceException,
+    AqualinkServiceUnauthorizedException,
+    AqualinkSystemOfflineException,
+    AqualinkSystemUnsupportedException,
+    AqualinkDeviceNotSupported,
+)
+
+__all__ = [
+    "AqualinkClient",
+    "AqualinkSystem",
+    "AqualinkDevice",
+    "AqualinkServiceException",
+    "AqualinkServiceUnauthorizedException",
+    "AqualinkSystemOfflineException",
+    "AqualinkSystemUnsupportedException",
+    "AqualinkDeviceNotSupported",
+]

--- a/src/iaqualink/onetouch.py
+++ b/src/iaqualink/onetouch.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict, List
+
+def parse_onetouch_response(data: dict[str, Any]) -> List[dict[str, Any]]:
+    """Parse the onetouch_screen response into a list of switches with label, state, and status."""
+    switches = []
+    for item in data.get("onetouch_screen", []):
+        # Each item is a dict with a key like 'onetouch_1', 'onetouch_2', etc.
+        key = next(iter(item.keys()), None)
+        if key and key.startswith("onetouch_"):
+            # Each value is a list of dicts with 'status', 'state', 'label'
+            switch_info = {d_k: d_v for d in item[key] for d_k, d_v in d.items()}
+            switch_info["index"] = int(key.split("_")[-1])
+            switches.append(switch_info)
+    return switches

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, AsyncMock, ANY
 
 import pytest
+import httpx
 
 from iaqualink.exception import (
     AqualinkServiceUnauthorizedException,
@@ -136,3 +137,86 @@ class TestIaquaSystem(TestBaseSystem):
 
         with pytest.raises(AqualinkServiceUnauthorizedException):
             await self.sut._send_devices_screen_request()
+
+    @patch("httpx.AsyncClient.request", new_callable=AsyncMock)
+    async def test_get_onetouch(self, mock_httpx_request):
+        if not isinstance(self.sut.aqualink._client, httpx.AsyncClient) or isinstance(self.sut.aqualink._client, MagicMock):
+             self.sut.aqualink._client = httpx.AsyncClient()
+        self.sut.aqualink._id_token = "mock_test_id_token"
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json = AsyncMock(return_value={
+            "onetouch_screen": [
+                {"onetouch_1": [{"status": "1"}, {"state": "0"}, {"label": "All OFF"}]},
+                {"onetouch_2": [{"status": "1"}, {"state": "0"}, {"label": "Spa Mode"}]},
+            ]
+        })
+        mock_response.raise_for_status = AsyncMock()
+        mock_httpx_request.return_value = mock_response
+
+        result = await self.sut.get_onetouch()
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["label"] == "All OFF"
+        assert result[0]["index"] == 1
+        assert result[1]["label"] == "Spa Mode"
+        assert result[1]["index"] == 2
+        
+        expected_url = f"https://p-api.iaqualink.net/v2/mobile/session.json?actionID=command&command=get_onetouch&serial={self.sut.serial}"
+        # These are the headers as they are passed to httpx.AsyncClient.request
+        expected_final_headers = {
+            "user-agent": "okhttp/3.14.7",
+            "content-type": "application/json",
+            "authorization": "mock_test_id_token"
+        }
+
+        mock_httpx_request.assert_any_call(
+            "get",
+            expected_url,
+            headers=expected_final_headers
+            # No json, params, content, or data for this GET request directly to client.request
+        )
+
+    @patch("httpx.AsyncClient.request", new_callable=AsyncMock)
+    async def test_set_onetouch(self, mock_httpx_request):
+        if not isinstance(self.sut.aqualink._client, httpx.AsyncClient) or isinstance(self.sut.aqualink._client, MagicMock):
+             self.sut.aqualink._client = httpx.AsyncClient()
+        self.sut.aqualink._id_token = "mock_test_id_token"
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json = AsyncMock(return_value={
+            "onetouch_screen": [
+                {"onetouch_1": [{"status": "1"}, {"state": "1"}, {"label": "All OFF"}]},
+                {"onetouch_2": [{"status": "1"}, {"state": "0"}, {"label": "Spa Mode"}]},
+            ]
+        })
+        mock_response.raise_for_status = AsyncMock()
+        mock_httpx_request.return_value = mock_response
+
+        onetouch_index_to_set = 1
+        result = await self.sut.set_onetouch(onetouch_index_to_set)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["state"] == "1"
+        assert result[0]["index"] == onetouch_index_to_set
+
+        expected_url = "https://p-api.iaqualink.net/v2/mobile/session.json"
+        expected_payload = {
+            "actionID": "command", # Order changed to match code construction
+            "command": f"set_onetouch_{onetouch_index_to_set}",
+            "serial": self.sut.serial,
+        }
+        # These are the headers as they are passed to httpx.AsyncClient.request
+        expected_final_headers = {
+            "user-agent": "okhttp/3.14.7",
+            "content-type": "application/json",
+            "authorization": "mock_test_id_token"
+        }
+        
+        mock_httpx_request.assert_any_call(
+            "post",
+            expected_url,
+            headers=expected_final_headers,
+            json=expected_payload
+            # No params, content, or data for this POST request directly to client.request
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,6 +18,9 @@ LOGIN_DATA = {
     "id": "id",
     "authentication_token": "token",
     "session_id": "session_id",
+    "userPoolOAuth": {
+        "IdToken": "mock_id_token"
+    }
 }
 
 


### PR DESCRIPTION
related issue: https://github.com/flz/iaqualink-py/issues/39

- added get and set functions
- updated send request function to accept v2 option
- added v2 api url and post function needed for set_onetouch
- added unit tests for new onetouch code
- added a live test script in root with credential placeholders