### PR TITLE
fix: cleanup retry logic for 401/429

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ The library follows a plugin-style architecture with base classes and system-spe
 1. **AqualinkClient** ([client.py](src/iaqualink/client.py)) - Entry point for authentication and system discovery
    - Handles login/authentication for both API types
    - Uses httpx with HTTP/2 support
+   - Uses `httpx-retries` for transport-level 429 retries with exponential backoff and `Retry-After`
+   - Rebuilds and retries auth-bearing client-owned requests such as systems discovery through the shared reauth helper instead of replaying stale requests inside `send_request()`
    - Manages session tokens and credentials
    - Factory method `get_systems()` returns appropriate system subclasses
 
@@ -83,6 +85,7 @@ The library follows a plugin-style architecture with base classes and system-spe
      - **IaquaSystem** ([systems/iaqua/system.py](src/iaqualink/systems/iaqua/system.py)) - For "iaqua" device_type
      - **ExoSystem** ([systems/exo/system.py](src/iaqualink/systems/exo/system.py)) - For "exo" device_type
    - Implements polling with rate limiting (MIN_SECS_TO_REFRESH per system: 5s iaqua, 50s exo)
+   - Uses the shared Tenacity-based reauth helper to retry iaqua and exo system requests once after refreshing auth on `AqualinkServiceUnauthorizedException`
    - Tracks online/offline status
 
 3. **AqualinkDevice** ([device.py](src/iaqualink/device.py)) - Base class for devices

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ The library follows a plugin-style architecture with base classes and system-spe
      - **IaquaSystem** ([systems/iaqua/system.py](src/iaqualink/systems/iaqua/system.py)) - For "iaqua" device_type
      - **ExoSystem** ([systems/exo/system.py](src/iaqualink/systems/exo/system.py)) - For "exo" device_type
    - Implements polling with rate limiting (MIN_SECS_TO_REFRESH per system: 5s iaqua, 50s exo)
-   - Uses the shared Tenacity-based reauth helper to retry iaqua and exo system requests once after refreshing auth on `AqualinkServiceUnauthorizedException`
+   - Uses the shared reauth helper to retry iaqua and exo system requests once after refreshing auth on `AqualinkServiceUnauthorizedException`
    - Tracks online/offline status
 
 3. **AqualinkDevice** ([device.py](src/iaqualink/device.py)) - Base class for devices
@@ -133,7 +133,8 @@ To add a new system type:
 4. Implement device parsing in `_parse_*_response()` methods
 5. Create corresponding device classes extending base device types
 6. In `update()`, re-raise `AqualinkServiceThrottledException` before the broader `AqualinkServiceException` handler to prevent `online = None` on rate-limiting (see existing implementations in `iaqua/system.py` and `exo/system.py`)
-7. Add tests following existing patterns in `tests/systems/newsystem/`
+7. Register the new system module import in `src/iaqualink/client.py` so `AqualinkSystem.from_data()` can discover the subclass at runtime
+8. Add tests following existing patterns in `tests/systems/newsystem/`
 
 ## Quality Gates
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 ### ✨ Features
 
 - 🔄 **Fully Asynchronous** - Built with `asyncio` and `httpx` for efficient, non-blocking I/O
+- 🔁 **HTTP Retry Transport** - Uses `httpx-retries` for 429 backoff and `Retry-After` handling
+- 🔐 **401 Replay for Auth-Bearing Requests** - Uses `tenacity` to rebuild and replay systems discovery and iaqua/exo system requests after token refresh
 - 🏗️ **Multi-System Support**
   - **iAqua** systems (iaqualink.net API)
   - **eXO** systems (zodiac-io.com API)
@@ -190,6 +192,8 @@ uv run mypy src/
 
 - Python 3.14 or higher
 - httpx with HTTP/2 support
+- httpx-retries for transport-level 429 retry handling
+- tenacity for system-level 401 refresh-and-retry handling
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 - 🔄 **Fully Asynchronous** - Built with `asyncio` and `httpx` for efficient, non-blocking I/O
 - 🔁 **HTTP Retry Transport** - Uses `httpx-retries` for 429 backoff and `Retry-After` handling
-- 🔐 **401 Replay for Auth-Bearing Requests** - Uses `tenacity` to rebuild and replay systems discovery and iaqua/exo system requests after token refresh
+- 🔐 **401 Replay for Auth-Bearing Requests** - Rebuilds and replays systems discovery and iaqua/exo system requests after auth refresh
 - 🏗️ **Multi-System Support**
   - **iAqua** systems (iaqualink.net API)
   - **eXO** systems (zodiac-io.com API)
@@ -193,7 +193,6 @@ uv run mypy src/
 - Python 3.14 or higher
 - httpx with HTTP/2 support
 - httpx-retries for transport-level 429 retry handling
