### PR TITLE
Check that a state update is valid before updating device values

### DIFF
--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -125,7 +125,11 @@ class IaquaSystem(AqualinkSystem):
         for k, v in devices.items():
             if k in self.devices:
                 for dk, dv in v.items():
-                    self.devices[k].data[dk] = dv
+                    # Don't allow empty updates through, except current temperature which can be empty depending on if it is in pool mode or spa mode
+                    if (dv != '') or (k == 'spa_temp') or (k == 'pool_temp'):
+                        self.devices[k].data[dk] = dv
+                    else:
+                        LOGGER.debug(f"Received empty update for home screen device {k}: {dk}, skipping")
             else:
                 try:
                     self.devices[k] = IaquaDevice.from_data(self, v)
@@ -147,6 +151,9 @@ class IaquaSystem(AqualinkSystem):
             aux = next(iter(x.keys()))
             attrs = {"aux": aux.replace("aux_", ""), "name": aux}
             for y in next(iter(x.values())):
+                if 'NaN' in y.values():
+                    LOGGER.debug("Received invalid devices screen state update, skipping")
+                    return
                 attrs.update(y)
             devices.update({aux: attrs})
 


### PR DESCRIPTION
Problem:
The Jandy api sends out a garbage state update after the lights are set (for some reason). We need to ignore these messages, otherwise the invalid system state will cause all commands for the next ~30 seconds to fail in strange ways.

For example, failing to set the value of lights and switches with the error "'`NaN' is not a valid Aqualink state`" Or `ValueError: could not convert string to float: ''`. See related open HA issue described: https://github.com/home-assistant/core/issues/156960

Here is what the update from the API looks like after turning a light on or off:

> Devices response: {'message': '', 'devices_screen': [{'status': 'Online'}, {'response': "AQU='70','0C 00 01 02 03 05 06 07 0E 0F 1A 20 21 00 03 00 03 00 58 00 46 00 51 00 00 00 42 30 33 31 36 38 32 33 20 52 53 2D 34 20 43 6F 6D 62 6F 00 00'"}, {'group': '1'}, {'aux_': [{'state': '0'}, {'label': 'AUX '}, {'icon': 'aux_3_0.png'}, {'type': '0'}, {'subtype': '3'}]}, {'aux_1': [{'state': '88'}, {'label': 'AUX 1'}, {'icon': 'aux_0_88.png'}, {'type': '70'}, {'subtype': '0'}]}, {'aux_2': [{'state': 'NaN'}, {'label': 'AUX 2'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}, {'aux_3': [{'state': 'NaN'}, {'label': 'AUX 3'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}, {'aux_5': [{'state': 'NaN'}, {'label': 'AUX 5'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}, {'aux_6': [{'state': 'NaN'}, {'label': 'AUX 6'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}, {'aux_7': [{'state': 'NaN'}, {'label': 'AUX 7'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}, {'aux_B7': [{'state': 'NaN'}, {'label': 'AUX B7'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}, {'aux_B8': [{'state': 'NaN'}, {'label': 'AUX B8'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}, {'aux_D3': [{'state': 'NaN'}, {'label': 'AUX D3'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}, {'aux_C5': [{'state': 'NaN'}, {'label': 'AUX C5'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}, {'aux_C6': [{'state': 'NaN'}, {'label': 'AUX C6'}, {'icon': 'aux_NaN_NaN.png'}, {'type': 'NaN'}, {'subtype': 'NaN'}]}], 'icl_info_list': []}
> 
> Home response: {'message': '', 'serial': 'QT75K6NQJGGB', 'home_screen': [{'status': 'Online'}, {'response': "AQU='72','32|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|0|1|0|0|Flood Light|1|1|1|100|Beach Light|1|7|2|1|Aux3|0|1|0|2|Aux V1|0|1|0|2|Aux V2|0|1|0|2|Aux V3|0|1|0|2|Aux V4|1|1|0|2|Aux V5|1|1|0|2|Aux V6|0|1|0|2|Aux V7|0|1|0|2|Aux V8|0|1|0|2|Aux V9|0|1|0|2|Aux V10|0|1|0|2|Aux V11|0|1|0|2|Aux V12|0|1|0|2|Aux V13|0|1|0|2|Aux V14|0|1|0|2|Aux V15|0|1|0|2|Aux V16|0|1|0|2|Aux V17|0|1|0|2|Aux V18|0|1|0|2|Aux V19|1|1|0|2|Aux V20|1|1|0|2|Aux V21|1|1|0|2|Aux V22|1|1|0|2|Aux V23|1|1|0|2|Aux V24|1|1|0|2|Aux V25|1|1|0|2|Aux V26|0|1|0|2|Aux V27|0|1|0|2|Aux V28|1|1|0|0|Extra Aux'"}, {'system_type': ''}, {'temp_scale': ''}, {'spa_temp': ''}, {'pool_temp': ''}, {'air_temp': ''}, {'spa_set_point': ''}, {'pool_set_point': ''}, {'cover_pool': ''}, {'freeze_protection': ''}, {'spa_pump': ''}, {'pool_pump': ''}, {'spa_heater': ''}, {'pool_heater': ''}, {'solar_heater': ''}, {'spa_salinity': ''}, {'pool_salinity': ''}, {'orp': ''}, {'ph': ''}, {'is_icl_present': 'absent'}, {'icl_custom_color_info': []}, {'heatpump_info': {}}, {'pool_chill_set_point': ''}, {'swc_info': {'isswcPresent': False}}, {'relay_count': ''}]}

Solution:
The jandy api provides two separate sets of update data. One is "home screen" and one is "devices screen" each corresponding to a page in the jandy native mobile app.

Devices Screen:
After a light is set, the devices screen update will have mostly 'NaN' values as the update data. However, it may also have various random numerical value or empty values as well. If we see any NaN values in the update, we can assume that the entire update is unreliable and skip it. This circumvents the issue of needing to know whether a devices' state should be in the list of valid "Aqualink states" or if it should be a numerical value, or if it should allow empty values. If it is not flagged as a bad update by having NaN values, we will simply assume that the jandy api is giving us good data and allow it all through.

Home Screen:
After a light is set, the home screen will have mostly empty values, however sadly the presence of empty values is not a good way to determine if the update is bad since there will likely always be some empty values present depending on how the system is configured. And so in this case, we simply skip any empty values on an individual basis. However, I allow empty values through for pool_temp or spa_temp, because an empty update is valid for current temperature depending on the mode of the pool/spa system.

Note: This fix only applies to the iaqua system, a similar fix may be needed for other systems

Confidence Testing:
Able to switch lights on and off, and control other switches immediately after toggling a light, without any errors.