### PR TITLE
Add VSP (variable speed pump) support for iAqua systems

### DIFF
--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -80,7 +80,9 @@ class IaquaDevice(AqualinkDevice):
         if isinstance(data["state"], dict | list):
             raise AqualinkDeviceNotSupported(data)
 
-        if data["name"].endswith("_heater") or data["name"].endswith("_pump"):
+        if data["name"].endswith("_pump"):
+            class_ = IaquaPump
+        elif data["name"].endswith("_heater"):
             class_ = IaquaSwitch
         elif data["name"].endswith("_set_point"):
             if data["state"] == "":
@@ -133,6 +135,59 @@ class IaquaSwitch(IaquaBinarySensor, AqualinkSwitch):
     async def turn_off(self) -> None:
         if self.is_on:
             await self._toggle()
+
+
+class IaquaPump(IaquaSwitch):
+    """VSP (variable speed pump) with speed preset support."""
+
+    def __init__(self, system: IaquaSystem, data: DeviceData):
+        super().__init__(system, data)
+        self._speed_presets: list[dict] | None = None
+        self._active_speed_id: int | None = None
+        self._active_speed_rpm: int | None = None
+
+    @property
+    def speed(self) -> int | None:
+        """Current pump speed in RPM, or None if not yet fetched."""
+        return self._active_speed_rpm
+
+    @property
+    def speed_id(self) -> int | None:
+        """Currently active speed preset ID (1-8), or None if not yet fetched."""
+        return self._active_speed_id
+
+    @property
+    def speed_presets(self) -> list[dict] | None:
+        """List of speed presets from get_vsp_speedauxinfo, or None if not yet fetched."""
+        return self._speed_presets
+
+    async def fetch_speed(self, slot_id: int = 1) -> int | None:
+        """Fetch current speed from VSP API and update local state. Returns RPM."""
+        data = await self.system.get_vsp_speed(slot_id)
+        self._speed_presets = data.get("vsp_speedInfo", [])
+        self._active_speed_id = None
+        self._active_speed_rpm = None
+        for preset in self._speed_presets:
+            if preset.get("enabled") == "true":
+                self._active_speed_id = int(preset["speedid"])
+                self._active_speed_rpm = int(preset["speedvalue"])
+                break
+        return self._active_speed_rpm
+
+    async def set_speed(self, speed_id: int, slot_id: int = 1) -> None:
+        """Set the active speed preset (1-8) on this pump."""
+        if speed_id < 1 or speed_id > 8:
+            raise AqualinkInvalidParameterException(
+                f"speed_id must be 1-8, got {speed_id}"
+            )
+        await self.system.set_vsp_speed(speed_id, slot_id)
+        self._active_speed_id = speed_id
+        # Update RPM from presets if available
+        if self._speed_presets:
+            for preset in self._speed_presets:
+                if int(preset["speedid"]) == speed_id:
+                    self._active_speed_rpm = int(preset["speedvalue"])
+                    break
 
 
 class IaquaAuxSwitch(IaquaSwitch):

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -34,6 +34,9 @@ IAQUA_COMMAND_SET_SPA_HEATER = "set_spa_heater"
 IAQUA_COMMAND_SET_SPA_PUMP = "set_spa_pump"
 IAQUA_COMMAND_SET_TEMPS = "set_temps"
 
+IAQUA_COMMAND_GET_VSP_SPEED = "get_vsp_speedauxinfo"
+IAQUA_COMMAND_SET_VSP_SPEED = "enable_disable_pump_speedId"
+
 
 LOGGER = logging.getLogger("iaqualink")
 
@@ -187,3 +190,24 @@ class IaquaSystem(AqualinkSystem):
     async def set_light(self, data: Payload) -> None:
         r = await self._send_session_request(IAQUA_COMMAND_SET_LIGHT, data)
         self._parse_devices_response(r)
+
+    async def get_vsp_speed(self, slot_id: int = 1) -> Payload:
+        """Get VSP speed presets and active speed for a pump slot."""
+        r = await self._send_session_request(
+            IAQUA_COMMAND_GET_VSP_SPEED, {"slot_id": str(slot_id)}
+        )
+        return r.json()
+
+    async def set_vsp_speed(
+        self, speed_id: int, slot_id: int = 1
+    ) -> Payload:
+        """Enable a speed preset on a VSP pump slot."""
+        r = await self._send_session_request(
+            IAQUA_COMMAND_SET_VSP_SPEED,
+            {
+                "slot_id": str(slot_id),
+                "speed_id": str(speed_id),
+                "on_off_action": "on",
+            },
+        )
+        return r.json()


### PR DESCRIPTION
## Summary

- Add `IaquaPump` device class (extends `IaquaSwitch`) with speed preset read/write support
- Route `_pump` device names to `IaquaPump` in `from_data()` (backwards-compatible — on/off still works)
- Add `get_vsp_speed()` and `set_vsp_speed()` methods to `IaquaSystem`
- Uses undocumented iAquaLink session API commands: `get_vsp_speedauxinfo` and `enable_disable_pump_speedId`

## Details

The iAquaLink cloud API exposes VSP pump speed data through undocumented session commands (discovered by reverse-engineering the Android APK). This PR adds support for:

- **Reading speed**: `IaquaPump.fetch_speed(slot_id)` calls `get_vsp_speedauxinfo` and populates `speed` (RPM), `speed_id` (active preset 1-8), and `speed_presets` (all 8 presets with names/RPM values)
- **Setting speed**: `IaquaPump.set_speed(speed_id, slot_id)` calls `enable_disable_pump_speedId` with `on_off_action=on` to activate a preset

Tested on a live system: Jandy ePump on AquaLink RS-4 (iAqua system type), successfully switched between speed presets.

## Test plan

- [x] All existing tests pass (185 passed, 4 skipped)
- [x] `_pump` devices now create `IaquaPump` instead of `IaquaSwitch`
- [x] `IaquaPump` inherits all `IaquaSwitch` behavior (turn_on/turn_off via toggle)
- [x] Verified on live hardware: read speed presets, switch active preset, verify RPM change

🤖 Generated with [Claude Code](https://claude.com/claude-code)