-- tenacity for system-level 401 refresh-and-retry handling
 
 ## 📄 License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
 ]
 dependencies = [
     "httpx[http2]>=0.27.0",
+    "httpx-retries>=0.4.6",
+    "tenacity>=9.0.0",
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 dependencies = [
     "httpx[http2]>=0.27.0",
     "httpx-retries>=0.4.6",
-    "tenacity>=9.0.0",
 ]
 dynamic = [
     "version",

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import asyncio
 import contextlib
+import importlib
 import logging
-import random
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING, Any, Self
 
 import httpx
+from httpx_retries import Retry, RetryTransport
 
 from iaqualink.const import (
     AQUALINK_API_KEY,
@@ -27,18 +25,33 @@ from iaqualink.exception import (
     AqualinkServiceUnauthorizedException,
     AqualinkSystemUnsupportedException,
 )
+from iaqualink.reauth import send_with_reauth_retry
 from iaqualink.system import AqualinkSystem
-from iaqualink.systems import *  # noqa: F403
 
 if TYPE_CHECKING:
     from types import TracebackType
+
+for module_name in (
+    "iaqualink.systems.exo.system",
+    "iaqualink.systems.iaqua.system",
+):
+    importlib.import_module(module_name)
 
 AQUALINK_HTTP_HEADERS = {
     "user-agent": "okhttp/3.14.7",
     "content-type": "application/json",
 }
+RETRYABLE_METHODS = frozenset({"GET", "POST"})
 
 LOGGER = logging.getLogger("iaqualink")
+
+
+class AqualinkRetry(Retry):
+    def parse_retry_after(self, retry_after: str) -> float:
+        return min(
+            super().parse_retry_after(retry_after),
+            RETRY_AFTER_MAX_DELAY,
+        )
 
 
 class AqualinkClient:
@@ -53,12 +66,14 @@ class AqualinkClient:
         self._logged = False
 
         self._client: httpx.AsyncClient | None = None
+        self._single_attempt_client: httpx.AsyncClient | None = None
 
         if httpx_client is None:
             self._client = None
             self._must_close_client = True
         else:
             self._client = httpx_client
+            self._single_attempt_client = httpx_client
             self._must_close_client = False
 
         self.client_id = ""
@@ -77,10 +92,15 @@ class AqualinkClient:
         if self._must_close_client is False:
             return
 
-        # There shouldn't be a case where this is None but this quietens mypy.
         if self._client is not None:
             await self._client.aclose()
             self._client = None
+        if (
+            self._single_attempt_client is not None
+            and self._single_attempt_client is not self._client
+        ):
+            await self._single_attempt_client.aclose()
+            self._single_attempt_client = None
 
     async def __aenter__(self) -> Self:
         try:
@@ -108,129 +128,69 @@ class AqualinkClient:
         retry: bool = True,
         **kwargs: Any,
     ) -> httpx.Response:
-        """Send an HTTP request with optional retry on 429 responses.
+        """Send an HTTP request.
 
-        By default (``retry=True``) every request, including login,
-        retries up to :data:`RETRY_MAX_ATTEMPTS` times on 429.
-        Server-provided ``Retry-After`` values are honoured up to
-        :data:`RETRY_AFTER_MAX_DELAY` (60 s); callers that need
-        tighter latency should catch
-        :exc:`AqualinkServiceThrottledException` or wrap calls with
-        :func:`asyncio.wait_for`.
-
-        When ``retry=False`` (``max_attempts=1``) the single attempt
-        raises :exc:`AqualinkServiceThrottledException` immediately on
-        429 with no actual retry.
+        When ``retry=True`` the managed client uses ``httpx-retries`` to
+        handle HTTP 429 responses with exponential backoff and ``Retry-After``.
+        When ``retry=False`` the request is sent through a plain client with no
+        transport-level retries.
         """
-        if self._client is None:
-            self._client = httpx.AsyncClient(
-                http2=True,
-                limits=httpx.Limits(keepalive_expiry=KEEPALIVE_EXPIRY),
-            )
+        client = self._get_httpx_client(retry)
 
         headers = AQUALINK_HTTP_HEADERS.copy()
         headers.update(kwargs.pop("headers", {}))
 
-        max_attempts = RETRY_MAX_ATTEMPTS if retry else 1
+        LOGGER.debug("-> %s %s %s", method.upper(), url, kwargs)
+        r = await client.request(method, url, headers=headers, **kwargs)
 
-        attempt_429 = 0
-        refreshed = False
+        LOGGER.debug("<- %s %s - %s", r.status_code, r.reason_phrase, url)
 
-        while True:
-            LOGGER.debug("-> %s %s %s", method.upper(), url, kwargs)
-            r = await self._client.request(
-                method, url, headers=headers, **kwargs
+        if r.status_code == httpx.codes.UNAUTHORIZED:
+            self._logged = False
+            raise AqualinkServiceUnauthorizedException()
+
+        if r.status_code == httpx.codes.TOO_MANY_REQUESTS:
+            attempts = RETRY_MAX_ATTEMPTS if retry else 1
+            LOGGER.warning(
+                "Rate limited (429), giving up after %d attempt(s)",
+                attempts,
+            )
+            raise AqualinkServiceThrottledException(
+                f"Rate limited after {attempts} attempt(s)"
             )
 
-            LOGGER.debug("<- %s %s - %s", r.status_code, r.reason_phrase, url)
+        if r.status_code != httpx.codes.OK:
+            m = f"Unexpected response: {r.status_code} {r.reason_phrase}"
+            raise AqualinkServiceException(m)
 
-            if r.status_code == httpx.codes.UNAUTHORIZED:
-                was_logged = self._logged
-                self._logged = False
-                if was_logged and self._refresh_token and not refreshed:
-                    refreshed = True
-                    await self._refresh_auth()
-                    # _refresh_auth sets _logged=True, but the Authorization
-                    # header below hasn't been updated yet. The window is
-                    # narrow (no await between here and continue) so a
-                    # concurrent coroutine that reads _logged=True would still
-                    # use its own locally-built headers — not ours.
-                    if "Authorization" in headers:
-                        old = headers["Authorization"]
-                        # Preserve caller format: "Bearer <token>" (iAqua) or
-                        # raw token (eXO). Case-sensitive match is intentional
-                        # — `headers` is a plain dict whose keys are set by
-                        # this method and by callers, all using title-case.
-                        # Converting to httpx.Headers just for this check
-                        # would be over-engineered.
-                        prefix = "Bearer " if old.startswith("Bearer ") else ""
-                        headers["Authorization"] = f"{prefix}{self.id_token}"
-                    # Reset the 429 counter so the post-refresh retry gets
-                    # its own full rate-limit budget; 429s before the token
-                    # expired should not penalise the refreshed request.
-                    attempt_429 = 0
-                    # Re-enter the loop so 429 backoff applies to the retry.
-                    continue
-                raise AqualinkServiceUnauthorizedException()
+        return r
 
-            if r.status_code == httpx.codes.TOO_MANY_REQUESTS:
-                LOGGER.debug("429 response headers: %s", dict(r.headers))
-                if attempt_429 < max_attempts - 1:
-                    delay = self._get_retry_delay(r, attempt_429)
-                    LOGGER.warning(
-                        "Rate limited (429), retry %d/%d in %.1fs",
-                        attempt_429 + 1,
-                        max_attempts,
-                        delay,
-                    )
-                    await asyncio.sleep(delay)
-                    attempt_429 += 1
-                    continue
-                break
-
-            if r.status_code != httpx.codes.OK:
-                m = f"Unexpected response: {r.status_code} {r.reason_phrase}"
-                raise AqualinkServiceException(m)
-
-            return r
-
-        LOGGER.warning(
-            "Rate limited (429), giving up after %d attempt(s)",
-            max_attempts,
-        )
-        raise AqualinkServiceThrottledException(
-            f"Rate limited after {max_attempts} attempt(s)"
-        )
-
-    @staticmethod
-    def _get_retry_delay(response: httpx.Response, attempt: int) -> float:
-        """Determine delay before the next retry.
-
-        Fallback order: numeric Retry-After → HTTP-date Retry-After
-        → exponential backoff with half-jitter.
-        """
-        retry_after = response.headers.get("retry-after")
-        if retry_after is not None:
-            try:
-                return min(float(retry_after), RETRY_AFTER_MAX_DELAY)
-            except ValueError:
-                pass
-
-            try:
-                dt = parsedate_to_datetime(retry_after)
-                delay = (dt - datetime.now(tz=timezone.utc)).total_seconds()
-                if delay > 0:
-                    return min(delay, RETRY_AFTER_MAX_DELAY)
-            except (ValueError, TypeError):
-                pass
-
-            LOGGER.debug(
-                "Could not parse Retry-After header: %s",
-                retry_after,
+    def _build_httpx_client(self, retry: bool) -> httpx.AsyncClient:
+        kwargs: dict[str, Any] = {
+            "http2": True,
+            "limits": httpx.Limits(keepalive_expiry=KEEPALIVE_EXPIRY),
+        }
+        if retry:
+            kwargs["transport"] = RetryTransport(
+                retry=AqualinkRetry(
+                    total=RETRY_MAX_ATTEMPTS - 1,
+                    backoff_factor=RETRY_BASE_DELAY,
+                    max_backoff_wait=RETRY_MAX_DELAY,
+                    allowed_methods=RETRYABLE_METHODS,
+                    status_forcelist={httpx.codes.TOO_MANY_REQUESTS},
+                )
             )
+        return httpx.AsyncClient(**kwargs)
 
-        delay = min(RETRY_BASE_DELAY * (2**attempt), RETRY_MAX_DELAY)
-        return random.uniform(delay / 2, delay)
+    def _get_httpx_client(self, retry: bool) -> httpx.AsyncClient:
+        if retry:
+            if self._client is None:
+                self._client = self._build_httpx_client(retry=True)
+            return self._client
+
+        if self._single_attempt_client is None:
+            self._single_attempt_client = self._build_httpx_client(retry=False)
+        return self._single_attempt_client
 
     async def _send_login_request(self) -> httpx.Response:
         data = {
@@ -279,36 +239,45 @@ class AqualinkClient:
             await self.login()
             return
 
-        data = r.json()
+        self._apply_login_data(
+            r.json(),
+            refresh_token_fallback=self._refresh_token,
+        )
+
+    async def login(self) -> None:
+        r = await self._send_login_request()
+        self._apply_login_data(r.json(), refresh_token_fallback="")
+
+    def _apply_login_data(
+        self,
+        data: dict[str, Any],
+        refresh_token_fallback: str,
+    ) -> None:
         self.client_id = data["session_id"]
         self._token = data["authentication_token"]
         self._user_id = data["id"]
         self.id_token = data["userPoolOAuth"]["IdToken"]
         self._refresh_token = data["userPoolOAuth"].get(
-            "RefreshToken", self._refresh_token
+            "RefreshToken", refresh_token_fallback
         )
         self._logged = True
 
-    async def login(self) -> None:
-        r = await self._send_login_request()
-
-        data = r.json()
-        self.client_id = data["session_id"]
-        self._token = data["authentication_token"]
-        self._user_id = data["id"]
-        self.id_token = data["userPoolOAuth"]["IdToken"]
-        self._refresh_token = data["userPoolOAuth"].get("RefreshToken", "")
-        self._logged = True
-
     async def _send_systems_request(self) -> httpx.Response:
-        params = {
-            "api_key": AQUALINK_API_KEY,
-            "authentication_token": self._token,
-            "user_id": self._user_id,
-        }
-        params_str = "&".join(f"{k}={v}" for k, v in params.items())
-        url = f"{AQUALINK_DEVICES_URL}?{params_str}"
-        return await self.send_request(url)
+        async def do_request() -> httpx.Response:
+            params = {
+                "api_key": AQUALINK_API_KEY,
+                "authentication_token": self._token,
+                "user_id": self._user_id,
+            }
+            params_str = "&".join(f"{k}={v}" for k, v in params.items())
+            url = f"{AQUALINK_DEVICES_URL}?{params_str}"
+            return await self.send_request(url)
+
+        return await send_with_reauth_retry(
+            do_request,
+            self._refresh_auth,
+            can_refresh=lambda: bool(self._refresh_token),
+        )
 
     async def get_systems(self) -> dict[str, AqualinkSystem]:
         try:

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import importlib
 import logging
@@ -41,8 +42,10 @@ AQUALINK_HTTP_HEADERS = {
     "user-agent": "okhttp/3.14.7",
     "content-type": "application/json",
 }
-# POST remains retryable here because the transport only retries 429 responses,
-# where the server declined the request due to rate limiting.
+# POST remains retryable here because the transport only retries explicit 429
+# responses, where the server asked the client to retry later rather than
+# acknowledging the request. That covers auth POSTs plus the eXO desired-state
+# update, which replaces a target state instead of appending a side effect.
 RETRYABLE_METHODS = frozenset({"GET", "POST"})
 
 LOGGER = logging.getLogger("iaqualink")
@@ -51,7 +54,7 @@ LOGGER = logging.getLogger("iaqualink")
 class AqualinkRetry(Retry):
     def parse_retry_after(self, retry_after: str) -> float:
         return min(
-            super().parse_retry_after(retry_after),
+            max(super().parse_retry_after(retry_after), 0.0),
             RETRY_AFTER_MAX_DELAY,
         )
 
@@ -81,6 +84,7 @@ class AqualinkClient:
         self._user_id = ""
         self.id_token = ""
         self._refresh_token = ""
+        self._refresh_lock = asyncio.Lock()
 
         self._last_refresh = 0
 
@@ -202,37 +206,34 @@ class AqualinkClient:
     async def _refresh_auth(self) -> None:
         """Attempt a token refresh; fall back to full login on 401.
 
-        Called from :meth:`send_request` when a 401 is received and a
-        refresh token is available.  Re-entrancy is prevented because
-        :attr:`_logged` is ``False`` by the time this method is called,
-        so the inner call to :meth:`send_request` skips the refresh path.
+        Concurrent unauthorized requests share a single refresh/login attempt.
+        Once one waiter restores authentication, later waiters return without
+        sending an extra refresh request.
 
         Only :exc:`AqualinkServiceUnauthorizedException` (401) from the
         refresh endpoint is caught — other errors (5xx, throttle) propagate
-        to the caller of :meth:`send_request` unchanged.  If the fallback
-        :meth:`login` also raises (wrong password, network error, 429),
-        that exception likewise propagates from :meth:`send_request` with
-        no additional wrapping.
+        unchanged. If the fallback :meth:`login` also raises, that exception
+        likewise propagates with no additional wrapping.
         """
-        # _send_refresh_request calls send_request, which would normally
-        # attempt another token refresh on 401 — that is prevented because
-        # self._logged is False by the time this method is called, so the
-        # re-entrant 401 path in send_request is skipped.
-        if not self._refresh_token:
-            await self.login()
-            return
+        async with self._refresh_lock:
+            if self._logged:
+                return
 
-        try:
-            r = await self._send_refresh_request()
-        except AqualinkServiceUnauthorizedException:
-            # Refresh token is expired or invalid — fall back to full login.
-            await self.login()
-            return
+            if not self._refresh_token:
+                await self.login()
+                return
 
-        self._apply_login_data(
-            r.json(),
-            refresh_token_fallback=self._refresh_token,
-        )
+            try:
+                r = await self._send_refresh_request()
+            except AqualinkServiceUnauthorizedException:
+                # Refresh token is expired or invalid — fall back to full login.
+                await self.login()
+                return
+
+            self._apply_login_data(
+                r.json(),
+                refresh_token_fallback=self._refresh_token,
+            )
 
     async def login(self) -> None:
         r = await self._send_login_request()

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -41,6 +41,8 @@ AQUALINK_HTTP_HEADERS = {
     "user-agent": "okhttp/3.14.7",
     "content-type": "application/json",
 }
+# POST remains retryable here because the transport only retries 429 responses,
+# where the server declined the request due to rate limiting.
 RETRYABLE_METHODS = frozenset({"GET", "POST"})
 
 LOGGER = logging.getLogger("iaqualink")
@@ -139,6 +141,8 @@ class AqualinkClient:
             raise AqualinkServiceUnauthorizedException()
 
         if r.status_code == httpx.codes.TOO_MANY_REQUESTS:
+            # RetryTransport returns the final 429 response once the retry
+            # budget is exhausted, so translate it to the library exception here.
             LOGGER.warning(
                 "Rate limited (429), giving up after %d attempt(s)",
                 RETRY_MAX_ATTEMPTS,
@@ -214,6 +218,10 @@ class AqualinkClient:
         # attempt another token refresh on 401 — that is prevented because
         # self._logged is False by the time this method is called, so the
         # re-entrant 401 path in send_request is skipped.
+        if not self._refresh_token:
+            await self.login()
+            return
+
         try:
             r = await self._send_refresh_request()
         except AqualinkServiceUnauthorizedException:
@@ -258,7 +266,6 @@ class AqualinkClient:
         return await send_with_reauth_retry(
             do_request,
             self._refresh_auth,
-            can_refresh=lambda: bool(self._refresh_token),
         )
 
     async def get_systems(self) -> dict[str, AqualinkSystem]:

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -46,6 +46,8 @@ AQUALINK_HTTP_HEADERS = {
 # responses, where the server asked the client to retry later rather than
 # acknowledging the request. That covers auth POSTs plus the eXO desired-state
 # update, which replaces a target state instead of appending a side effect.
+# iAqua command POSTs are a trade-off: a retried 429 assumes the server rejected
+# the command before processing it, which matches observed rate-limit behavior.
 RETRYABLE_METHODS = frozenset({"GET", "POST"})
 
 LOGGER = logging.getLogger("iaqualink")
@@ -53,10 +55,12 @@ LOGGER = logging.getLogger("iaqualink")
 
 class AqualinkRetry(Retry):
     def parse_retry_after(self, retry_after: str) -> float:
-        return min(
-            max(super().parse_retry_after(retry_after), 0.0),
-            RETRY_AFTER_MAX_DELAY,
-        )
+        try:
+            delay = super().parse_retry_after(retry_after)
+        except ValueError:
+            return 0.0
+
+        return min(max(delay, 0.0), RETRY_AFTER_MAX_DELAY)
 
 
 class AqualinkClient:
@@ -161,25 +165,21 @@ class AqualinkClient:
 
         return r
 
-    def _build_httpx_client(self) -> httpx.AsyncClient:
-        kwargs: dict[str, Any] = {
-            "http2": True,
-            "limits": httpx.Limits(keepalive_expiry=KEEPALIVE_EXPIRY),
-            "transport": RetryTransport(
-                retry=AqualinkRetry(
-                    total=RETRY_MAX_ATTEMPTS - 1,
-                    backoff_factor=RETRY_BASE_DELAY,
-                    max_backoff_wait=RETRY_MAX_DELAY,
-                    allowed_methods=RETRYABLE_METHODS,
-                    status_forcelist={httpx.codes.TOO_MANY_REQUESTS},
-                )
-            ),
-        }
-        return httpx.AsyncClient(**kwargs)
-
     def _get_httpx_client(self) -> httpx.AsyncClient:
         if self._client is None:
-            self._client = self._build_httpx_client()
+            self._client = httpx.AsyncClient(
+                http2=True,
+                limits=httpx.Limits(keepalive_expiry=KEEPALIVE_EXPIRY),
+                transport=RetryTransport(
+                    retry=AqualinkRetry(
+                        total=RETRY_MAX_ATTEMPTS - 1,
+                        backoff_factor=RETRY_BASE_DELAY,
+                        max_backoff_wait=RETRY_MAX_DELAY,
+                        allowed_methods=RETRYABLE_METHODS,
+                        status_forcelist={httpx.codes.TOO_MANY_REQUESTS},
+                    )
+                ),
+            )
         return self._client
 
     async def _send_login_request(self) -> httpx.Response:

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -66,14 +66,12 @@ class AqualinkClient:
         self._logged = False
 
         self._client: httpx.AsyncClient | None = None
-        self._single_attempt_client: httpx.AsyncClient | None = None
 
         if httpx_client is None:
             self._client = None
             self._must_close_client = True
         else:
             self._client = httpx_client
-            self._single_attempt_client = httpx_client
             self._must_close_client = False
 
         self.client_id = ""
@@ -95,12 +93,6 @@ class AqualinkClient:
         if self._client is not None:
             await self._client.aclose()
             self._client = None
-        if (
-            self._single_attempt_client is not None
-            and self._single_attempt_client is not self._client
-        ):
-            await self._single_attempt_client.aclose()
-            self._single_attempt_client = None
 
     async def __aenter__(self) -> Self:
         try:
@@ -125,17 +117,14 @@ class AqualinkClient:
         self,
         url: str,
         method: str = "get",
-        retry: bool = True,
         **kwargs: Any,
     ) -> httpx.Response:
         """Send an HTTP request.
 
-        When ``retry=True`` the managed client uses ``httpx-retries`` to
-        handle HTTP 429 responses with exponential backoff and ``Retry-After``.
-        When ``retry=False`` the request is sent through a plain client with no
-        transport-level retries.
+        The managed client uses ``httpx-retries`` to handle HTTP 429
+        responses with exponential backoff and ``Retry-After``.
         """
-        client = self._get_httpx_client(retry)
+        client = self._get_httpx_client()
 
         headers = AQUALINK_HTTP_HEADERS.copy()
         headers.update(kwargs.pop("headers", {}))
@@ -150,13 +139,12 @@ class AqualinkClient:
             raise AqualinkServiceUnauthorizedException()
 
         if r.status_code == httpx.codes.TOO_MANY_REQUESTS:
-            attempts = RETRY_MAX_ATTEMPTS if retry else 1
             LOGGER.warning(
                 "Rate limited (429), giving up after %d attempt(s)",
-                attempts,
+                RETRY_MAX_ATTEMPTS,
             )
             raise AqualinkServiceThrottledException(
-                f"Rate limited after {attempts} attempt(s)"
+                f"Rate limited after {RETRY_MAX_ATTEMPTS} attempt(s)"
             )
 
         if r.status_code != httpx.codes.OK:
@@ -165,13 +153,11 @@ class AqualinkClient:
 
         return r
 
-    def _build_httpx_client(self, retry: bool) -> httpx.AsyncClient:
+    def _build_httpx_client(self) -> httpx.AsyncClient:
         kwargs: dict[str, Any] = {
             "http2": True,
             "limits": httpx.Limits(keepalive_expiry=KEEPALIVE_EXPIRY),
-        }
-        if retry:
-            kwargs["transport"] = RetryTransport(
+            "transport": RetryTransport(
                 retry=AqualinkRetry(
                     total=RETRY_MAX_ATTEMPTS - 1,
                     backoff_factor=RETRY_BASE_DELAY,
@@ -179,18 +165,14 @@ class AqualinkClient:
                     allowed_methods=RETRYABLE_METHODS,
                     status_forcelist={httpx.codes.TOO_MANY_REQUESTS},
                 )
-            )
+            ),
+        }
         return httpx.AsyncClient(**kwargs)
 
-    def _get_httpx_client(self, retry: bool) -> httpx.AsyncClient:
-        if retry:
-            if self._client is None:
-                self._client = self._build_httpx_client(retry=True)
-            return self._client
-
-        if self._single_attempt_client is None:
-            self._single_attempt_client = self._build_httpx_client(retry=False)
-        return self._single_attempt_client
+    def _get_httpx_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = self._build_httpx_client()
+        return self._client
 
     async def _send_login_request(self) -> httpx.Response:
         data = {

--- a/src/iaqualink/reauth.py
+++ b/src/iaqualink/reauth.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
-from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt
-
 from iaqualink.exception import AqualinkServiceUnauthorizedException
 
 if TYPE_CHECKING:
@@ -14,30 +12,14 @@ if TYPE_CHECKING:
 async def send_with_reauth_retry(
     request_factory: Callable[[], Awaitable[httpx.Response]],
     refresh_auth: Callable[[], Awaitable[None]],
-    can_refresh: Callable[[], bool] | None = None,
 ) -> httpx.Response:
-    should_retry = False
-
-    def should_retry_unauthorized(exc: BaseException) -> bool:
-        return should_retry and isinstance(
-            exc, AqualinkServiceUnauthorizedException
-        )
-
-    async for attempt in AsyncRetrying(
-        stop=stop_after_attempt(2),
-        retry=retry_if_exception(should_retry_unauthorized),
-        reraise=True,
-    ):
-        with attempt:
-            try:
-                return await request_factory()
-            except AqualinkServiceUnauthorizedException:
-                should_retry = False
-                if attempt.retry_state.attempt_number == 1 and (
-                    can_refresh is None or can_refresh()
-                ):
-                    should_retry = True
-                    await refresh_auth()
-                raise
+    for attempt in range(2):
+        try:
+            return await request_factory()
+        except AqualinkServiceUnauthorizedException:
+            if attempt == 0:
+                await refresh_auth()
+                continue
+            raise
 
     raise AssertionError("unreachable")

--- a/src/iaqualink/reauth.py
+++ b/src/iaqualink/reauth.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from tenacity import AsyncRetrying, retry_if_exception, stop_after_attempt
+
+from iaqualink.exception import AqualinkServiceUnauthorizedException
+
+if TYPE_CHECKING:
+    import httpx
+
+
+async def send_with_reauth_retry(
+    request_factory: Callable[[], Awaitable[httpx.Response]],
+    refresh_auth: Callable[[], Awaitable[None]],
+    can_refresh: Callable[[], bool] | None = None,
+) -> httpx.Response:
+    should_retry = False
+
+    def should_retry_unauthorized(exc: BaseException) -> bool:
+        return should_retry and isinstance(
+            exc, AqualinkServiceUnauthorizedException
+        )
+
+    async for attempt in AsyncRetrying(
+        stop=stop_after_attempt(2),
+        retry=retry_if_exception(should_retry_unauthorized),
+        reraise=True,
+    ):
+        with attempt:
+            try:
+                return await request_factory()
+            except AqualinkServiceUnauthorizedException:
+                should_retry = False
+                if attempt.retry_state.attempt_number == 1 and (
+                    can_refresh is None or can_refresh()
+                ):
+                    should_retry = True
+                    await refresh_auth()
+                raise
+
+    raise AssertionError("unreachable")

--- a/src/iaqualink/reauth.py
+++ b/src/iaqualink/reauth.py
@@ -13,13 +13,9 @@ async def send_with_reauth_retry(
     request_factory: Callable[[], Awaitable[httpx.Response]],
     refresh_auth: Callable[[], Awaitable[None]],
 ) -> httpx.Response:
-    for attempt in range(2):
-        try:
-            return await request_factory()
-        except AqualinkServiceUnauthorizedException:
-            if attempt == 0:
-                await refresh_auth()
-                continue
-            raise
+    try:
+        return await request_factory()
+    except AqualinkServiceUnauthorizedException:
+        await refresh_auth()
 
-    raise AssertionError("unreachable")  # pragma: no cover
+    return await request_factory()

--- a/src/iaqualink/reauth.py
+++ b/src/iaqualink/reauth.py
@@ -22,4 +22,4 @@ async def send_with_reauth_retry(
                 continue
             raise
 
-    raise AssertionError("unreachable")
+    raise AssertionError("unreachable")  # pragma: no cover

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 import logging
 from typing import TYPE_CHECKING, ClassVar
 
 from iaqualink.exception import AqualinkSystemUnsupportedException
+from iaqualink.reauth import send_with_reauth_retry
 
 if TYPE_CHECKING:
+    import httpx
+
     from iaqualink.client import AqualinkClient
     from iaqualink.device import AqualinkDevice
     from iaqualink.typing import Payload
@@ -62,6 +66,15 @@ class AqualinkSystem:
         if not self.devices:
             await self.update()
         return self.devices
+
+    async def _send_with_reauth_retry(
+        self,
+        request_factory: Callable[[], Awaitable[httpx.Response]],
+    ) -> httpx.Response:
+        return await send_with_reauth_retry(
+            request_factory,
+            self.aqualink._refresh_auth,
+        )
 
     async def update(self) -> None:
         raise NotImplementedError

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -40,9 +40,16 @@ class ExoSystem(AqualinkSystem):
         return f"{self.__class__.__name__}({' '.join(attrs)})"
 
     async def send_devices_request(self, **kwargs: Any) -> httpx.Response:
-        url = f"{EXO_DEVICES_URL}/{self.serial}/shadow"
-        headers = {"Authorization": self.aqualink.id_token}
-        return await self.aqualink.send_request(url, headers=headers, **kwargs)
+        async def do_request() -> httpx.Response:
+            url = f"{EXO_DEVICES_URL}/{self.serial}/shadow"
+            headers = {"Authorization": self.aqualink.id_token}
+            return await self.aqualink.send_request(
+                url,
+                headers=headers,
+                **kwargs,
+            )
+
+        return await self._send_with_reauth_retry(do_request)
 
     async def send_reported_state_request(self) -> httpx.Response:
         return await self.send_devices_request()

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -65,16 +65,26 @@ class IaquaSystem(AqualinkSystem):
                 "actionID": "command",
                 "command": command,
                 "serial": self.serial,
-                "sessionID": self.aqualink.client_id,
             }
         )
-        params_str = "&".join(f"{k}={v}" for k, v in params.items())
-        url = f"{IAQUA_SESSION_URL}?{params_str}"
-        headers = {
-            "Authorization": f"Bearer {self.aqualink.id_token}",
-            "api_key": AQUALINK_API_KEY,
-        }
-        return await self.aqualink.send_request(url, headers=headers)
+
+        async def do_request() -> httpx.Response:
+            request_params = {
+                **params,
+                "sessionID": self.aqualink.client_id,
+            }
+            params_str = "&".join(f"{k}={v}" for k, v in request_params.items())
+            url = f"{IAQUA_SESSION_URL}?{params_str}"
+            headers = {
+                "Authorization": f"Bearer {self.aqualink.id_token}",
+                "api_key": AQUALINK_API_KEY,
+            }
+            return await self.aqualink.send_request(
+                url,
+                headers=headers,
+            )
+
+        return await self._send_with_reauth_retry(do_request)
 
     async def _send_home_screen_request(self) -> httpx.Response:
         return await self._send_session_request(IAQUA_COMMAND_GET_HOME)

--- a/tests/systems/exo/test_system.py
+++ b/tests/systems/exo/test_system.py
@@ -272,6 +272,56 @@ class TestExoSystem(unittest.IsolatedAsyncioTestCase):
         with pytest.raises(AqualinkServiceUnauthorizedException):
             await system.send_reported_state_request()
 
+    @patch("httpx.AsyncClient.request")
+    async def test_reported_state_request_retries_after_refresh(
+        self, mock_request
+    ):
+        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "exo"}
+        aqualink = AqualinkClient("user", "pass")
+        system = ExoSystem.from_data(aqualink, data)
+
+        mock_request.side_effect = [
+            MagicMock(status_code=401),
+            MagicMock(status_code=200),
+        ]
+        aqualink.id_token = "old-id-token"
+
+        async def fake_refresh() -> None:
+            aqualink.id_token = "new-id-token"
+
+        with patch.object(
+            aqualink, "_refresh_auth", side_effect=fake_refresh
+        ) as mock_refresh:
+            await system.send_reported_state_request()
+
+        retry_headers = mock_request.call_args_list[1][1]["headers"]
+
+        mock_refresh.assert_awaited_once()
+        assert retry_headers["Authorization"] == "new-id-token"
+
+    @patch("httpx.AsyncClient.request")
+    async def test_reported_state_request_refreshes_only_once_on_repeated_401(
+        self, mock_request
+    ):
+        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "exo"}
+        aqualink = AqualinkClient("user", "pass")
+        system = ExoSystem.from_data(aqualink, data)
+
+        mock_request.side_effect = [
+            MagicMock(status_code=401),
+            MagicMock(status_code=401),
+        ]
+
+        with (
+            patch.object(
+                aqualink, "_refresh_auth", return_value=None
+            ) as mock_refresh,
+            pytest.raises(AqualinkServiceUnauthorizedException),
+        ):
+            await system.send_reported_state_request()
+
+        mock_refresh.assert_awaited_once()
+
     async def test_update_skipped_within_refresh_interval(self):
         aqualink = MagicMock()
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "exo"}

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import urllib.parse
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -138,6 +139,55 @@ class TestIaquaSystem(TestBaseSystem):
 
         with pytest.raises(AqualinkServiceUnauthorizedException):
             await self.sut._send_devices_screen_request()
+
+    @patch("httpx.AsyncClient.request")
+    async def test_session_request_retries_after_refresh(
+        self, mock_request
+    ) -> None:
+        mock_request.side_effect = [
+            MagicMock(status_code=401),
+            MagicMock(status_code=200),
+        ]
+        self.client.client_id = "old-session-id"
+        self.client.id_token = "old-id-token"
+
+        async def fake_refresh() -> None:
+            self.client.client_id = "new-session-id"
+            self.client.id_token = "new-id-token"
+
+        with patch.object(
+            self.client, "_refresh_auth", side_effect=fake_refresh
+        ) as mock_refresh:
+            await self.sut._send_home_screen_request()
+
+        retry_url = mock_request.call_args_list[1][0][1]
+        retry_headers = mock_request.call_args_list[1][1]["headers"]
+        retry_params = urllib.parse.parse_qs(
+            urllib.parse.urlparse(retry_url).query
+        )
+
+        mock_refresh.assert_awaited_once()
+        assert retry_params["sessionID"] == ["new-session-id"]
+        assert retry_headers["Authorization"] == "Bearer new-id-token"
+
+    @patch("httpx.AsyncClient.request")
+    async def test_session_request_refreshes_only_once_on_repeated_401(
+        self, mock_request
+    ) -> None:
+        mock_request.side_effect = [
+            MagicMock(status_code=401),
+            MagicMock(status_code=401),
+        ]
+
+        with (
+            patch.object(
+                self.client, "_refresh_auth", return_value=None
+            ) as mock_refresh,
+            pytest.raises(AqualinkServiceUnauthorizedException),
+        ):
+            await self.sut._send_home_screen_request()
+
+        mock_refresh.assert_awaited_once()
 
     @patch("httpx.AsyncClient.request")
     async def test_session_request_uses_v2_url(self, mock_request) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -234,7 +234,9 @@ class TestAqualinkClient(TestBase):
         mock_refresh.assert_awaited_once()
 
     @patch("httpx.AsyncClient.request")
-    async def test_systems_request_unauthorized(self, mock_request) -> None:
+    async def test_systems_request_404_maps_to_unauthorized(
+        self, mock_request
+    ) -> None:
         mock_request.return_value.status_code = 404
 
         with pytest.raises(AqualinkServiceUnauthorizedException):
@@ -275,6 +277,13 @@ class TestAqualinkClient(TestBase):
         past = datetime.now(tz=UTC) - timedelta(days=1)
 
         assert retry.parse_retry_after(format_datetime(past, usegmt=True)) == 0
+
+    def test_429_retry_after_unparseable_does_not_raise(self) -> None:
+        retry = AqualinkRetry(total=RETRY_MAX_ATTEMPTS - 1)
+
+        result = retry.parse_retry_after("totally-invalid")
+
+        assert result >= 0.0
 
     @respx.mock
     @patch("iaqualink.client.AqualinkRetry.asleep", new_callable=AsyncMock)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -355,19 +355,77 @@ class TestAqualinkClient(TestBase):
             await self.client._send_systems_request()
 
     @patch("httpx.AsyncClient.request")
-    async def test_401_without_refresh_token_raises_immediately(
+    async def test_401_without_refresh_token_falls_back_to_login(
         self, mock_request
     ) -> None:
-        # When no refresh token is available, 401 raises without any retry.
         mock_request.side_effect = [
             _make_resp(200, LOGIN_DATA),  # login — no RefreshToken in response
             _make_resp(401),
+            _make_resp(200, LOGIN_DATA),
+            _make_resp(200, []),
         ]
 
         await self.client.login()
-        with pytest.raises(AqualinkServiceUnauthorizedException):
+        response = await self.client._send_systems_request()
+
+        assert response.status_code == httpx.codes.OK
+        assert mock_request.call_count == 4
+
+    @respx.mock
+    @patch("iaqualink.client.AqualinkRetry.asleep", new_callable=AsyncMock)
+    async def test_systems_request_retry_after_refresh_gets_full_429_budget(
+        self, mock_sleep
+    ) -> None:
+        self.client._token = "old-token"
+        self.client._user_id = "id"
+
+        async def fake_refresh() -> None:
+            self.client._token = "new-token"
+
+        initial_route = respx.get(
+            "https://r-api.iaqualink.net/devices.json?api_key=EOOEMOW4YR6QNB07&authentication_token=old-token&user_id=id"
+        ).mock(
+            return_value=httpx.Response(status_code=httpx.codes.UNAUTHORIZED)
+        )
+        retry_route = respx.get(
+            "https://r-api.iaqualink.net/devices.json?api_key=EOOEMOW4YR6QNB07&authentication_token=new-token&user_id=id"
+        ).mock(
+            side_effect=[
+                httpx.Response(status_code=httpx.codes.TOO_MANY_REQUESTS)
+            ]
+            * RETRY_MAX_ATTEMPTS
+        )
+
+        with (
+            patch.object(
+                self.client, "_refresh_auth", side_effect=fake_refresh
+            ),
+            pytest.raises(AqualinkServiceThrottledException),
+        ):
             await self.client._send_systems_request()
-        assert mock_request.call_count == 2
+
+        assert initial_route.call_count == 1
+        assert retry_route.call_count == RETRY_MAX_ATTEMPTS
+        assert mock_sleep.call_count == RETRY_MAX_ATTEMPTS - 1
+
+    @patch("httpx.AsyncClient.request")
+    async def test_systems_request_500_after_refresh_raises_service_exception(
+        self, mock_request
+    ) -> None:
+        mock_request.side_effect = [
+            _make_resp(401),
+            _make_resp(500),
+        ]
+
+        with (
+            patch.object(self.client, "_refresh_auth", return_value=None),
+            pytest.raises(AqualinkServiceException) as exc_info,
+        ):
+            await self.client._send_systems_request()
+
+        assert not isinstance(
+            exc_info.value, AqualinkServiceUnauthorizedException
+        )
 
     @patch("httpx.AsyncClient.request")
     async def test_refresh_retains_existing_token_when_none_returned(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -269,6 +270,12 @@ class TestAqualinkClient(TestBase):
             == RETRY_AFTER_MAX_DELAY
         )
 
+    def test_429_retry_after_past_date_clamped_to_zero(self) -> None:
+        retry = AqualinkRetry(total=RETRY_MAX_ATTEMPTS - 1)
+        past = datetime.now(tz=UTC) - timedelta(days=1)
+
+        assert retry.parse_retry_after(format_datetime(past, usegmt=True)) == 0
+
     @respx.mock
     @patch("iaqualink.client.AqualinkRetry.asleep", new_callable=AsyncMock)
     async def test_429_retries_exhausted(self, mock_sleep) -> None:
@@ -317,6 +324,38 @@ class TestAqualinkClient(TestBase):
             pytest.raises(AqualinkServiceThrottledException),
         ):
             await self.client._refresh_auth()
+
+    async def test_refresh_auth_concurrent_calls_only_refresh_once(
+        self,
+    ) -> None:
+        self.client._refresh_token = "refresh-token"
+        self.client._logged = False
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fake_send_refresh_request() -> MagicMock:
+            started.set()
+            await release.wait()
+            return _make_resp(200, REFRESH_RESPONSE_DATA)
+
+        with patch.object(
+            self.client,
+            "_send_refresh_request",
+            side_effect=fake_send_refresh_request,
+        ) as mock_refresh:
+            first = asyncio.create_task(self.client._refresh_auth())
+            await started.wait()
+            second = asyncio.create_task(self.client._refresh_auth())
+
+            release.set()
+            await asyncio.gather(first, second)
+
+        mock_refresh.assert_awaited_once()
+        assert self.client.logged is True
+        assert (
+            self.client._token == REFRESH_RESPONSE_DATA["authentication_token"]
+        )
 
     @patch("httpx.AsyncClient.request")
     async def test_refresh_request_does_not_retry_unauthorized(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+import respx
 
-from iaqualink.client import AqualinkClient
+from iaqualink.client import AqualinkClient, AqualinkRetry
 from iaqualink.const import (
     RETRY_AFTER_MAX_DELAY,
     RETRY_MAX_ATTEMPTS,
-    RETRY_MAX_DELAY,
 )
 from iaqualink.exception import (
     AqualinkServiceException,
@@ -112,6 +112,21 @@ class TestAqualinkClient(TestBase):
         assert self.client.logged is False
 
     @patch("httpx.AsyncClient.request")
+    async def test_login_does_not_retry_unauthorized(
+        self, mock_request
+    ) -> None:
+        mock_request.return_value.status_code = 401
+
+        with (
+            pytest.raises(AqualinkServiceException),
+            patch.object(self.client, "_refresh_auth") as mock_refresh,
+        ):
+            await self.client.login()
+
+        mock_refresh.assert_not_called()
+        assert mock_request.call_count == 1
+
+    @patch("httpx.AsyncClient.request")
     async def test_login_exception(self, mock_request) -> None:
         mock_request.return_value.status_code = 500
 
@@ -178,80 +193,100 @@ class TestAqualinkClient(TestBase):
         assert len(systems) == 1
 
     @patch("httpx.AsyncClient.request")
+    async def test_systems_request_retries_after_refresh(
+        self, mock_request
+    ) -> None:
+        mock_request.side_effect = [
+            _make_resp(200, LOGIN_DATA_WITH_REFRESH),
+            _make_resp(401),
+            _make_resp(200, REFRESH_RESPONSE_DATA),
+            _make_resp(200, []),
+        ]
+
+        await self.client.login()
+        systems = await self.client.get_systems()
+
+        assert systems == {}
+        retry_url = mock_request.call_args_list[3][0][1]
+        assert "authentication_token=new-token" in retry_url
+        assert "user_id=id" in retry_url
+
+    @patch("httpx.AsyncClient.request")
+    async def test_systems_request_repeated_401_refreshes_only_once(
+        self, mock_request
+    ) -> None:
+        mock_request.side_effect = [
+            _make_resp(401),
+            _make_resp(401),
+        ]
+        self.client._logged = True
+        self.client._refresh_token = "refresh-token"
+
+        with (
+            patch.object(
+                self.client, "_refresh_auth", return_value=None
+            ) as mock_refresh,
+            pytest.raises(AqualinkServiceUnauthorizedException),
+        ):
+            await self.client._send_systems_request()
+
+        mock_refresh.assert_awaited_once()
+
+    @patch("httpx.AsyncClient.request")
     async def test_systems_request_unauthorized(self, mock_request) -> None:
         mock_request.return_value.status_code = 404
 
         with pytest.raises(AqualinkServiceUnauthorizedException):
             await self.client.get_systems()
 
-    # The 429-retry tests use @patch("httpx.AsyncClient.request") rather
-    # than respx because respx intercepts at transport level, before the
-    # retry loop in send_request() — we need to control per-call
-    # responses (side_effect) and inspect asyncio.sleep calls.
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_429_retry_then_success(
-        self, mock_request, mock_sleep
-    ) -> None:
-        resp_429 = MagicMock()
-        resp_429.status_code = httpx.codes.TOO_MANY_REQUESTS
-        resp_429.reason_phrase = "Too Many Requests"
-        resp_429.headers = httpx.Headers({})
-
-        resp_200 = MagicMock()
-        resp_200.status_code = httpx.codes.OK
-        resp_200.reason_phrase = "OK"
-        resp_200.json = MagicMock(return_value={})
-
-        mock_request.side_effect = [resp_429, resp_200]
+    @respx.mock
+    @patch("iaqualink.client.AqualinkRetry.asleep", new_callable=AsyncMock)
+    async def test_429_retry_then_success(self, mock_sleep) -> None:
+        route = respx.get("https://example.com").mock(
+            side_effect=[
+                httpx.Response(status_code=httpx.codes.TOO_MANY_REQUESTS),
+                httpx.Response(status_code=httpx.codes.OK, json={}),
+            ]
+        )
 
         r = await self.client.send_request("https://example.com")
+
         assert r.status_code == httpx.codes.OK
-        assert mock_request.call_count == 2
+        assert route.call_count == 2
         mock_sleep.assert_called_once()
 
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_429_retry_after_header(
-        self, mock_request, mock_sleep
-    ) -> None:
-        resp_429 = MagicMock()
-        resp_429.status_code = httpx.codes.TOO_MANY_REQUESTS
-        resp_429.reason_phrase = "Too Many Requests"
-        resp_429.headers = httpx.Headers({"retry-after": "5"})
+    def test_429_retry_after_header_is_capped(self) -> None:
+        retry = AqualinkRetry(total=RETRY_MAX_ATTEMPTS - 1)
 
-        resp_200 = MagicMock()
-        resp_200.status_code = httpx.codes.OK
-        resp_200.reason_phrase = "OK"
-        resp_200.json = MagicMock(return_value={})
+        assert retry.parse_retry_after("999") == RETRY_AFTER_MAX_DELAY
 
-        mock_request.side_effect = [resp_429, resp_200]
+    def test_429_retry_after_http_date_is_capped(self) -> None:
+        retry = AqualinkRetry(total=RETRY_MAX_ATTEMPTS - 1)
+        future = datetime.now(tz=UTC) + timedelta(days=365)
 
-        r = await self.client.send_request("https://example.com")
-        assert r.status_code == httpx.codes.OK
-        mock_sleep.assert_called_once_with(5.0)
+        assert (
+            retry.parse_retry_after(format_datetime(future, usegmt=True))
+            == RETRY_AFTER_MAX_DELAY
+        )
 
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_429_retries_exhausted(
-        self, mock_request, mock_sleep
-    ) -> None:
-        resp_429 = MagicMock()
-        resp_429.status_code = httpx.codes.TOO_MANY_REQUESTS
-        resp_429.reason_phrase = "Too Many Requests"
-        resp_429.headers = httpx.Headers({})
-
-        mock_request.return_value = resp_429
+    @respx.mock
+    @patch("iaqualink.client.AqualinkRetry.asleep", new_callable=AsyncMock)
+    async def test_429_retries_exhausted(self, mock_sleep) -> None:
+        route = respx.get("https://example.com").mock(
+            side_effect=[
+                httpx.Response(status_code=httpx.codes.TOO_MANY_REQUESTS)
+            ]
+            * RETRY_MAX_ATTEMPTS
+        )
 
         with pytest.raises(AqualinkServiceThrottledException):
             await self.client.send_request("https://example.com")
 
-        assert mock_request.call_count == RETRY_MAX_ATTEMPTS
+        assert route.call_count == RETRY_MAX_ATTEMPTS
         assert mock_sleep.call_count == RETRY_MAX_ATTEMPTS - 1
 
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
     @patch("httpx.AsyncClient.request")
-    async def test_500_not_retried(self, mock_request, mock_sleep) -> None:
+    async def test_500_not_retried(self, mock_request) -> None:
         mock_request.return_value.status_code = (
             httpx.codes.INTERNAL_SERVER_ERROR
         )
@@ -261,259 +296,58 @@ class TestAqualinkClient(TestBase):
             await self.client.send_request("https://example.com")
 
         assert mock_request.call_count == 1
-        mock_sleep.assert_not_called()
 
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
     @patch("httpx.AsyncClient.request")
-    async def test_401_not_retried(self, mock_request, mock_sleep) -> None:
+    async def test_401_not_retried(self, mock_request) -> None:
         mock_request.return_value.status_code = httpx.codes.UNAUTHORIZED
 
         with pytest.raises(AqualinkServiceUnauthorizedException):
             await self.client.send_request("https://example.com")
 
         assert mock_request.call_count == 1
-        mock_sleep.assert_not_called()
 
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_429_retry_after_http_date(
-        self, mock_request, mock_sleep
-    ) -> None:
-        future = datetime.now(tz=timezone.utc) + timedelta(days=365)
-        resp_429 = MagicMock()
-        resp_429.status_code = httpx.codes.TOO_MANY_REQUESTS
-        resp_429.reason_phrase = "Too Many Requests"
-        resp_429.headers = httpx.Headers(
-            {"retry-after": format_datetime(future, usegmt=True)}
+    @respx.mock
+    @patch("iaqualink.client.AqualinkRetry.asleep", new_callable=AsyncMock)
+    async def test_429_no_retry_when_disabled(self, mock_sleep) -> None:
+        route = respx.get("https://example.com").mock(
+            return_value=httpx.Response(
+                status_code=httpx.codes.TOO_MANY_REQUESTS
+            )
         )
-
-        resp_200 = MagicMock()
-        resp_200.status_code = httpx.codes.OK
-        resp_200.reason_phrase = "OK"
-        resp_200.json = MagicMock(return_value={})
-
-        mock_request.side_effect = [resp_429, resp_200]
-
-        r = await self.client.send_request("https://example.com")
-        assert r.status_code == httpx.codes.OK
-        # Future HTTP-date is parsed and capped at RETRY_AFTER_MAX_DELAY.
-        mock_sleep.assert_called_once_with(RETRY_AFTER_MAX_DELAY)
-
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_429_retry_after_capped_at_max_delay(
-        self, mock_request, mock_sleep
-    ) -> None:
-        resp_429 = MagicMock()
-        resp_429.status_code = httpx.codes.TOO_MANY_REQUESTS
-        resp_429.reason_phrase = "Too Many Requests"
-        resp_429.headers = httpx.Headers({"retry-after": "999"})
-
-        resp_200 = MagicMock()
-        resp_200.status_code = httpx.codes.OK
-        resp_200.reason_phrase = "OK"
-        resp_200.json = MagicMock(return_value={})
-
-        mock_request.side_effect = [resp_429, resp_200]
-
-        r = await self.client.send_request("https://example.com")
-        assert r.status_code == httpx.codes.OK
-        mock_sleep.assert_called_once_with(RETRY_AFTER_MAX_DELAY)
-
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_429_no_retry_when_disabled(
-        self, mock_request, mock_sleep
-    ) -> None:
-        resp_429 = MagicMock()
-        resp_429.status_code = httpx.codes.TOO_MANY_REQUESTS
-        resp_429.reason_phrase = "Too Many Requests"
-        resp_429.headers = httpx.Headers({})
-
-        mock_request.return_value = resp_429
 
         with pytest.raises(AqualinkServiceThrottledException):
             await self.client.send_request("https://example.com", retry=False)
 
-        assert mock_request.call_count == 1
+        assert route.call_count == 1
         mock_sleep.assert_not_called()
-
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_429_retry_after_past_date(
-        self, mock_request, mock_sleep
-    ) -> None:
-        resp_429 = MagicMock()
-        resp_429.status_code = httpx.codes.TOO_MANY_REQUESTS
-        resp_429.reason_phrase = "Too Many Requests"
-        resp_429.headers = httpx.Headers(
-            {"retry-after": "Wed, 21 Oct 2015 07:28:00 GMT"}
-        )
-
-        resp_200 = MagicMock()
-        resp_200.status_code = httpx.codes.OK
-        resp_200.reason_phrase = "OK"
-        resp_200.json = MagicMock(return_value={})
-
-        mock_request.side_effect = [resp_429, resp_200]
-
-        r = await self.client.send_request("https://example.com")
-        assert r.status_code == httpx.codes.OK
-        # Past date yields negative delay, so falls back to
-        # exponential backoff.
-        mock_sleep.assert_called_once()
-        delay = mock_sleep.call_args[0][0]
-        assert 0 <= delay <= RETRY_MAX_DELAY
-
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_429_retry_after_unparseable(
-        self, mock_request, mock_sleep
-    ) -> None:
-        resp_429 = MagicMock()
-        resp_429.status_code = httpx.codes.TOO_MANY_REQUESTS
-        resp_429.reason_phrase = "Too Many Requests"
-        resp_429.headers = httpx.Headers({"retry-after": "totally-invalid"})
-
-        resp_200 = MagicMock()
-        resp_200.status_code = httpx.codes.OK
-        resp_200.reason_phrase = "OK"
-        resp_200.json = MagicMock(return_value={})
-
-        mock_request.side_effect = [resp_429, resp_200]
-
-        r = await self.client.send_request("https://example.com")
-        assert r.status_code == httpx.codes.OK
-        # Unparseable header falls back to exponential backoff.
-        mock_sleep.assert_called_once()
-        delay = mock_sleep.call_args[0][0]
-        assert 0 <= delay <= RETRY_MAX_DELAY
-
-    @patch("httpx.AsyncClient.request")
-    async def test_refresh_on_401_retries_and_succeeds(
-        self, mock_request
-    ) -> None:
-        mock_request.side_effect = [
-            _make_resp(200, LOGIN_DATA_WITH_REFRESH),  # login
-            _make_resp(401),  # original request → 401
-            _make_resp(200, REFRESH_RESPONSE_DATA),  # refresh token call
-            _make_resp(200, {}),  # retry of original request
-        ]
-
-        await self.client.login()
-        r = await self.client.send_request("https://example.com")
-
-        assert r.status_code == httpx.codes.OK
-        assert mock_request.call_count == 4
-
-    @patch("httpx.AsyncClient.request")
-    async def test_refresh_updates_tokens(self, mock_request) -> None:
-        mock_request.side_effect = [
-            _make_resp(200, LOGIN_DATA_WITH_REFRESH),
-            _make_resp(401),
-            _make_resp(200, REFRESH_RESPONSE_DATA),
-            _make_resp(200, {}),
-        ]
-
-        await self.client.login()
-        await self.client.send_request("https://example.com")
-
-        assert self.client.id_token == "new-id-token"
-        assert self.client._token == "new-token"
-        assert self.client._user_id == "id"
-        assert self.client.client_id == "new-session-id"
-        assert self.client.logged is True
-
-    @patch("httpx.AsyncClient.request")
-    async def test_refresh_fallback_to_login_on_refresh_failure(
-        self, mock_request
-    ) -> None:
-        mock_request.side_effect = [
-            _make_resp(200, LOGIN_DATA_WITH_REFRESH),  # initial login
-            _make_resp(401),  # original request → 401
-            _make_resp(401),  # refresh request → 401
-            _make_resp(200, LOGIN_DATA_WITH_REFRESH),  # fallback full login
-            _make_resp(200, {}),  # retry of original request
-        ]
-
-        await self.client.login()
-        r = await self.client.send_request("https://example.com")
-
-        assert r.status_code == httpx.codes.OK
-        assert mock_request.call_count == 5
-        assert self.client.logged is True
-
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_refresh_retry_429_raises_throttled(
-        self, mock_request, mock_sleep
-    ) -> None:
-        # After a token refresh the retry re-enters the main loop, so 429
-        # responses benefit from the same backoff/retry budget as normal.
-        mock_request.side_effect = [
-            _make_resp(200, LOGIN_DATA_WITH_REFRESH),  # login
-            _make_resp(401),  # original → 401
-            _make_resp(200, REFRESH_RESPONSE_DATA),  # refresh token
-            *[_make_resp(429)] * RETRY_MAX_ATTEMPTS,  # all retries exhausted
-        ]
-
-        await self.client.login()
-        with pytest.raises(AqualinkServiceThrottledException):
-            await self.client.send_request("https://example.com")
-        assert mock_sleep.call_count == RETRY_MAX_ATTEMPTS - 1
-
-    @patch("iaqualink.client.asyncio.sleep", new_callable=AsyncMock)
-    @patch("httpx.AsyncClient.request")
-    async def test_refresh_retry_gets_full_429_budget(
-        self, mock_request, mock_sleep
-    ) -> None:
-        # 429s received before the 401 must not reduce the retry budget
-        # available to the post-refresh request.
-        pre_refresh_429s = 2
-        mock_request.side_effect = [
-            _make_resp(200, LOGIN_DATA_WITH_REFRESH),  # login
-            *[_make_resp(429)] * pre_refresh_429s,  # rate-limited before 401
-            _make_resp(401),  # original → triggers refresh
-            _make_resp(200, REFRESH_RESPONSE_DATA),  # refresh token
-            *[_make_resp(429)]
-            * RETRY_MAX_ATTEMPTS,  # post-refresh: full budget
-        ]
-
-        await self.client.login()
-        with pytest.raises(AqualinkServiceThrottledException):
-            await self.client.send_request("https://example.com")
-        # pre-refresh sleeps + post-refresh sleeps (full budget)
-        assert mock_sleep.call_count == pre_refresh_429s + (
-            RETRY_MAX_ATTEMPTS - 1
-        )
-
-    @patch("httpx.AsyncClient.request")
-    async def test_refresh_retry_500_raises_service_exception(
-        self, mock_request
-    ) -> None:
-        mock_request.side_effect = [
-            _make_resp(200, LOGIN_DATA_WITH_REFRESH),
-            _make_resp(401),
-            _make_resp(200, REFRESH_RESPONSE_DATA),
-            _make_resp(500),  # retry after refresh gets a server error
-        ]
-
-        await self.client.login()
-        with pytest.raises(AqualinkServiceException) as exc_info:
-            await self.client.send_request("https://example.com")
-        assert not isinstance(
-            exc_info.value, AqualinkServiceUnauthorizedException
-        )
 
     async def test_refresh_auth_propagates_throttled(self) -> None:
         self.client._refresh_token = "some-refresh-token"
-        with patch.object(
-            self.client,
-            "_send_refresh_request",
-            side_effect=AqualinkServiceThrottledException("Rate limited"),
+        with (
+            patch.object(
+                self.client,
+                "_send_refresh_request",
+                side_effect=AqualinkServiceThrottledException("Rate limited"),
+            ),
+            pytest.raises(AqualinkServiceThrottledException),
         ):
-            with pytest.raises(AqualinkServiceThrottledException):
-                await self.client._refresh_auth()
+            await self.client._refresh_auth()
+
+    @patch("httpx.AsyncClient.request")
+    async def test_refresh_request_does_not_retry_unauthorized(
+        self, mock_request
+    ) -> None:
+        mock_request.return_value.status_code = 401
+        self.client._refresh_token = "refresh-token"
+
+        with (
+            pytest.raises(AqualinkServiceUnauthorizedException),
+            patch.object(self.client, "login") as mock_login,
+        ):
+            await self.client._send_refresh_request()
+
+        mock_login.assert_not_called()
+        assert mock_request.call_count == 1
 
     @patch("httpx.AsyncClient.request")
     async def test_refresh_throttled_propagates_from_send_request(
@@ -525,55 +359,15 @@ class TestAqualinkClient(TestBase):
         ]
 
         await self.client.login()
-        with patch.object(
-            self.client,
-            "_refresh_auth",
-            side_effect=AqualinkServiceThrottledException("Rate limited"),
+        with (
+            patch.object(
+                self.client,
+                "_refresh_auth",
+                side_effect=AqualinkServiceThrottledException("Rate limited"),
+            ),
+            pytest.raises(AqualinkServiceThrottledException),
         ):
-            with pytest.raises(AqualinkServiceThrottledException):
-                await self.client.send_request("https://example.com")
-
-    @patch("httpx.AsyncClient.request")
-    async def test_refresh_updates_bearer_auth_header_on_retry(
-        self, mock_request
-    ) -> None:
-        mock_request.side_effect = [
-            _make_resp(200, LOGIN_DATA_WITH_REFRESH),
-            _make_resp(401),
-            _make_resp(200, REFRESH_RESPONSE_DATA),
-            _make_resp(200, {}),
-        ]
-
-        await self.client.login()
-        await self.client.send_request(
-            "https://example.com",
-            headers={"Authorization": f"Bearer {self.client.id_token}"},
-        )
-
-        # The retry (4th call) must use the new token, not the stale one.
-        retry_headers = mock_request.call_args_list[3][1]["headers"]
-        assert retry_headers["Authorization"] == "Bearer new-id-token"
-
-    @patch("httpx.AsyncClient.request")
-    async def test_refresh_updates_raw_auth_header_on_retry(
-        self, mock_request
-    ) -> None:
-        mock_request.side_effect = [
-            _make_resp(200, LOGIN_DATA_WITH_REFRESH),
-            _make_resp(401),
-            _make_resp(200, REFRESH_RESPONSE_DATA),
-            _make_resp(200, {}),
-        ]
-
-        await self.client.login()
-        # eXO-style: raw token without Bearer prefix
-        await self.client.send_request(
-            "https://example.com",
-            headers={"Authorization": self.client.id_token},
-        )
-
-        retry_headers = mock_request.call_args_list[3][1]["headers"]
-        assert retry_headers["Authorization"] == "new-id-token"
+            await self.client._send_systems_request()
 
     @patch("httpx.AsyncClient.request")
     async def test_401_without_refresh_token_raises_immediately(
@@ -587,7 +381,7 @@ class TestAqualinkClient(TestBase):
 
         await self.client.login()
         with pytest.raises(AqualinkServiceUnauthorizedException):
-            await self.client.send_request("https://example.com")
+            await self.client._send_systems_request()
         assert mock_request.call_count == 2
 
     @patch("httpx.AsyncClient.request")
@@ -610,6 +404,6 @@ class TestAqualinkClient(TestBase):
 
         await self.client.login()
         original_refresh_token = self.client._refresh_token
-        await self.client.send_request("https://example.com")
+        await self.client._send_systems_request()
 
         assert self.client._refresh_token == original_refresh_token

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -306,21 +306,6 @@ class TestAqualinkClient(TestBase):
 
         assert mock_request.call_count == 1
 
-    @respx.mock
-    @patch("iaqualink.client.AqualinkRetry.asleep", new_callable=AsyncMock)
-    async def test_429_no_retry_when_disabled(self, mock_sleep) -> None:
-        route = respx.get("https://example.com").mock(
-            return_value=httpx.Response(
-                status_code=httpx.codes.TOO_MANY_REQUESTS
-            )
-        )
-
-        with pytest.raises(AqualinkServiceThrottledException):
-            await self.client.send_request("https://example.com", retry=False)
-
-        assert route.call_count == 1
-        mock_sleep.assert_not_called()
-
     async def test_refresh_auth_propagates_throttled(self) -> None:
         self.client._refresh_token = "some-refresh-token"
         with (

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,18 @@ http2 = [
 ]
 
 [[package]]
+name = "httpx-retries"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/13/5eac2df576c02280f79e4639a6d4c93a25cfe94458275f5aa55f5e6c8ea0/httpx_retries-0.4.6.tar.gz", hash = "sha256:a076d8a5ede5d5794e9c241da17b15b393b482129ddd2fdf1fa56a3fa1f28a7f", size = 13466, upload-time = "2026-02-17T16:16:05.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/97/63f56da4400034adde22adfe7524635dba068f17d6858f92ecd96f55b53e/httpx_retries-0.4.6-py3-none-any.whl", hash = "sha256:d66d912173b844e065ffb109345a453b922f4c2cd9c9e11139304cb33e7a1ee1", size = 8490, upload-time = "2026-02-17T16:16:04.137Z" },
+]
+
+[[package]]
 name = "hyperframe"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -261,6 +273,8 @@ name = "iaqualink"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
+    { name = "httpx-retries" },
+    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -286,7 +300,11 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "httpx", extras = ["http2"], specifier = ">=0.27.0" }]
+requires-dist = [
+    { name = "httpx", extras = ["http2"], specifier = ">=0.27.0" },
+    { name = "httpx-retries", specifier = ">=0.4.6" },
+    { name = "tenacity", specifier = ">=9.0.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -873,6 +891,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,6 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "httpx-retries" },
-    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -303,7 +302,6 @@ test = [
 requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.0" },
     { name = "httpx-retries", specifier = ">=0.4.6" },
-    { name = "tenacity", specifier = ">=9.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -891,15 +889,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "tenacity"
-version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- move HTTP 429 backoff and Retry-After handling to httpx-retries transport
- rebuild auth-bearing systems, iaqua, and exo requests through a shared reauth retry helper
- keep login and refresh requests terminal on 401 while limiting refresh/replay to a single attempt
- update tests, docs, and dependency metadata for the new retry architecture

## Breaking Changes
- removed the public send_request(..., retry=False) escape hatch; callers should now handle throttling by catching AqualinkServiceThrottledException or by applying their own external timeout/cancellation policy
