### PR TITLE
feat(iaqua): add OneTouch polling, control, and session/country fixes

### DIFF
--- a/docs/api/iaqua.md
+++ b/docs/api/iaqua.md
@@ -27,10 +27,11 @@ All session requests use:
 
 ### Device Refresh
 
-iAqua systems use a two-step refresh process:
+iAqua systems use a two- or three-step refresh process:
 
-1. **Home data** - Basic system information
+1. **Home data** - Basic system information and OneTouch support flag
 2. **Device data** - Detailed device states
+3. **OneTouch data** - OneTouch scene states (only when `"onetouch": "true"` in home response)
 
 ```python
 # Implemented internally by IaquaSystem.update()
@@ -87,6 +88,12 @@ Temperature ranges:
 ### Auxiliary Devices
 
 - `aux_1` through `aux_7` - Configurable auxiliary switches
+
+### OneTouch Scenes
+
+- `onetouch_1` through `onetouch_N` - Saved scenes (only present when system advertises `"onetouch": "true"` in the home response)
+
+OneTouch scenes have toggle semantics: sending the command flips the scene state. `turn_on()` activates an inactive scene; `turn_off()` deactivates an active one.
 
 ### Chemistry Sensors
 

--- a/docs/guide/devices.md
+++ b/docs/guide/devices.md
@@ -79,6 +79,26 @@ await aux_1.turn_on()
 await aux_1.turn_off()
 ```
 
+### OneTouch Scenes
+
+Saved scenes that activate a preset combination of device states. Only present on systems that advertise OneTouch support in the home response.
+
+```python
+# List available scenes
+onetouch_scenes = {
+    name: device
+    for name, device in devices.items()
+    if name.startswith("onetouch_")
+}
+
+# Activate a scene (toggle semantics: fires command regardless of guard)
+morning = devices.get("onetouch_1")
+if morning:
+    print(f"{morning.label}: {'active' if morning.is_on else 'inactive'}")
+    await morning.turn_on()   # activates if inactive
+    await morning.turn_off()  # deactivates if active
+```
+
 ### Lights
 
 Special switches with toggle support:
@@ -245,7 +265,7 @@ except AqualinkServiceException as e:
 iAqua systems have these specific characteristics:
 - Devices use numeric IDs
 - Commands sent via session requests
-- Two-step state refresh
+- Two-step state refresh (home + devices); three-step when OneTouch is advertised
 
 ### eXO Devices
 

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -177,7 +177,12 @@ class AqualinkClient:
         kwargs.setdefault("timeout", DEFAULT_REQUEST_TIMEOUT)
 
         LOGGER.debug("-> %s %s %s", method.upper(), url, kwargs)
-        r = await client.request(method, url, headers=headers, **kwargs)
+        try:
+            r = await client.request(method, url, headers=headers, **kwargs)
+        except httpx.ReadTimeout as e:
+            raise AqualinkServiceException(
+                f"Request timed out: {method.upper()} {url}"
+            ) from e
 
         LOGGER.debug("<- %s %s - %s", r.status_code, r.reason_phrase, url)
 

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -100,6 +100,7 @@ class AqualinkClient:
         self.user_id = ""
         self.id_token = ""
         self.refresh_token = ""
+        self.country = ""
         self._refresh_lock = asyncio.Lock()
 
         self._last_refresh = 0
@@ -148,6 +149,12 @@ class AqualinkClient:
         try:
             if not self._logged:
                 await self.login()
+            else:
+                # Auth was restored from a persisted session; force a refresh to
+                # obtain fresh tokens and populate attributes (e.g. country) that
+                # are not stored in the session.
+                self._logged = False
+                await self._refresh_auth()
         except AqualinkServiceException:
             await self.close()
             raise
@@ -273,6 +280,7 @@ class AqualinkClient:
         self.user_id = ""
         self.id_token = ""
         self.refresh_token = ""
+        self.country = ""
         self._logged = False
 
     def _apply_login_data(
@@ -287,6 +295,7 @@ class AqualinkClient:
         self.refresh_token = data["userPoolOAuth"].get(
             "RefreshToken", refresh_token_fallback
         )
+        self.country = (data.get("country") or "us").lower()
         self._logged = True
 
     async def _send_systems_request(self) -> httpx.Response:

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -205,6 +205,7 @@ class AqualinkClient:
             self._client = httpx.AsyncClient(
                 http2=True,
                 limits=httpx.Limits(keepalive_expiry=KEEPALIVE_EXPIRY),
+                timeout=10,
             )
         return self._client
 

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -183,7 +183,7 @@ class AqualinkClient:
             # TransportError covers all Timeout* and Connect*/Read*/WriteError variants;
             # OSError covers platform-level socket errors (e.g. "network unreachable").
             raise AqualinkServiceException(
-                f"Request failed: {method.upper()} {url}"
+                f"Request failed: {method.upper()} {url}: {e}"
             ) from e
 
         LOGGER.debug("<- %s %s - %s", r.status_code, r.reason_phrase, url)

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -179,9 +179,9 @@ class AqualinkClient:
         LOGGER.debug("-> %s %s %s", method.upper(), url, kwargs)
         try:
             r = await client.request(method, url, headers=headers, **kwargs)
-        except httpx.TimeoutException as e:
+        except Exception as e:
             raise AqualinkServiceException(
-                f"Request timed out: {method.upper()} {url}"
+                f"Request failed: {method.upper()} {url}"
             ) from e
 
         LOGGER.debug("<- %s %s - %s", r.status_code, r.reason_phrase, url)
@@ -205,7 +205,6 @@ class AqualinkClient:
             self._client = httpx.AsyncClient(
                 http2=True,
                 limits=httpx.Limits(keepalive_expiry=KEEPALIVE_EXPIRY),
-                timeout=10,
             )
         return self._client
 

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -179,7 +179,7 @@ class AqualinkClient:
         LOGGER.debug("-> %s %s %s", method.upper(), url, kwargs)
         try:
             r = await client.request(method, url, headers=headers, **kwargs)
-        except httpx.ReadTimeout as e:
+        except httpx.TimeoutException as e:
             raise AqualinkServiceException(
                 f"Request timed out: {method.upper()} {url}"
             ) from e

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -179,7 +179,9 @@ class AqualinkClient:
         LOGGER.debug("-> %s %s %s", method.upper(), url, kwargs)
         try:
             r = await client.request(method, url, headers=headers, **kwargs)
-        except Exception as e:
+        except (httpx.TransportError, OSError) as e:
+            # TransportError covers all Timeout* and Connect*/Read*/WriteError variants;
+            # OSError covers platform-level socket errors (e.g. "network unreachable").
             raise AqualinkServiceException(
                 f"Request failed: {method.upper()} {url}"
             ) from e

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -122,6 +122,8 @@ class IaquaSwitch(IaquaBinarySensor, AqualinkSwitch):
 
 
 class IaquaOneTouchSwitch(IaquaSwitch):
+    # set_onetouch has toggle semantics: sending the command flips the scene
+    # state, so the inherited turn_on/turn_off guards are correct as-is.
     async def _toggle(self) -> None:
         await self.system.set_onetouch(self.data["name"])
 

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -125,14 +125,6 @@ class IaquaOneTouchSwitch(IaquaSwitch):
     # set_onetouch has toggle semantics: sending the command flips the scene
     # state, so the inherited turn_on/turn_off guards are correct as-is.
     async def _toggle(self) -> None:
-        # "status" controls availability (can this scene be activated?);
-        # "state" is the current on/off value populated by the onetouch response.
-        # IaquaBinaryState.OFF == "0" applies to both fields by coincidence.
-        if self.data.get("status") == IaquaBinaryState.OFF:
-            LOGGER.warning(
-                "OneTouch %s is unavailable (status=0); skipping.", self.name
-            )
-            return
         await self.system.set_onetouch(self.data["name"])
 
 

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -125,6 +125,9 @@ class IaquaOneTouchSwitch(IaquaSwitch):
     # set_onetouch has toggle semantics: sending the command flips the scene
     # state, so the inherited turn_on/turn_off guards are correct as-is.
     async def _toggle(self) -> None:
+        # "status" controls availability (can this scene be activated?);
+        # "state" is the current on/off value populated by the onetouch response.
+        # IaquaBinaryState.OFF == "0" applies to both fields by coincidence.
         if self.data.get("status") == IaquaBinaryState.OFF:
             LOGGER.warning(
                 "OneTouch %s is unavailable (status=0); skipping.", self.name

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -498,4 +498,5 @@ _HOME_DEVICE_MAP: dict[str, type[IaquaDevice]] = {
     "pool_set_point": IaquaThermostat,
     "pool_chill_set_point": IaquaThermostat,
     "relay_count": IaquaSensor,
+    "one_touch": IaquaBinarySensor,
 }

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -125,6 +125,11 @@ class IaquaOneTouchSwitch(IaquaSwitch):
     # set_onetouch has toggle semantics: sending the command flips the scene
     # state, so the inherited turn_on/turn_off guards are correct as-is.
     async def _toggle(self) -> None:
+        if self.data.get("status") == IaquaBinaryState.OFF:
+            LOGGER.warning(
+                "OneTouch %s is unavailable (status=0); skipping.", self.name
+            )
+            return
         await self.system.set_onetouch(self.data["name"])
 
 

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -121,6 +121,11 @@ class IaquaSwitch(IaquaBinarySensor, AqualinkSwitch):
             await self._toggle()
 
 
+class IaquaOneTouchSwitch(IaquaSwitch):
+    async def _toggle(self) -> None:
+        await self.system.set_onetouch(self.data["name"])
+
+
 class IaquaHeater(IaquaSwitch):
     @property
     def is_on(self) -> bool:

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -498,5 +498,4 @@ _HOME_DEVICE_MAP: dict[str, type[IaquaDevice]] = {
     "pool_set_point": IaquaThermostat,
     "pool_chill_set_point": IaquaThermostat,
     "relay_count": IaquaSensor,
-    "one_touch": IaquaBinarySensor,
 }

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -133,9 +133,11 @@ class IaquaSystem(AqualinkSystem):
             try:
                 r3 = await self._send_onetouch_screen_request()
             except AqualinkServiceThrottledException:
+                self.status = SystemStatus.UNKNOWN
                 raise
             except AqualinkServiceException:
-                LOGGER.warning("OneTouch request failed; skipping this update.")
+                self.status = SystemStatus.ERROR
+                raise
 
         try:
             self._parse_devices_response(r2)

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -37,6 +37,7 @@ IAQUA_COMMAND_GET_HOME = "get_home"
 IAQUA_COMMAND_GET_ONETOUCH = "get_onetouch"
 
 IAQUA_COMMAND_SET_AUX = "set_aux"
+IAQUA_COMMAND_SET_ONETOUCH = "set_onetouch"
 IAQUA_COMMAND_SET_LIGHT = "set_light"
 IAQUA_COMMAND_SET_POOL_HEATER = "set_pool_heater"
 IAQUA_COMMAND_SET_POOL_PUMP = "set_pool_pump"
@@ -102,10 +103,14 @@ class IaquaSystem(AqualinkSystem):
     async def _send_devices_screen_request(self) -> httpx.Response:
         return await self._send_session_request(IAQUA_COMMAND_GET_DEVICES)
 
+    async def _send_onetouch_screen_request(self) -> httpx.Response:
+        return await self._send_session_request(IAQUA_COMMAND_GET_ONETOUCH)
+
     async def update(self) -> None:
         try:
             r1 = await self._send_home_screen_request()
             r2 = await self._send_devices_screen_request()
+            r3 = await self._send_onetouch_screen_request()
         except AqualinkServiceThrottledException:
             self.status = SystemStatus.UNKNOWN
             raise
@@ -116,6 +121,7 @@ class IaquaSystem(AqualinkSystem):
         try:
             self._parse_home_response(r1)
             self._parse_devices_response(r2)
+            self._parse_onetouch_response(r3)
         except AqualinkSystemOfflineException:
             self.status = SystemStatus.OFFLINE
             raise
@@ -240,3 +246,36 @@ class IaquaSystem(AqualinkSystem):
     async def set_light(self, data: Payload) -> None:
         r = await self._send_session_request(IAQUA_COMMAND_SET_LIGHT, data)
         self._parse_devices_response(r)
+
+    def _parse_onetouch_response(self, response: httpx.Response) -> None:
+        data = response.json()
+
+        LOGGER.debug(f"OneTouch response: {data}")
+
+        if data["one_touch"][0]["status"] == "Offline":
+            LOGGER.warning(f"Status for system {self.serial} is Offline.")
+            raise AqualinkSystemOfflineException
+
+        # Make the data a bit flatter.
+        devices = {}
+        for x in data["one_touch"][2:]:
+            name = next(iter(x.keys()))
+            attrs = {"name": name}
+            for y in next(iter(x.values())):
+                attrs.update(y)
+            devices[name] = attrs
+
+        for k, v in devices.items():
+            if k in self.devices:
+                for dk, dv in v.items():
+                    self.devices[k].data[dk] = dv
+            else:
+                try:
+                    self.devices[k] = IaquaDevice.from_data(self, v)
+                except AqualinkDeviceNotSupported as e:
+                    LOGGER.debug("Device found was ignored: %s", e)
+
+    async def set_onetouch(self, name: str) -> None:
+        cmd = IAQUA_COMMAND_SET_ONETOUCH + "_" + name.replace("onetouch_", "")
+        r = await self._send_session_request(cmd)
+        self._parse_onetouch_response(r)

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -277,10 +277,10 @@ class IaquaSystem(AqualinkSystem):
     def _parse_onetouch_response(self, response: httpx.Response) -> None:
         data = response.json()
 
-        LOGGER.debug(f"OneTouch response: {data}")
+        LOGGER.debug("OneTouch response: %s", data)
 
-        if data["one_touch"][0]["status"] == "Offline":
-            LOGGER.warning(f"Status for system {self.serial} is Offline.")
+        if data["one_touch"][0]["status"] != "Online":
+            LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
         # Make the data a bit flatter.
@@ -331,6 +331,6 @@ class IaquaSystem(AqualinkSystem):
         self._parse_devices_response(r)
 
     async def set_onetouch(self, name: str) -> None:
-        cmd = IAQUA_COMMAND_SET_ONETOUCH + "_" + name.replace("onetouch_", "")
+        cmd = IAQUA_COMMAND_SET_ONETOUCH + "_" + name.removeprefix("onetouch_")
         r = await self._send_session_request(cmd)
         self._parse_onetouch_response(r)

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -124,6 +124,8 @@ class IaquaSystem(AqualinkSystem):
             try:
                 r3 = await self._send_onetouch_screen_request()
                 self._onetouch_supported = True
+            except AqualinkServiceThrottledException:
+                raise
             except AqualinkServiceException:
                 if self._onetouch_supported is None:
                     LOGGER.warning(
@@ -299,6 +301,34 @@ class IaquaSystem(AqualinkSystem):
                     self.devices[k] = IaquaDevice.from_data(self, v)
                 except AqualinkDeviceNotSupported as e:
                     LOGGER.debug("Device found was ignored: %s", e)
+
+    async def set_switch(self, command: str) -> None:
+        r = await self._send_session_request(command)
+        self._parse_home_response(r)
+
+    async def set_temps(self, temps: Payload) -> None:
+        # I'm not proud of this. If you read this, please submit a PR to make it better.
+        # We need to pass the temperatures for both pool and spa (if present) in the same request.
+        # Set args to current target temperatures and override with the request payload.
+        args = {}
+        i = 1
+        if "spa_set_point" in self.devices:
+            args[f"temp{i}"] = self.devices["spa_set_point"].target_temperature
+            i += 1
+        args[f"temp{i}"] = self.devices["pool_set_point"].target_temperature
+        args.update(temps)
+
+        r = await self._send_session_request(IAQUA_COMMAND_SET_TEMPS, args)
+        self._parse_home_response(r)
+
+    async def set_aux(self, aux: str) -> None:
+        aux = IAQUA_COMMAND_SET_AUX + "_" + aux.replace("aux_", "")
+        r = await self._send_session_request(aux)
+        self._parse_devices_response(r)
+
+    async def set_light(self, data: Payload) -> None:
+        r = await self._send_session_request(IAQUA_COMMAND_SET_LIGHT, data)
+        self._parse_devices_response(r)
 
     async def set_onetouch(self, name: str) -> None:
         cmd = IAQUA_COMMAND_SET_ONETOUCH + "_" + name.replace("onetouch_", "")

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -287,13 +287,13 @@ class IaquaSystem(AqualinkSystem):
 
         LOGGER.debug("OneTouch response: %s", data)
 
-        if data["one_touch"][0]["status"] == "Offline":
+        if data["onetouch_screen"][0]["status"] == "Offline":
             LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
         # Make the data a bit flatter.
         devices = {}
-        for x in data["one_touch"][2:]:
+        for x in data["onetouch_screen"][2:]:
             name = next(iter(x.keys()))
             attrs = {"name": name}
             for y in next(iter(x.values())):

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -58,7 +58,8 @@ class IaquaSystem(AqualinkSystem):
 
         self.system_type: IaquaSystemType | None = None
         self.temp_unit: IaquaTemperatureUnit | None = None
-        # None = not yet tried, True = working, False = disabled
+        # Re-evaluated from the home response on every update() call.
+        # None = home response not yet parsed; True/False = last home response value.
         self._onetouch_supported: bool | None = None
 
     def __repr__(self) -> str:

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -12,6 +12,7 @@ from iaqualink.exception import (
 from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import (
     IaquaAuxSwitch,
+    IaquaBinaryState,
     IaquaDimmableLight,
     IaquaLightSwitch,
     IaquaOneTouchSwitch,
@@ -301,6 +302,9 @@ class IaquaSystem(AqualinkSystem):
             attrs = {"name": name}
             for y in val:
                 attrs.update(y)
+            if attrs.get("status") == IaquaBinaryState.OFF:
+                self.devices.pop(name, None)
+                continue
             if name in self.devices:
                 for dk, dv in attrs.items():
                     self.devices[name].data[dk] = dv

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -275,25 +275,25 @@ class IaquaSystem(AqualinkSystem):
 
         LOGGER.debug("OneTouch response: %s", data)
 
-        if data["onetouch_screen"][0]["status"] == "Offline":
+        onetouch: dict = {}
+        for x in data["onetouch_screen"]:
+            onetouch.update(x)
+
+        if onetouch["status"] == "Offline":
             LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
-        # Make the data a bit flatter.
-        devices = {}
-        for x in data["onetouch_screen"][2:]:
-            name = next(iter(x.keys()))
+        for name, val in onetouch.items():
+            if not isinstance(val, list):
+                continue
             attrs = {"name": name}
-            for y in next(iter(x.values())):
+            for y in val:
                 attrs.update(y)
-            devices[name] = attrs
-
-        for k, v in devices.items():
-            if k in self.devices:
-                for dk, dv in v.items():
-                    self.devices[k].data[dk] = dv
+            if name in self.devices:
+                for dk, dv in attrs.items():
+                    self.devices[name].data[dk] = dv
             else:
-                self.devices[k] = IaquaOneTouchSwitch(self, v)
+                self.devices[name] = IaquaOneTouchSwitch(self, attrs)
 
     async def set_onetouch(self, name: str) -> None:
         cmd = IAQUA_COMMAND_SET_ONETOUCH + "_" + name.removeprefix("onetouch_")

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -120,7 +120,7 @@ class IaquaSystem(AqualinkSystem):
             self.status = SystemStatus.ERROR
             raise
 
-        # Parse the home response first so the one_touch flag is available
+        # Parse the home response first so the onetouch flag is available
         # before deciding whether to issue the onetouch request.
         try:
             self._parse_home_response(r1)
@@ -128,30 +128,14 @@ class IaquaSystem(AqualinkSystem):
             self.status = SystemStatus.OFFLINE
             raise
 
-        # Honour the oneTouch enabled flag from the home response.
-        # If the controller reports it as disabled, stop polling it.
-        if self._onetouch_supported is not False:
-            one_touch_device = self.devices.get("one_touch")
-            if one_touch_device is not None and one_touch_device.state == "0":
-                LOGGER.debug(
-                    "OneTouch disabled per home response; skipping future polls."
-                )
-                self._onetouch_supported = False
-
         r3 = None
-        if self._onetouch_supported is not False:
+        if self._onetouch_supported:
             try:
                 r3 = await self._send_onetouch_screen_request()
-                self._onetouch_supported = True
             except AqualinkServiceThrottledException:
                 raise
             except AqualinkServiceException:
-                if self._onetouch_supported is None:
-                    LOGGER.warning(
-                        "OneTouch request failed on first attempt; "
-                        "disabling for this session."
-                    )
-                    self._onetouch_supported = False
+                LOGGER.warning("OneTouch request failed; skipping this update.")
 
         try:
             self._parse_devices_response(r2)
@@ -184,6 +168,8 @@ class IaquaSystem(AqualinkSystem):
         if home["system_type"] == "":
             LOGGER.debug("Skipping home screen update with empty system_type.")
             return
+
+        self._onetouch_supported = data.get("onetouch") == "true"
 
         try:
             self.system_type = IaquaSystemType(home["system_type"])

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -279,7 +279,7 @@ class IaquaSystem(AqualinkSystem):
         for x in data["onetouch_screen"]:
             onetouch.update(x)
 
-        if onetouch["status"] in (
+        if onetouch.get("status") in (
             IaquaSystemStatus.OFFLINE,
             IaquaSystemStatus.SERVICE,
         ):
@@ -289,7 +289,7 @@ class IaquaSystem(AqualinkSystem):
             raise AqualinkSystemOfflineException
 
         for name, val in onetouch.items():
-            if not isinstance(val, list):
+            if not isinstance(val, list) or not name.startswith("onetouch_"):
                 continue
             attrs = {"name": name}
             for y in val:

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -14,6 +14,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaAuxSwitch,
     IaquaDimmableLight,
     IaquaLightSwitch,
+    IaquaOneTouchSwitch,
     IaquaThermostat,
     _HOME_DEVICE_MAP,
     light_subtype_to_class,
@@ -119,6 +120,24 @@ class IaquaSystem(AqualinkSystem):
             self.status = SystemStatus.ERROR
             raise
 
+        # Parse the home response first so the one_touch flag is available
+        # before deciding whether to issue the onetouch request.
+        try:
+            self._parse_home_response(r1)
+        except AqualinkSystemOfflineException:
+            self.status = SystemStatus.OFFLINE
+            raise
+
+        # Honour the oneTouch enabled flag from the home response.
+        # If the controller reports it as disabled, stop polling it.
+        if self._onetouch_supported is not False:
+            one_touch_device = self.devices.get("one_touch")
+            if one_touch_device is not None and one_touch_device.state == "0":
+                LOGGER.debug(
+                    "OneTouch disabled per home response; skipping future polls."
+                )
+                self._onetouch_supported = False
+
         r3 = None
         if self._onetouch_supported is not False:
             try:
@@ -135,23 +154,12 @@ class IaquaSystem(AqualinkSystem):
                 self._onetouch_supported = False
 
         try:
-            self._parse_home_response(r1)
             self._parse_devices_response(r2)
             if r3 is not None:
                 self._parse_onetouch_response(r3)
         except AqualinkSystemOfflineException:
             self.status = SystemStatus.OFFLINE
             raise
-
-        # Honour the oneTouch enabled flag from the home response.
-        # If the controller reports it as disabled, stop polling it.
-        if self._onetouch_supported is not False:
-            one_touch_device = self.devices.get("one_touch")
-            if one_touch_device is not None and one_touch_device.state == "0":
-                LOGGER.debug(
-                    "OneTouch disabled per home response; skipping future polls."
-                )
-                self._onetouch_supported = False
 
         self.status = SystemStatus.ONLINE
 
@@ -266,7 +274,7 @@ class IaquaSystem(AqualinkSystem):
         self._parse_home_response(r)
 
     async def set_aux(self, aux: str) -> None:
-        aux = IAQUA_COMMAND_SET_AUX + "_" + aux.replace("aux_", "")
+        aux = IAQUA_COMMAND_SET_AUX + "_" + aux.removeprefix("aux_")
         r = await self._send_session_request(aux)
         self._parse_devices_response(r)
 
@@ -279,7 +287,7 @@ class IaquaSystem(AqualinkSystem):
 
         LOGGER.debug("OneTouch response: %s", data)
 
-        if data["one_touch"][0]["status"] != "Online":
+        if data["one_touch"][0]["status"] == "Offline":
             LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
@@ -297,38 +305,7 @@ class IaquaSystem(AqualinkSystem):
                 for dk, dv in v.items():
                     self.devices[k].data[dk] = dv
             else:
-                try:
-                    self.devices[k] = IaquaDevice.from_data(self, v)
-                except AqualinkDeviceNotSupported as e:
-                    LOGGER.debug("Device found was ignored: %s", e)
-
-    async def set_switch(self, command: str) -> None:
-        r = await self._send_session_request(command)
-        self._parse_home_response(r)
-
-    async def set_temps(self, temps: Payload) -> None:
-        # I'm not proud of this. If you read this, please submit a PR to make it better.
-        # We need to pass the temperatures for both pool and spa (if present) in the same request.
-        # Set args to current target temperatures and override with the request payload.
-        args = {}
-        i = 1
-        if "spa_set_point" in self.devices:
-            args[f"temp{i}"] = self.devices["spa_set_point"].target_temperature
-            i += 1
-        args[f"temp{i}"] = self.devices["pool_set_point"].target_temperature
-        args.update(temps)
-
-        r = await self._send_session_request(IAQUA_COMMAND_SET_TEMPS, args)
-        self._parse_home_response(r)
-
-    async def set_aux(self, aux: str) -> None:
-        aux = IAQUA_COMMAND_SET_AUX + "_" + aux.replace("aux_", "")
-        r = await self._send_session_request(aux)
-        self._parse_devices_response(r)
-
-    async def set_light(self, data: Payload) -> None:
-        r = await self._send_session_request(IAQUA_COMMAND_SET_LIGHT, data)
-        self._parse_devices_response(r)
+                self.devices[k] = IaquaOneTouchSwitch(self, v)
 
     async def set_onetouch(self, name: str) -> None:
         cmd = IAQUA_COMMAND_SET_ONETOUCH + "_" + name.removeprefix("onetouch_")

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -31,7 +31,10 @@ if TYPE_CHECKING:
     from iaqualink.client import AqualinkClient
     from iaqualink.typing import Payload
 
-IAQUA_SESSION_URL = "https://r-api.iaqualink.net/v2/mobile/session.json"
+# v2 session endpoint (p-api); used for all get_*/set_* commands.
+# r-api hosts v1 / swc endpoints — kept here for future reference.
+IAQUA_SESSION_URL = "https://p-api.iaqualink.net/v2/mobile/session.json"
+IAQUA_SESSION_V1_URL = "https://r-api.iaqualink.net/v1/mobile/session.json"
 
 IAQUA_COMMAND_GET_DEVICES = "get_devices"
 IAQUA_COMMAND_GET_HOME = "get_home"
@@ -102,7 +105,10 @@ class IaquaSystem(AqualinkSystem):
         return await self._send_with_reauth_retry(do_request)
 
     async def _send_home_screen_request(self) -> httpx.Response:
-        return await self._send_session_request(IAQUA_COMMAND_GET_HOME)
+        return await self._send_session_request(
+            IAQUA_COMMAND_GET_HOME,
+            {"attached_test": "true", "country": self.aqualink.country},
+        )
 
     async def _send_devices_screen_request(self) -> httpx.Response:
         return await self._send_session_request(IAQUA_COMMAND_GET_DEVICES)

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -57,6 +57,8 @@ class IaquaSystem(AqualinkSystem):
 
         self.system_type: IaquaSystemType | None = None
         self.temp_unit: IaquaTemperatureUnit | None = None
+        # None = not yet tried, True = working, False = disabled
+        self._onetouch_supported: bool | None = None
 
     def __repr__(self) -> str:
         attrs = ["name", "serial", "data"]
@@ -110,7 +112,6 @@ class IaquaSystem(AqualinkSystem):
         try:
             r1 = await self._send_home_screen_request()
             r2 = await self._send_devices_screen_request()
-            r3 = await self._send_onetouch_screen_request()
         except AqualinkServiceThrottledException:
             self.status = SystemStatus.UNKNOWN
             raise
@@ -118,13 +119,37 @@ class IaquaSystem(AqualinkSystem):
             self.status = SystemStatus.ERROR
             raise
 
+        r3 = None
+        if self._onetouch_supported is not False:
+            try:
+                r3 = await self._send_onetouch_screen_request()
+                self._onetouch_supported = True
+            except AqualinkServiceException:
+                if self._onetouch_supported is None:
+                    LOGGER.warning(
+                        "OneTouch request failed on first attempt; "
+                        "disabling for this session."
+                    )
+                self._onetouch_supported = False
+
         try:
             self._parse_home_response(r1)
             self._parse_devices_response(r2)
-            self._parse_onetouch_response(r3)
+            if r3 is not None:
+                self._parse_onetouch_response(r3)
         except AqualinkSystemOfflineException:
             self.status = SystemStatus.OFFLINE
             raise
+
+        # Honour the oneTouch enabled flag from the home response.
+        # If the controller reports it as disabled, stop polling it.
+        if self._onetouch_supported is not False:
+            one_touch_device = self.devices.get("one_touch")
+            if one_touch_device is not None and one_touch_device.state == "0":
+                LOGGER.debug(
+                    "OneTouch disabled per home response; skipping future polls."
+                )
+                self._onetouch_supported = False
 
         self.status = SystemStatus.ONLINE
 

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -151,7 +151,7 @@ class IaquaSystem(AqualinkSystem):
                         "OneTouch request failed on first attempt; "
                         "disabling for this session."
                     )
-                self._onetouch_supported = False
+                    self._onetouch_supported = False
 
         try:
             self._parse_devices_response(r2)

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -279,8 +279,13 @@ class IaquaSystem(AqualinkSystem):
         for x in data["onetouch_screen"]:
             onetouch.update(x)
 
-        if onetouch["status"] == "Offline":
-            LOGGER.warning("Status for system %s is Offline.", self.serial)
+        if onetouch["status"] in (
+            IaquaSystemStatus.OFFLINE,
+            IaquaSystemStatus.SERVICE,
+        ):
+            LOGGER.warning(
+                "Status for system %s is %s.", self.serial, onetouch["status"]
+            )
             raise AqualinkSystemOfflineException
 
         for name, val in onetouch.items():

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -234,6 +234,13 @@ class TestIaquaOneTouchSwitch(TestIaquaSwitch, TestBaseSwitch):
         with patch.object(self.sut.system, "_parse_onetouch_response"):
             await super().test_turn_off_noop()
 
+    async def test_toggle_skipped_when_unavailable(self) -> None:
+        self.sut.data["state"] = "0"
+        self.sut.data["status"] = "0"
+        with patch.object(self.sut.system, "set_onetouch") as mock_set:
+            await self.sut.turn_on()
+        mock_set.assert_not_called()
+
     def test_property_label(self) -> None:
         super().test_property_label()
         assert self.sut.label == "Morning Scene"

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -21,6 +21,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaHeater,
     IaquaHeaterState,
     IaquaLightSwitch,
+    IaquaOneTouchSwitch,
     IaquaPresenceSensor,
     IaquaPresenceState,
     IaquaSensor,
@@ -198,6 +199,44 @@ class TestIaquaHeater(TestIaquaBinarySensor, TestBaseSwitch):
 
     def test_property_state_enum(self) -> None:
         assert self.sut.state_enum is IaquaHeaterState
+
+
+class TestIaquaOneTouchSwitch(TestIaquaSwitch, TestBaseSwitch):
+    def setUp(self) -> None:
+        super().setUp()
+
+        data = {
+            "name": "onetouch_1",
+            "state": "0",
+            "label": "Morning Scene",
+            "status": "1",
+        }
+        self.sut = IaquaOneTouchSwitch(self.system, data)
+        self.sut_class = IaquaOneTouchSwitch
+
+    async def test_turn_on(self) -> None:
+        self.sut.data["state"] = "0"
+        with patch.object(self.sut.system, "_parse_onetouch_response"):
+            await super().test_turn_on()
+
+    async def test_turn_on_noop(self) -> None:
+        self.sut.data["state"] = "1"
+        with patch.object(self.sut.system, "_parse_onetouch_response"):
+            await super().test_turn_on_noop()
+
+    async def test_turn_off(self) -> None:
+        self.sut.data["state"] = "1"
+        with patch.object(self.sut.system, "_parse_onetouch_response"):
+            await super().test_turn_off()
+
+    async def test_turn_off_noop(self) -> None:
+        self.sut.data["state"] = "0"
+        with patch.object(self.sut.system, "_parse_onetouch_response"):
+            await super().test_turn_off_noop()
+
+    def test_property_label(self) -> None:
+        super().test_property_label()
+        assert self.sut.label == "Morning Scene"
 
 
 class TestIaquaAuxSwitch(TestIaquaSwitch, TestBaseSwitch):

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -234,13 +234,6 @@ class TestIaquaOneTouchSwitch(TestIaquaSwitch, TestBaseSwitch):
         with patch.object(self.sut.system, "_parse_onetouch_response"):
             await super().test_turn_off_noop()
 
-    async def test_toggle_skipped_when_unavailable(self) -> None:
-        self.sut.data["state"] = "0"
-        self.sut.data["status"] = "0"
-        with patch.object(self.sut.system, "set_onetouch") as mock_set:
-            await self.sut.turn_on()
-        mock_set.assert_not_called()
-
     def test_property_label(self) -> None:
         super().test_property_label()
         assert self.sut.label == "Morning Scene"

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -387,6 +387,56 @@ class TestIaquaSystem(TestBaseSystem):
         self.sut._parse_onetouch_response(response)
         assert self.sut.devices == expected
 
+    async def test_parse_onetouch_skips_disabled_device(self) -> None:
+        message = {
+            "message": "",
+            "onetouch_screen": [
+                {"status": "Online"},
+                {"response": ""},
+                {
+                    "onetouch_1": [
+                        {"state": "0"},
+                        {"label": "Morning Scene"},
+                        {"status": "0"},
+                    ]
+                },
+            ],
+        }
+        response = MagicMock()
+        response.json.return_value = message
+
+        self.sut._parse_onetouch_response(response)
+        assert "onetouch_1" not in self.sut.devices
+
+    async def test_parse_onetouch_removes_previously_added_disabled_device(
+        self,
+    ) -> None:
+        existing = IaquaOneTouchSwitch(
+            system=self.sut,
+            data={"name": "onetouch_1", "state": "1", "status": "1"},
+        )
+        self.sut.devices["onetouch_1"] = existing
+
+        message = {
+            "message": "",
+            "onetouch_screen": [
+                {"status": "Online"},
+                {"response": ""},
+                {
+                    "onetouch_1": [
+                        {"state": "0"},
+                        {"label": "Morning Scene"},
+                        {"status": "0"},
+                    ]
+                },
+            ],
+        }
+        response = MagicMock()
+        response.json.return_value = message
+
+        self.sut._parse_onetouch_response(response)
+        assert "onetouch_1" not in self.sut.devices
+
     @patch("httpx.AsyncClient.request")
     async def test_onetouch_request(self, mock_request) -> None:
         mock_request.return_value.status_code = 200

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -359,6 +359,14 @@ class TestIaquaSystem(TestBaseSystem):
             self.sut._parse_onetouch_response(response)
         assert self.sut.devices == {}
 
+    async def test_parse_onetouch_offline_when_service(self) -> None:
+        message = {"message": "", "onetouch_screen": [{"status": "Service"}]}
+        response = MagicMock()
+        response.json.return_value = message
+
+        with pytest.raises(AqualinkSystemOfflineException):
+            self.sut._parse_onetouch_response(response)
+
     async def test_parse_onetouch_good(self) -> None:
         message = {
             "message": "",

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -291,6 +291,39 @@ class TestIaquaSystem(TestBaseSystem):
         self.sut._parse_home_response(response)
         assert self.sut.devices == {"pool_pump": existing}
 
+    async def test_parse_home_sets_onetouch_supported_true(self) -> None:
+        message = {
+            "onetouch": "true",
+            "home_screen": [
+                {"status": "Online"},
+                {"response": ""},
+                {"system_type": "iaqua"},
+                {"temp_scale": "F"},
+            ],
+        }
+        response = MagicMock()
+        response.json.return_value = message
+
+        self.sut._parse_home_response(response)
+        assert self.sut._onetouch_supported is True
+
+    async def test_parse_home_sets_onetouch_supported_false_when_absent(
+        self,
+    ) -> None:
+        message = {
+            "home_screen": [
+                {"status": "Online"},
+                {"response": ""},
+                {"system_type": "iaqua"},
+                {"temp_scale": "F"},
+            ],
+        }
+        response = MagicMock()
+        response.json.return_value = message
+
+        self.sut._parse_home_response(response)
+        assert self.sut._onetouch_supported is False
+
     @patch("httpx.AsyncClient.request")
     async def test_home_request(self, mock_request) -> None:
         mock_request.return_value.status_code = 200
@@ -383,6 +416,7 @@ class TestIaquaSystem(TestBaseSystem):
 
     async def test_update_onetouch_failure_is_nonfatal(self) -> None:
         """A failing onetouch request must not raise; update() should succeed."""
+        self.sut._onetouch_supported = True
         with (
             patch.object(self.sut, "_send_home_screen_request"),
             patch.object(self.sut, "_send_devices_screen_request"),
@@ -397,10 +431,12 @@ class TestIaquaSystem(TestBaseSystem):
             # Should not raise despite onetouch failure.
             await self.sut.update()
 
-        assert self.sut._onetouch_supported is False
+        # Transient failures do not disable onetouch.
+        assert self.sut._onetouch_supported is True
 
     async def test_update_onetouch_throttle_does_not_disable(self) -> None:
         """A 429 on onetouch must propagate and not permanently disable it."""
+        self.sut._onetouch_supported = True
         with (
             patch.object(self.sut, "_send_home_screen_request"),
             patch.object(self.sut, "_send_devices_screen_request"),
@@ -415,40 +451,64 @@ class TestIaquaSystem(TestBaseSystem):
             with pytest.raises(AqualinkServiceThrottledException):
                 await self.sut.update()
 
-        assert self.sut._onetouch_supported is None
+        assert self.sut._onetouch_supported is True
 
-    async def test_update_onetouch_disabled_after_first_failure(self) -> None:
-        """After a onetouch failure, subsequent updates skip the request."""
+    async def test_update_onetouch_not_requested_when_unsupported(self) -> None:
+        """When home response reports no onetouch, the request is never issued."""
         with (
             patch.object(self.sut, "_send_home_screen_request"),
             patch.object(self.sut, "_send_devices_screen_request"),
             patch.object(
-                self.sut,
-                "_send_onetouch_screen_request",
-                side_effect=AqualinkServiceException,
-            ) as onetouch_mock,
+                self.sut, "_send_onetouch_screen_request"
+            ) as onetouch_req,
             patch.object(self.sut, "_parse_home_response"),
             patch.object(self.sut, "_parse_devices_response"),
         ):
+            # _onetouch_supported starts None (falsy) — request must be skipped.
             await self.sut.update()
-            assert onetouch_mock.call_count == 1
+            assert onetouch_req.call_count == 0
 
-            # Reset timer so a second update() is not rate-limited.
-            self.sut.last_refresh = 0
-            onetouch_mock.reset_mock()
+    async def test_update_onetouch_enabled_by_home_flag(self) -> None:
+        """onetouch='true' in home response enables onetouch polling."""
+        message = {
+            "onetouch": "true",
+            "home_screen": [
+                {"status": "Online"},
+                {"response": ""},
+                {"system_type": "iaqua"},
+                {"temp_scale": "F"},
+            ],
+        }
+        response = MagicMock()
+        response.json.return_value = message
+
+        with (
+            patch.object(
+                self.sut, "_send_home_screen_request", return_value=response
+            ),
+            patch.object(
+                self.sut, "_send_devices_screen_request", return_value=response
+            ),
+            patch.object(
+                self.sut, "_send_onetouch_screen_request", return_value=response
+            ) as onetouch_req,
+            patch.object(self.sut, "_parse_devices_response"),
+            patch.object(self.sut, "_parse_onetouch_response"),
+        ):
             await self.sut.update()
-            assert onetouch_mock.call_count == 0
+            assert onetouch_req.call_count == 1
+
+        assert self.sut._onetouch_supported is True
 
     async def test_update_onetouch_disabled_by_home_flag(self) -> None:
-        """oneTouch=0 in home response disables onetouch polling immediately."""
+        """Absent or false onetouch flag in home response skips the request."""
         message = {
             "home_screen": [
                 {"status": "Online"},
                 {"response": ""},
                 {"system_type": "iaqua"},
                 {"temp_scale": "F"},
-                {"one_touch": "0"},
-            ]
+            ],
         }
         response = MagicMock()
         response.json.return_value = message
@@ -467,8 +527,6 @@ class TestIaquaSystem(TestBaseSystem):
             patch.object(self.sut, "_parse_onetouch_response"),
         ):
             await self.sut.update()
-            # Home response is parsed first; one_touch=0 disables the request
-            # before it is ever issued — not just on the second poll.
             assert onetouch_req.call_count == 0
 
         assert self.sut._onetouch_supported is False

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -436,47 +436,36 @@ class TestIaquaSystem(TestBaseSystem):
             assert onetouch_mock.call_count == 0
 
     async def test_update_onetouch_disabled_by_home_flag(self) -> None:
-        """oneTouch=0 in home response disables future onetouch polling."""
+        """oneTouch=0 in home response disables onetouch polling immediately."""
+        message = {
+            "home_screen": [
+                {"status": "Online"},
+                {"response": ""},
+                {"response": ""},
+                {"temp_scale": "F"},
+                {"one_touch": "0"},
+            ]
+        }
+        response = MagicMock()
+        response.json.return_value = message
+
         with (
+            patch.object(
+                self.sut, "_send_home_screen_request", return_value=response
+            ),
+            patch.object(
+                self.sut, "_send_devices_screen_request", return_value=response
+            ),
+            patch.object(
+                self.sut, "_send_onetouch_screen_request"
+            ) as onetouch_req,
             patch.object(self.sut, "_parse_devices_response"),
             patch.object(self.sut, "_parse_onetouch_response"),
         ):
-            message = {
-                "home_screen": [
-                    {"status": "Online"},
-                    {"response": ""},
-                    {"response": ""},
-                    {"temp_scale": "F"},
-                    {"one_touch": "0"},
-                ]
-            }
-            response = MagicMock()
-            response.json.return_value = message
-
-            with (
-                patch.object(
-                    self.sut, "_send_home_screen_request", return_value=response
-                ),
-                patch.object(
-                    self.sut,
-                    "_send_devices_screen_request",
-                    return_value=response,
-                ),
-                patch.object(
-                    self.sut,
-                    "_send_onetouch_screen_request",
-                    return_value=response,
-                ) as onetouch_req,
-            ):
-                await self.sut.update()
-                # Onetouch was attempted (unknown state → try once)
-                assert onetouch_req.call_count == 1
-
-                self.sut.last_refresh = 0
-                onetouch_req.reset_mock()
-                await self.sut.update()
-                # Now disabled via home flag — should not be called again
-                assert onetouch_req.call_count == 0
+            await self.sut.update()
+            # Home response is parsed first; one_touch=0 disables the request
+            # before it is ever issued — not just on the second poll.
+            assert onetouch_req.call_count == 0
 
         assert self.sut._onetouch_supported is False
 

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -12,9 +12,13 @@ from iaqualink.exception import (
     AqualinkSystemOfflineException,
 )
 from iaqualink.system import AqualinkSystem, SystemStatus
-from iaqualink.systems.iaqua.device import IaquaAuxSwitch
+from iaqualink.systems.iaqua.device import IaquaAuxSwitch, IaquaOneTouchSwitch
 from iaqualink.systems.iaqua.enums import IaquaSystemType, IaquaTemperatureUnit
-from iaqualink.systems.iaqua.system import IAQUA_SESSION_URL, IaquaSystem
+from iaqualink.systems.iaqua.system import (
+    IAQUA_SESSION_URL,
+    IAQUA_COMMAND_SET_ONETOUCH,
+    IaquaSystem,
+)
 
 from ...base_test_system import TestBaseSystem
 
@@ -44,11 +48,16 @@ class TestIaquaSystem(TestBaseSystem):
         with (
             patch.object(self.sut, "_parse_home_response"),
             patch.object(self.sut, "_parse_devices_response"),
+            patch.object(self.sut, "_parse_onetouch_response"),
         ):
             await super().test_update_success()
 
     async def test_update_offline(self) -> None:
-        with patch.object(self.sut, "_parse_home_response") as mock_parse:
+        with (
+            patch.object(self.sut, "_parse_home_response") as mock_parse,
+            patch.object(self.sut, "_parse_devices_response"),
+            patch.object(self.sut, "_parse_onetouch_response"),
+        ):
             mock_parse.side_effect = AqualinkSystemOfflineException
             with pytest.raises(AqualinkSystemOfflineException):
                 await super().test_update_success()
@@ -61,10 +70,19 @@ class TestIaquaSystem(TestBaseSystem):
                 await self.sut.update()
         assert self.sut.status is SystemStatus.UNKNOWN
 
+    async def test_update_consecutive(self) -> None:
+        with (
+            patch.object(self.sut, "_parse_home_response"),
+            patch.object(self.sut, "_parse_devices_response"),
+            patch.object(self.sut, "_parse_onetouch_response"),
+        ):
+            await super().test_update_consecutive()
+
     async def test_get_devices_needs_update(self) -> None:
         with (
             patch.object(self.sut, "_parse_home_response"),
             patch.object(self.sut, "_parse_devices_response"),
+            patch.object(self.sut, "_parse_onetouch_response"),
         ):
             await super().test_get_devices_needs_update()
 
@@ -293,6 +311,70 @@ class TestIaquaSystem(TestBaseSystem):
 
         with pytest.raises(AqualinkServiceUnauthorizedException):
             await self.sut._send_devices_screen_request()
+
+    async def test_parse_onetouch_offline(self) -> None:
+        message = {"message": "", "one_touch": [{"status": "Offline"}]}
+        response = MagicMock()
+        response.json.return_value = message
+
+        with pytest.raises(AqualinkSystemOfflineException):
+            self.sut._parse_onetouch_response(response)
+        assert self.sut.devices == {}
+
+    async def test_parse_onetouch_good(self) -> None:
+        message = {
+            "message": "",
+            "one_touch": [
+                {"status": "Online"},
+                {"response": ""},
+                {
+                    "onetouch_1": [
+                        {"state": "0"},
+                        {"label": "Morning Scene"},
+                        {"status": "1"},
+                    ]
+                },
+            ],
+        }
+        response = MagicMock()
+        response.json.return_value = message
+
+        expected = {
+            "onetouch_1": IaquaOneTouchSwitch(
+                system=self.sut,
+                data={
+                    "name": "onetouch_1",
+                    "state": "0",
+                    "label": "Morning Scene",
+                    "status": "1",
+                },
+            )
+        }
+        self.sut._parse_onetouch_response(response)
+        assert self.sut.devices == expected
+
+    @patch("httpx.AsyncClient.request")
+    async def test_onetouch_request(self, mock_request) -> None:
+        mock_request.return_value.status_code = 200
+
+        await self.sut._send_onetouch_screen_request()
+
+    @patch("httpx.AsyncClient.request")
+    async def test_onetouch_request_unauthorized(self, mock_request) -> None:
+        mock_request.return_value.status_code = 401
+
+        with pytest.raises(AqualinkServiceUnauthorizedException):
+            await self.sut._send_onetouch_screen_request()
+
+    @patch("httpx.AsyncClient.request")
+    async def test_set_onetouch(self, mock_request) -> None:
+        mock_request.return_value.status_code = 200
+        with patch.object(self.sut, "_parse_onetouch_response") as mock_parse:
+            await self.sut.set_onetouch("onetouch_1")
+
+        called_url = mock_request.call_args[0][1]
+        assert f"{IAQUA_COMMAND_SET_ONETOUCH}_1" in called_url
+        assert mock_parse.call_count == 1
 
     @patch("httpx.AsyncClient.request")
     async def test_session_request_retries_after_refresh(

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -373,9 +373,9 @@ class TestIaquaSystem(TestBaseSystem):
         with patch.object(self.sut, "_parse_onetouch_response") as mock_parse:
             await self.sut.set_onetouch("onetouch_1")
 
-        called_url = mock_request.call_args[0][1]
-        assert f"{IAQUA_COMMAND_SET_ONETOUCH}_1" in called_url
-        assert mock_parse.call_count == 1
+            called_url = mock_request.call_args[0][1]
+            assert f"{IAQUA_COMMAND_SET_ONETOUCH}_1" in called_url
+            mock_parse.assert_called_once_with(mock_request.return_value)
 
     async def test_update_onetouch_failure_is_nonfatal(self) -> None:
         """A failing onetouch request must not raise; update() should succeed."""
@@ -394,6 +394,24 @@ class TestIaquaSystem(TestBaseSystem):
             await self.sut.update()
 
         assert self.sut._onetouch_supported is False
+
+    async def test_update_onetouch_throttle_does_not_disable(self) -> None:
+        """A 429 on onetouch must propagate and not permanently disable it."""
+        with (
+            patch.object(self.sut, "_send_home_screen_request"),
+            patch.object(self.sut, "_send_devices_screen_request"),
+            patch.object(
+                self.sut,
+                "_send_onetouch_screen_request",
+                side_effect=AqualinkServiceThrottledException,
+            ),
+            patch.object(self.sut, "_parse_home_response"),
+            patch.object(self.sut, "_parse_devices_response"),
+        ):
+            with pytest.raises(AqualinkServiceThrottledException):
+                await self.sut.update()
+
+        assert self.sut._onetouch_supported is None
 
     async def test_update_onetouch_disabled_after_first_failure(self) -> None:
         """After a onetouch failure, subsequent updates skip the request."""

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -414,8 +414,8 @@ class TestIaquaSystem(TestBaseSystem):
             assert f"{IAQUA_COMMAND_SET_ONETOUCH}_1" in called_url
             mock_parse.assert_called_once_with(mock_request.return_value)
 
-    async def test_update_onetouch_failure_is_nonfatal(self) -> None:
-        """A failing onetouch request must not raise; update() should succeed."""
+    async def test_update_onetouch_failure_raises(self) -> None:
+        """A failing onetouch request raises and sets status to ERROR."""
         self.sut._onetouch_supported = True
         with (
             patch.object(self.sut, "_send_home_screen_request"),
@@ -428,14 +428,14 @@ class TestIaquaSystem(TestBaseSystem):
             patch.object(self.sut, "_parse_home_response"),
             patch.object(self.sut, "_parse_devices_response"),
         ):
-            # Should not raise despite onetouch failure.
-            await self.sut.update()
+            with pytest.raises(AqualinkServiceException):
+                await self.sut.update()
 
-        # Transient failures do not disable onetouch.
+        assert self.sut.status is SystemStatus.ERROR
         assert self.sut._onetouch_supported is True
 
-    async def test_update_onetouch_throttle_does_not_disable(self) -> None:
-        """A 429 on onetouch must propagate and not permanently disable it."""
+    async def test_update_onetouch_throttle_raises(self) -> None:
+        """A 429 on onetouch propagates and does not disable onetouch."""
         self.sut._onetouch_supported = True
         with (
             patch.object(self.sut, "_send_home_screen_request"),
@@ -451,6 +451,7 @@ class TestIaquaSystem(TestBaseSystem):
             with pytest.raises(AqualinkServiceThrottledException):
                 await self.sut.update()
 
+        assert self.sut.status is SystemStatus.UNKNOWN
         assert self.sut._onetouch_supported is True
 
     async def test_update_onetouch_not_requested_when_unsupported(self) -> None:

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -314,7 +314,7 @@ class TestIaquaSystem(TestBaseSystem):
             await self.sut._send_devices_screen_request()
 
     async def test_parse_onetouch_offline(self) -> None:
-        message = {"message": "", "one_touch": [{"status": "Offline"}]}
+        message = {"message": "", "onetouch_screen": [{"status": "Offline"}]}
         response = MagicMock()
         response.json.return_value = message
 
@@ -325,7 +325,7 @@ class TestIaquaSystem(TestBaseSystem):
     async def test_parse_onetouch_good(self) -> None:
         message = {
             "message": "",
-            "one_touch": [
+            "onetouch_screen": [
                 {"status": "Online"},
                 {"response": ""},
                 {

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -71,18 +71,6 @@ class TestIaquaSystem(TestBaseSystem):
                 await self.sut.update()
         assert self.sut.status is SystemStatus.UNKNOWN
 
-    async def test_update_consecutive(self) -> None:
-        with (
-            patch.object(self.sut, "_send_home_screen_request"),
-            patch.object(self.sut, "_send_devices_screen_request"),
-            patch.object(self.sut, "_send_onetouch_screen_request"),
-            patch.object(self.sut, "_parse_home_response"),
-            patch.object(self.sut, "_parse_devices_response"),
-            patch.object(self.sut, "_parse_onetouch_response"),
-        ):
-            await self.sut.update()
-            await self.sut.update()
-
     async def test_get_devices_needs_update(self) -> None:
         with (
             patch.object(self.sut, "_parse_home_response"),

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -7,6 +7,7 @@ import pytest
 
 from iaqualink.const import AQUALINK_API_KEY
 from iaqualink.exception import (
+    AqualinkServiceException,
     AqualinkServiceThrottledException,
     AqualinkServiceUnauthorizedException,
     AqualinkSystemOfflineException,
@@ -375,6 +376,91 @@ class TestIaquaSystem(TestBaseSystem):
         called_url = mock_request.call_args[0][1]
         assert f"{IAQUA_COMMAND_SET_ONETOUCH}_1" in called_url
         assert mock_parse.call_count == 1
+
+    async def test_update_onetouch_failure_is_nonfatal(self) -> None:
+        """A failing onetouch request must not raise; update() should succeed."""
+        with (
+            patch.object(self.sut, "_send_home_screen_request"),
+            patch.object(self.sut, "_send_devices_screen_request"),
+            patch.object(
+                self.sut,
+                "_send_onetouch_screen_request",
+                side_effect=AqualinkServiceException,
+            ),
+            patch.object(self.sut, "_parse_home_response"),
+            patch.object(self.sut, "_parse_devices_response"),
+        ):
+            # Should not raise despite onetouch failure.
+            await self.sut.update()
+
+        assert self.sut._onetouch_supported is False
+
+    async def test_update_onetouch_disabled_after_first_failure(self) -> None:
+        """After a onetouch failure, subsequent updates skip the request."""
+        with (
+            patch.object(self.sut, "_send_home_screen_request"),
+            patch.object(self.sut, "_send_devices_screen_request"),
+            patch.object(
+                self.sut,
+                "_send_onetouch_screen_request",
+                side_effect=AqualinkServiceException,
+            ) as onetouch_mock,
+            patch.object(self.sut, "_parse_home_response"),
+            patch.object(self.sut, "_parse_devices_response"),
+        ):
+            await self.sut.update()
+            assert onetouch_mock.call_count == 1
+
+            # Reset timer so a second update() is not rate-limited.
+            self.sut.last_refresh = 0
+            onetouch_mock.reset_mock()
+            await self.sut.update()
+            assert onetouch_mock.call_count == 0
+
+    async def test_update_onetouch_disabled_by_home_flag(self) -> None:
+        """oneTouch=0 in home response disables future onetouch polling."""
+        with (
+            patch.object(self.sut, "_parse_devices_response"),
+            patch.object(self.sut, "_parse_onetouch_response"),
+        ):
+            message = {
+                "home_screen": [
+                    {"status": "Online"},
+                    {"response": ""},
+                    {"response": ""},
+                    {"temp_scale": "F"},
+                    {"one_touch": "0"},
+                ]
+            }
+            response = MagicMock()
+            response.json.return_value = message
+
+            with (
+                patch.object(
+                    self.sut, "_send_home_screen_request", return_value=response
+                ),
+                patch.object(
+                    self.sut,
+                    "_send_devices_screen_request",
+                    return_value=response,
+                ),
+                patch.object(
+                    self.sut,
+                    "_send_onetouch_screen_request",
+                    return_value=response,
+                ) as onetouch_req,
+            ):
+                await self.sut.update()
+                # Onetouch was attempted (unknown state → try once)
+                assert onetouch_req.call_count == 1
+
+                self.sut.last_refresh = 0
+                onetouch_req.reset_mock()
+                await self.sut.update()
+                # Now disabled via home flag — should not be called again
+                assert onetouch_req.call_count == 0
+
+        assert self.sut._onetouch_supported is False
 
     @patch("httpx.AsyncClient.request")
     async def test_session_request_retries_after_refresh(

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -73,11 +73,15 @@ class TestIaquaSystem(TestBaseSystem):
 
     async def test_update_consecutive(self) -> None:
         with (
+            patch.object(self.sut, "_send_home_screen_request"),
+            patch.object(self.sut, "_send_devices_screen_request"),
+            patch.object(self.sut, "_send_onetouch_screen_request"),
             patch.object(self.sut, "_parse_home_response"),
             patch.object(self.sut, "_parse_devices_response"),
             patch.object(self.sut, "_parse_onetouch_response"),
         ):
-            await super().test_update_consecutive()
+            await self.sut.update()
+            await self.sut.update()
 
     async def test_get_devices_needs_update(self) -> None:
         with (
@@ -441,7 +445,7 @@ class TestIaquaSystem(TestBaseSystem):
             "home_screen": [
                 {"status": "Online"},
                 {"response": ""},
-                {"response": ""},
+                {"system_type": "iaqua"},
                 {"temp_scale": "F"},
                 {"one_touch": "0"},
             ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -153,7 +153,7 @@ class TestAqualinkClient(TestBase):
         assert self.client.logged is False
         assert self.client.auth_state is None
 
-    async def test_context_manager_skips_login_when_auth_restored(self) -> None:
+    async def test_context_manager_refreshes_when_auth_restored(self) -> None:
         self.client.auth_state = AqualinkAuthState(
             username="restored-user",
             client_id="restored-session-id",
@@ -163,11 +163,18 @@ class TestAqualinkClient(TestBase):
             refresh_token="restored-refresh-token",
         )
 
-        with patch.object(self.client, "login") as mock_login:
+        with (
+            patch.object(self.client, "login") as mock_login,
+            patch.object(
+                self.client, "_refresh_auth", return_value=None
+            ) as mock_refresh,
+        ):
+            mock_refresh.return_value = async_noop
             async with self.client:
                 pass
 
         mock_login.assert_not_called()
+        mock_refresh.assert_awaited_once()
 
     @patch("iaqualink.client.AqualinkClient.login", async_noop)
     async def test_context_manager_with_client(self) -> None:
@@ -188,6 +195,27 @@ class TestAqualinkClient(TestBase):
         await self.client.login()
 
         assert self.client.logged is True
+
+    @patch("httpx.AsyncClient.request")
+    async def test_login_sets_country_lowercased(self, mock_request) -> None:
+        data = {**LOGIN_DATA, "country": "FR"}
+        mock_request.return_value.status_code = 200
+        mock_request.return_value.json = MagicMock(return_value=data)
+
+        await self.client.login()
+
+        assert self.client.country == "fr"
+
+    @patch("httpx.AsyncClient.request")
+    async def test_login_defaults_country_to_us_when_absent(
+        self, mock_request
+    ) -> None:
+        mock_request.return_value.status_code = 200
+        mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
+
+        await self.client.login()
+
+        assert self.client.country == "us"
 
     @patch("httpx.AsyncClient.request")
     async def test_send_request_uses_default_timeout(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -364,7 +364,6 @@ class TestAqualinkClient(TestBase):
         with pytest.raises(AqualinkServiceThrottledException):
             await self.client.send_request("https://example.com")
 
-
     @patch("httpx.AsyncClient.request")
     async def test_timeout_raises_service_exception(self, mock_request) -> None:
         for exc_class in (
@@ -376,7 +375,6 @@ class TestAqualinkClient(TestBase):
             mock_request.side_effect = exc_class("timed out")
             with pytest.raises(AqualinkServiceException):
                 await self.client.send_request("https://example.com")
-
 
     @patch("httpx.AsyncClient.request")
     async def test_500_not_retried(self, mock_request) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -364,6 +364,17 @@ class TestAqualinkClient(TestBase):
         with pytest.raises(AqualinkServiceThrottledException):
             await self.client.send_request("https://example.com")
 
+
+    @patch("httpx.AsyncClient.request")
+    async def test_read_timeout_raises_service_exception(
+        self, mock_request
+    ) -> None:
+        mock_request.side_effect = httpx.ReadTimeout("timed out")
+
+        with pytest.raises(AqualinkServiceException):
+            await self.client.send_request("https://example.com")
+
+
     @patch("httpx.AsyncClient.request")
     async def test_500_not_retried(self, mock_request) -> None:
         mock_request.return_value.status_code = (

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -365,14 +365,18 @@ class TestAqualinkClient(TestBase):
             await self.client.send_request("https://example.com")
 
     @patch("httpx.AsyncClient.request")
-    async def test_timeout_raises_service_exception(self, mock_request) -> None:
-        for exc_class in (
-            httpx.ReadTimeout,
-            httpx.ConnectTimeout,
-            httpx.WriteTimeout,
-            httpx.PoolTimeout,
+    async def test_transport_error_raises_service_exception(
+        self, mock_request
+    ) -> None:
+        for exc in (
+            httpx.ReadTimeout("timed out"),
+            httpx.ConnectTimeout("timed out"),
+            httpx.WriteTimeout("timed out"),
+            httpx.PoolTimeout("timed out"),
+            httpx.ConnectError("connection refused"),
+            OSError("network unreachable"),
         ):
-            mock_request.side_effect = exc_class("timed out")
+            mock_request.side_effect = exc
             with pytest.raises(AqualinkServiceException):
                 await self.client.send_request("https://example.com")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -366,13 +366,16 @@ class TestAqualinkClient(TestBase):
 
 
     @patch("httpx.AsyncClient.request")
-    async def test_read_timeout_raises_service_exception(
-        self, mock_request
-    ) -> None:
-        mock_request.side_effect = httpx.ReadTimeout("timed out")
-
-        with pytest.raises(AqualinkServiceException):
-            await self.client.send_request("https://example.com")
+    async def test_timeout_raises_service_exception(self, mock_request) -> None:
+        for exc_class in (
+            httpx.ReadTimeout,
+            httpx.ConnectTimeout,
+            httpx.WriteTimeout,
+            httpx.PoolTimeout,
+        ):
+            mock_request.side_effect = exc_class("timed out")
+            with pytest.raises(AqualinkServiceException):
+                await self.client.send_request("https://example.com")
 
 
     @patch("httpx.AsyncClient.request")


### PR DESCRIPTION
## Summary

### OneTouch support
- Polls \`get_onetouch\` after \`get_home\` when the home response carries \`"onetouch": "true"\`; skips entirely on systems without OneTouch
- Adds \`IaquaOneTouchSwitch\` device class with toggle semantics (the API command flips scene state; inherited \`turn_on\`/\`turn_off\` guards are correct)
- Disabled scenes (\`status=0\`) are filtered out at parse time — never added to \`devices\`; removed if they were previously present
- Raises \`AqualinkServiceException\` on OneTouch request failure (\`status = ERROR\`); \`AqualinkServiceThrottledException\` re-raised before the broader handler
- Uses \`IaquaSystemStatus\` enum for offline/service checks in all three parse methods

### Session and country
- \`client.py\`: stores \`country\` from login/refresh response (lowercased, default \`"us"\`)
- On \`__aenter__\` with a restored session, forces a token refresh to populate \`country\` and other non-persisted user attributes without a separate login call

### API endpoint
- Moves session requests to \`p-api.iaqualink.net/v2\`; preserves \`IAQUA_SESSION_V1_URL\` (\`r-api\`) for future v1/swc use
- \`get_home\` now includes \`attached_test=true\` and \`country\` query parameters

### Client hardening
- \`send_request\`: narrows \`except Exception\` → \`except (httpx.TransportError, OSError)\` with comment; includes original error in the exception message

## Test plan

- [x] \`test_parse_onetouch_offline\` / \`test_parse_onetouch_offline_when_service\`
- [x] \`test_parse_onetouch_good\`
- [x] \`test_parse_onetouch_skips_disabled_device\` / \`test_parse_onetouch_removes_previously_added_disabled_device\`
- [x] \`test_update_onetouch_enabled_by_home_flag\` / \`test_update_onetouch_disabled_by_home_flag\`
- [x] \`test_update_onetouch_failure_raises\` / \`test_update_onetouch_throttle_raises\`
- [x] \`test_update_onetouch_not_requested_when_unsupported\`
- [x] \`test_parse_home_sets_onetouch_supported_true\` / \`test_parse_home_sets_onetouch_supported_false_when_absent\`
- [x] \`TestIaquaOneTouchSwitch\` (turn_on / turn_on_noop / turn_off / turn_off_noop)
- [x] \`test_login_sets_country_lowercased\` / \`test_login_defaults_country_to_us_when_absent\`
- [x] \`test_context_manager_refreshes_when_auth_restored\`
- [x] \`test_transport_error_raises_service_exception\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)