### PR TITLE
feat: use mashumaro for response parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,9 +21,8 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - types-PyYAML==6.0.12
+          - types-PyYAML
         exclude: ^(tests/.*)
-        additional_dependencies: ["types-PyYAML"]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.6.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
         additional_dependencies:
           - types-PyYAML==6.0.12
         exclude: ^(tests/.*)
+        additional_dependencies: ["types-PyYAML"]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.6.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx[http2]>=0.27.0",
-    "mashumaro",
+    "mashumaro>=3.21",
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx[http2]>=0.27.0",
+    "pyserde",
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx[http2]>=0.27.0",
-    "pyserde",
+    "mashumaro",
 ]
 dynamic = [
     "version",

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -232,7 +232,7 @@ def _sorted_devices(
 
 
 def _format_system_line(system: AqualinkSystem) -> str:
-    system_type = system.data.get("device_type", "unknown")
+    system_type = system.data.device_type
     suffix = " (unsupported)" if not system.supported else ""
     return f"{system.name} ({system.serial}) [{system_type}]{suffix}"
 

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -25,7 +25,8 @@ from iaqualink.exception import (
 )
 from iaqualink.reauth import send_with_reauth_retry
 from iaqualink.system import AqualinkSystem
-from iaqualink.types import DevicesResponse
+from iaqualink.types import DevicesResponse, LoginResponse
+from iaqualink.util import json_to_dataclass
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -257,13 +258,16 @@ class AqualinkClient:
                 return
 
             self._apply_login_data(
-                r.json(),
+                json_to_dataclass(LoginResponse, r.text),
                 refresh_token_fallback=self.refresh_token,
             )
 
     async def login(self) -> None:
         r = await self._send_login_request()
-        self._apply_login_data(r.json(), refresh_token_fallback="")
+        self._apply_login_data(
+            json_to_dataclass(LoginResponse, r.text),
+            refresh_token_fallback="",
+        )
 
     def _clear_auth_state(self) -> None:
         self.client_id = ""
@@ -275,15 +279,15 @@ class AqualinkClient:
 
     def _apply_login_data(
         self,
-        data: dict[str, Any],
+        data: LoginResponse,
         refresh_token_fallback: str,
     ) -> None:
-        self.client_id = data["session_id"]
-        self.authentication_token = data["authentication_token"]
-        self.user_id = str(data["id"])
-        self.id_token = data["userPoolOAuth"]["IdToken"]
-        self.refresh_token = data["userPoolOAuth"].get(
-            "RefreshToken", refresh_token_fallback
+        self.client_id = data.session_id
+        self.authentication_token = data.authentication_token
+        self.user_id = str(data.id)
+        self.id_token = data.user_pool_o_auth.id_token
+        self.refresh_token = (
+            data.user_pool_o_auth.refresh_token or refresh_token_fallback
         )
         self._logged = True
 

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -37,6 +37,8 @@ for module_name in (
 ):
     importlib.import_module(module_name)
 
+# DevicesResponse is a list type alias, not a DataClassJSONMixin, so it needs a
+# pre-built JSONDecoder rather than json_to_dataclass(). See decode_json() in util.py.
 _devices_decoder = JSONDecoder(DevicesResponse)
 
 AQUALINK_HTTP_HEADERS = {

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -10,6 +10,7 @@ from mashumaro.codecs.json import JSONDecoder
 
 import httpx
 
+
 from iaqualink.const import (
     AQUALINK_API_KEY,
     AQUALINK_DEVICES_URL,
@@ -26,7 +27,7 @@ from iaqualink.exception import (
 from iaqualink.reauth import send_with_reauth_retry
 from iaqualink.system import AqualinkSystem
 from iaqualink.types import DevicesResponse, LoginResponse
-from iaqualink.util import json_to_dataclass
+from iaqualink.util import decode_json, json_to_dataclass
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -285,9 +286,9 @@ class AqualinkClient:
         self.client_id = data.session_id
         self.authentication_token = data.authentication_token
         self.user_id = str(data.id)
-        self.id_token = data.user_pool_o_auth.id_token
+        self.id_token = data.user_pool_oauth.id_token
         self.refresh_token = (
-            data.user_pool_o_auth.refresh_token or refresh_token_fallback
+            data.user_pool_oauth.refresh_token or refresh_token_fallback
         )
         self._logged = True
 
@@ -315,6 +316,6 @@ class AqualinkClient:
                 raise AqualinkServiceUnauthorizedException from e
             raise
 
-        response = _devices_decoder.decode(r.text)
+        response = decode_json(_devices_decoder, r.text)
         systems = [AqualinkSystem.from_data(self, x) for x in response]
         return {x.serial: x for x in systems}

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -6,7 +6,6 @@ import logging
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Self
 
-from serde import serde
 from serde.json import from_json
 
 import httpx
@@ -26,6 +25,7 @@ from iaqualink.exception import (
 )
 from iaqualink.reauth import send_with_reauth_retry
 from iaqualink.system import AqualinkSystem
+from iaqualink.types import DevicesResponse
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -77,26 +77,6 @@ class AqualinkAuthState:
 
         return cls(**values)
 
-
-@serde
-class SystemsResponseElement:
-    created_at: str
-    device_type: str
-    firmware_version: str | None
-    id: int
-    last_activity_at: str | None
-    name: str
-    owner_id: int | None
-    serial_number: str
-    target_firmware_version: str | None
-    update_firmware_start_at: str | None
-    updated_at: str
-    updating: bool
-
-
-@serde
-class SystemsResponse:
-    systems: list[SystemsResponseElement]
 
 
 class AqualinkClient:
@@ -330,7 +310,6 @@ class AqualinkClient:
                 raise AqualinkServiceUnauthorizedException from e
             raise
 
-        response = from_json(SystemsResponse, r.json())
-
-        systems = [AqualinkSystem.from_data(self, x) for x in response.systems]
+        response = from_json(DevicesResponse, r.text)
+        systems = [AqualinkSystem.from_data(self, x) for x in response]
         return {x.serial: x for x in systems}

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -10,7 +10,6 @@ from mashumaro.codecs.json import JSONDecoder
 
 import httpx
 
-
 from iaqualink.const import (
     AQUALINK_API_KEY,
     AQUALINK_DEVICES_URL,

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -263,6 +263,7 @@ class AqualinkClient:
 
     async def login(self) -> None:
         r = await self._send_login_request()
+        self._apply_login_data(r.json(), refresh_token_fallback="")
 
     def _clear_auth_state(self) -> None:
         self.client_id = ""
@@ -279,7 +280,7 @@ class AqualinkClient:
     ) -> None:
         self.client_id = data["session_id"]
         self.authentication_token = data["authentication_token"]
-        self.user_id = data["id"]
+        self.user_id = str(data["id"])
         self.id_token = data["userPoolOAuth"]["IdToken"]
         self.refresh_token = data["userPoolOAuth"].get(
             "RefreshToken", refresh_token_fallback

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -6,6 +6,9 @@ import logging
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Self
 
+from serde import serde
+from serde.json import from_json
+
 import httpx
 
 from iaqualink.const import (
@@ -73,6 +76,27 @@ class AqualinkAuthState:
             values[field_name] = value
 
         return cls(**values)
+
+
+@serde
+class SystemsResponseElement:
+    created_at: str
+    device_type: str
+    firmware_version: str | None
+    id: int
+    last_activity_at: str | None
+    name: str
+    owner_id: int | None
+    serial_number: str
+    target_firmware_version: str | None
+    update_firmware_start_at: str | None
+    updated_at: str
+    updating: bool
+
+
+@serde
+class SystemsResponse:
+    systems: list[SystemsResponseElement]
 
 
 class AqualinkClient:
@@ -306,7 +330,7 @@ class AqualinkClient:
                 raise AqualinkServiceUnauthorizedException from e
             raise
 
-        data = r.json()
+        response = from_json(SystemsResponse, r.json())
 
-        systems = [AqualinkSystem.from_data(self, x) for x in data]
+        systems = [AqualinkSystem.from_data(self, x) for x in response.systems]
         return {x.serial: x for x in systems}

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Self
 
-from serde.json import from_json
+from mashumaro.codecs.json import JSONDecoder
 
 import httpx
 
@@ -35,6 +35,8 @@ for module_name in (
     "iaqualink.systems.iaqua.system",
 ):
     importlib.import_module(module_name)
+
+_devices_decoder = JSONDecoder(DevicesResponse)
 
 AQUALINK_HTTP_HEADERS = {
     "user-agent": "okhttp/3.14.7",
@@ -76,7 +78,6 @@ class AqualinkAuthState:
             values[field_name] = value
 
         return cls(**values)
-
 
 
 class AqualinkClient:
@@ -262,7 +263,6 @@ class AqualinkClient:
 
     async def login(self) -> None:
         r = await self._send_login_request()
-        self._apply_login_data(r.json(), refresh_token_fallback="")
 
     def _clear_auth_state(self) -> None:
         self.client_id = ""
@@ -310,6 +310,6 @@ class AqualinkClient:
                 raise AqualinkServiceUnauthorizedException from e
             raise
 
-        response = from_json(DevicesResponse, r.text)
+        response = _devices_decoder.decode(r.text)
         systems = [AqualinkSystem.from_data(self, x) for x in response]
         return {x.serial: x for x in systems}

--- a/src/iaqualink/exception.py
+++ b/src/iaqualink/exception.py
@@ -27,6 +27,10 @@ class AqualinkServiceThrottledException(AqualinkServiceException):
     """Exception raised when the service returns 429 Too Many Requests."""
 
 
+class AqualinkUnexpectedResponseException(AqualinkServiceException):
+    """Exception raised when the service returns an unexpected or unparseable response."""
+
+
 class AqualinkOperationNotSupportedException(AqualinkException):
     """Exception raised when trying to issue an unsupported operation."""
 

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -10,8 +10,9 @@ from iaqualink.reauth import send_with_reauth_retry
 if TYPE_CHECKING:
     import httpx
 
-    from iaqualink.client import AqualinkClient, SystemsResponseElement
+    from iaqualink.client import AqualinkClient
     from iaqualink.device import AqualinkDevice
+    from iaqualink.types import DevicesResponseElement
 
 
 LOGGER = logging.getLogger("iaqualink")
@@ -27,7 +28,7 @@ class SystemStatus(enum.StrEnum):
 class AqualinkSystem:
     subclasses: ClassVar[dict[str, type[AqualinkSystem]]] = {}
 
-    def __init__(self, aqualink: AqualinkClient, data: SystemsResponseElement):
+    def __init__(self, aqualink: AqualinkClient, data: DevicesResponseElement):
         self.aqualink = aqualink
         self.data = data
         self.devices: dict[str, AqualinkDevice] = {}
@@ -58,7 +59,7 @@ class AqualinkSystem:
 
     @classmethod
     def from_data(
-        cls, aqualink: AqualinkClient, data: SystemsResponseElement
+        cls, aqualink: AqualinkClient, data: DevicesResponseElement
     ) -> AqualinkSystem:
         if data.device_type not in cls.subclasses:
             LOGGER.warning(

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -10,9 +10,8 @@ from iaqualink.reauth import send_with_reauth_retry
 if TYPE_CHECKING:
     import httpx
 
-    from iaqualink.client import AqualinkClient
+    from iaqualink.client import AqualinkClient, SystemsResponseElement
     from iaqualink.device import AqualinkDevice
-    from iaqualink.typing import Payload
 
 
 LOGGER = logging.getLogger("iaqualink")
@@ -28,7 +27,7 @@ class SystemStatus(enum.StrEnum):
 class AqualinkSystem:
     subclasses: ClassVar[dict[str, type[AqualinkSystem]]] = {}
 
-    def __init__(self, aqualink: AqualinkClient, data: Payload):
+    def __init__(self, aqualink: AqualinkClient, data: SystemsResponseElement):
         self.aqualink = aqualink
         self.data = data
         self.devices: dict[str, AqualinkDevice] = {}
@@ -47,11 +46,11 @@ class AqualinkSystem:
 
     @property
     def name(self) -> str:
-        return self.data["name"]
+        return self.data.name
 
     @property
     def serial(self) -> str:
-        return self.data["serial_number"]
+        return self.data.serial_number
 
     @property
     def supported(self) -> bool:
@@ -59,16 +58,15 @@ class AqualinkSystem:
 
     @classmethod
     def from_data(
-        cls, aqualink: AqualinkClient, data: Payload
+        cls, aqualink: AqualinkClient, data: SystemsResponseElement
     ) -> AqualinkSystem:
-        if data["device_type"] not in cls.subclasses:
+        if data.device_type not in cls.subclasses:
             LOGGER.warning(
-                "%s is not a supported system type.", data["device_type"]
+                "%s is not a supported system type.", data.device_type
             )
-            # UnsupportedSystem is defined after this class in this module.
             return UnsupportedSystem(aqualink, data)
 
-        return cls.subclasses[data["device_type"]](aqualink, data)
+        return cls.subclasses[data.device_type](aqualink, data)
 
     async def get_devices(self) -> dict[str, AqualinkDevice]:
         if not self.devices:

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -87,11 +87,8 @@ class ExoSystem(AqualinkSystem):
         root = data.state.reported.equipment["swc_0"]
 
         # Scalar int fields — each becomes a simple state device.
-        _COMPLEX = frozenset(
-            {"aux_devices", "sensors", "filter_pump", "vsp_speed"}
-        )
         for f in dataclasses.fields(root):
-            if f.name in _COMPLEX:
+            if f.name in root.COMPLEX_FIELDS:
                 continue
             devices[f.name] = {"name": f.name, "state": getattr(root, f.name)}
 

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -87,10 +87,8 @@ class ExoSystem(AqualinkSystem):
         root = data.state.reported.equipment["swc_0"]
 
         # Scalar int fields — each becomes a simple state device.
-        for f in dataclasses.fields(root):
-            if f.name in root.COMPLEX_FIELDS:
-                continue
-            devices[f.name] = {"name": f.name, "state": getattr(root, f.name)}
+        for name, state in root.scalar_devices().items():
+            devices[name] = {"name": name, "state": state}
 
         # Aux switches.
         for name, aux in root.aux_devices.items():

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -98,11 +98,12 @@ class ExoSystem(AqualinkSystem):
         for name, sensor in root.sensors.items():
             devices[name] = {"name": name, **dataclasses.asdict(sensor)}
 
-        # Filter pump.
-        devices["filter_pump"] = {
-            "name": "filter_pump",
-            **dataclasses.asdict(root.filter_pump),
-        }
+        # Filter pump (absent on salt-only units).
+        if root.filter_pump is not None:
+            devices["filter_pump"] = {
+                "name": "filter_pump",
+                **dataclasses.asdict(root.filter_pump),
+            }
 
         # Process the heating control attributes.
         if data.state.reported.heating is not None:

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -10,12 +10,14 @@ from iaqualink.exception import (
 )
 from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.exo.device import ExoDevice
+from iaqualink.systems.exo.types import ExoShadowResponse
+from iaqualink.util import json_to_dataclass
 
 if TYPE_CHECKING:
     import httpx
 
     from iaqualink.client import AqualinkClient
-    from iaqualink.typing import Payload
+    from iaqualink.types import DevicesResponseElement
 
 EXO_DEVICES_URL = "https://prod.zodiac-io.com/devices/v1"
 
@@ -25,7 +27,7 @@ LOGGER = logging.getLogger("iaqualink")
 class ExoSystem(AqualinkSystem):
     NAME = "exo"
 
-    def __init__(self, aqualink: AqualinkClient, data: Payload):
+    def __init__(self, aqualink: AqualinkClient, data: DevicesResponseElement):
         super().__init__(aqualink, data)
         self.temp_unit = "C"  # TODO: check if unit can be changed on panel?
 
@@ -75,15 +77,15 @@ class ExoSystem(AqualinkSystem):
         self.status = SystemStatus.ONLINE
 
     def _parse_shadow_response(self, response: httpx.Response) -> None:
-        data = response.json()
+        data = json_to_dataclass(ExoShadowResponse, response.text)
 
         LOGGER.debug("Shadow response: %s", data)
 
         devices = {}
 
-        # Process the chlorinator attributes[equipmen]
+        # Process the chlorinator attributes (equipment).
         # Make the data a bit flatter.
-        root = data["state"]["reported"]["equipment"]["swc_0"]
+        root = data.state.reported.equipment["swc_0"]
         for name, state in root.items():
             attrs = {"name": name}
             if isinstance(state, dict):
@@ -99,19 +101,19 @@ class ExoSystem(AqualinkSystem):
         devices.pop("vr", None)
         devices.pop("version", None)
 
-        # Process the heating control attributes
-        if "heating" in data["state"]["reported"]:
-            name = "heating"
-            attrs = {"name": name}
-            attrs.update(data["state"]["reported"]["heating"])
-            devices.update({name: attrs})
-            # extract heater state into seperate device to maintain homeassistant API
-            name = "heater"
-            attrs = {"name": name}
-            attrs.update(
-                {"state": data["state"]["reported"]["heating"]["state"]}
-            )
-            devices.update({name: attrs})
+        # Process the heating control attributes.
+        if data.state.reported.heating is not None:
+            h = data.state.reported.heating
+            devices["heating"] = {
+                "name": "heating",
+                "state": h.state,
+                "sp": h.sp,
+                "enabled": h.enabled,
+                "sp_min": h.sp_min,
+                "sp_max": h.sp_max,
+            }
+            # Extract heater state into separate device to maintain HA API.
+            devices["heater"] = {"name": "heater", "state": h.state}
 
         LOGGER.debug("devices: %s", devices)
 

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -81,25 +82,32 @@ class ExoSystem(AqualinkSystem):
 
         LOGGER.debug("Shadow response: %s", data)
 
-        devices = {}
+        devices: dict[str, Any] = {}
 
-        # Process the chlorinator attributes (equipment).
-        # Make the data a bit flatter.
         root = data.state.reported.equipment["swc_0"]
-        for name, state in root.items():
-            attrs = {"name": name}
-            if isinstance(state, dict):
-                attrs.update(state)
-            else:
-                attrs.update({"state": state})
-            devices.update({name: attrs})
 
-        # Remove those values, they're not handled properly.
-        devices.pop("boost_time", None)
-        devices.pop("vsp_speed", None)
-        devices.pop("sn", None)
-        devices.pop("vr", None)
-        devices.pop("version", None)
+        # Scalar int fields — each becomes a simple state device.
+        _COMPLEX = frozenset(
+            {"aux_devices", "sensors", "filter_pump", "vsp_speed"}
+        )
+        for f in dataclasses.fields(root):
+            if f.name in _COMPLEX:
+                continue
+            devices[f.name] = {"name": f.name, "state": getattr(root, f.name)}
+
+        # Aux switches.
+        for name, aux in root.aux_devices.items():
+            devices[name] = {"name": name, **dataclasses.asdict(aux)}
+
+        # Chemistry / temperature sensors.
+        for name, sensor in root.sensors.items():
+            devices[name] = {"name": name, **dataclasses.asdict(sensor)}
+
+        # Filter pump.
+        devices["filter_pump"] = {
+            "name": "filter_pump",
+            **dataclasses.asdict(root.filter_pump),
+        }
 
         # Process the heating control attributes.
         if data.state.reported.heating is not None:

--- a/src/iaqualink/systems/exo/types.py
+++ b/src/iaqualink/systems/exo/types.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 from mashumaro.mixins.json import DataClassJSONMixin
 
 
 @dataclass
-class ExoAux(DataClassJSONMixin):
+class ExoAux:
     mode: int
     type: str
     color: int
@@ -13,32 +13,38 @@ class ExoAux(DataClassJSONMixin):
 
 
 @dataclass
-class ExoSensorData(DataClassJSONMixin):
+class ExoSensorData:
     state: int
     value: int
     sensor_type: str
 
 
 @dataclass
-class ExoFilterPumpData(DataClassJSONMixin):
+class ExoFilterPumpData:
     type: int
     state: int
 
 
 @dataclass
-class ExoVspSpeed(DataClassJSONMixin):
+class ExoVspSpeed:
     min: int
     max: int
 
 
 @dataclass
-class ExoSwcDevice(DataClassJSONMixin):
+class ExoSwcDevice:
     """Represents the swc_0 equipment block in the shadow response.
 
     ``__pre_deserialize__`` collects the variable-key ``aux_*`` and ``sns_*``
     entries into typed dicts so that the rest of the fields can be declared
     as fixed dataclass members.
     """
+
+    # Fields handled explicitly by _parse_shadow_response; all other fields
+    # are emitted as scalar state devices. Update when adding structured fields.
+    COMPLEX_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"aux_devices", "sensors", "filter_pump", "vsp_speed"}
+    )
 
     filter_pump: ExoFilterPumpData
     aux_devices: dict[str, ExoAux]
@@ -78,7 +84,7 @@ class ExoSwcDevice(DataClassJSONMixin):
 
 
 @dataclass
-class ExoHeating(DataClassJSONMixin):
+class ExoHeating:
     state: int
     sp: int
     enabled: int
@@ -90,13 +96,13 @@ class ExoHeating(DataClassJSONMixin):
 
 
 @dataclass
-class ExoShadowReported(DataClassJSONMixin):
+class ExoShadowReported:
     equipment: dict[str, ExoSwcDevice]
     heating: ExoHeating | None = None
 
 
 @dataclass
-class ExoShadowState(DataClassJSONMixin):
+class ExoShadowState:
     reported: ExoShadowReported
 
 

--- a/src/iaqualink/systems/exo/types.py
+++ b/src/iaqualink/systems/exo/types.py
@@ -1,3 +1,4 @@
+import dataclasses
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
@@ -67,6 +68,14 @@ class ExoSwcDevice:
     error_state: int
     aux230: int
     vsp_speed: ExoVspSpeed | None = None
+
+    def scalar_devices(self) -> dict[str, int]:
+        """Return all scalar int state fields as {name: value} pairs."""
+        return {
+            f.name: getattr(self, f.name)
+            for f in dataclasses.fields(self)
+            if f.name not in self.COMPLEX_FIELDS
+        }
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:

--- a/src/iaqualink/systems/exo/types.py
+++ b/src/iaqualink/systems/exo/types.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from typing import Any
+
+from mashumaro.mixins.json import DataClassJSONMixin
+
+
+@dataclass
+class ExoHeating(DataClassJSONMixin):
+    state: int
+    sp: int
+    enabled: int
+    sp_min: int
+    sp_max: int
+
+
+@dataclass
+class ExoShadowReported(DataClassJSONMixin):
+    equipment: dict[str, Any]
+    heating: ExoHeating | None = None
+
+
+@dataclass
+class ExoShadowState(DataClassJSONMixin):
+    reported: ExoShadowReported
+
+
+@dataclass
+class ExoShadowResponse(DataClassJSONMixin):
+    state: ExoShadowState

--- a/src/iaqualink/systems/exo/types.py
+++ b/src/iaqualink/systems/exo/types.py
@@ -7,17 +7,17 @@ from mashumaro.mixins.json import DataClassJSONMixin
 
 @dataclass
 class ExoAux:
-    mode: int
-    type: str
-    color: int
-    state: int
+    mode: int | None = None
+    type: str | None = None
+    color: int | None = None
+    state: int | None = None
 
 
 @dataclass
 class ExoSensorData:
     state: int
     value: int
-    sensor_type: str
+    sensor_type: str | None = None
 
 
 @dataclass

--- a/src/iaqualink/systems/exo/types.py
+++ b/src/iaqualink/systems/exo/types.py
@@ -1,6 +1,6 @@
 import dataclasses
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import Any
 
 from mashumaro.mixins.json import DataClassJSONMixin
 
@@ -41,13 +41,6 @@ class ExoSwcDevice:
     as fixed dataclass members.
     """
 
-    # Fields handled explicitly by _parse_shadow_response; all other fields
-    # are emitted as scalar state devices. Update when adding structured fields.
-    COMPLEX_FIELDS: ClassVar[frozenset[str]] = frozenset(
-        {"aux_devices", "sensors", "filter_pump", "vsp_speed"}
-    )
-
-    filter_pump: ExoFilterPumpData
     aux_devices: dict[str, ExoAux]
     sensors: dict[str, ExoSensorData]
     swc: int
@@ -67,14 +60,15 @@ class ExoSwcDevice:
     error_code: int
     error_state: int
     aux230: int
+    filter_pump: ExoFilterPumpData | None = None
     vsp_speed: ExoVspSpeed | None = None
 
     def scalar_devices(self) -> dict[str, int]:
-        """Return all scalar int state fields as {name: value} pairs."""
+        """Return scalar int state fields as {name: value} pairs."""
         return {
-            f.name: getattr(self, f.name)
+            f.name: v
             for f in dataclasses.fields(self)
-            if f.name not in self.COMPLEX_FIELDS
+            if isinstance(v := getattr(self, f.name), int)
         }
 
     @classmethod

--- a/src/iaqualink/systems/exo/types.py
+++ b/src/iaqualink/systems/exo/types.py
@@ -5,17 +5,93 @@ from mashumaro.mixins.json import DataClassJSONMixin
 
 
 @dataclass
+class ExoAux(DataClassJSONMixin):
+    mode: int
+    type: str
+    color: int
+    state: int
+
+
+@dataclass
+class ExoSensorData(DataClassJSONMixin):
+    state: int
+    value: int
+    sensor_type: str
+
+
+@dataclass
+class ExoFilterPumpData(DataClassJSONMixin):
+    type: int
+    state: int
+
+
+@dataclass
+class ExoVspSpeed(DataClassJSONMixin):
+    min: int
+    max: int
+
+
+@dataclass
+class ExoSwcDevice(DataClassJSONMixin):
+    """Represents the swc_0 equipment block in the shadow response.
+
+    ``__pre_deserialize__`` collects the variable-key ``aux_*`` and ``sns_*``
+    entries into typed dicts so that the rest of the fields can be declared
+    as fixed dataclass members.
+    """
+
+    filter_pump: ExoFilterPumpData
+    aux_devices: dict[str, ExoAux]
+    sensors: dict[str, ExoSensorData]
+    swc: int
+    low: int
+    vsp: int
+    amp: int
+    temp: int
+    lang: int
+    ph_sp: int
+    boost: int
+    orp_sp: int
+    ph_only: int
+    swc_low: int
+    exo_state: int
+    dual_link: int
+    production: int
+    error_code: int
+    error_state: int
+    aux230: int
+    vsp_speed: ExoVspSpeed | None = None
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
+        d = dict(d)
+        aux_devices: dict[str, Any] = {}
+        sensors: dict[str, Any] = {}
+        for key in list(d):
+            if key.startswith("aux_"):
+                aux_devices[key] = d.pop(key)
+            elif key.startswith("sns_"):
+                sensors[key] = d.pop(key)
+        d["aux_devices"] = aux_devices
+        d["sensors"] = sensors
+        return d
+
+
+@dataclass
 class ExoHeating(DataClassJSONMixin):
     state: int
     sp: int
     enabled: int
     sp_min: int
     sp_max: int
+    vsp_rpm_list: dict[str, int] | None = None
+    vsp_rpm_index: int | None = None
+    priority_enabled: int | None = None
 
 
 @dataclass
 class ExoShadowReported(DataClassJSONMixin):
-    equipment: dict[str, Any]
+    equipment: dict[str, ExoSwcDevice]
     heating: ExoHeating | None = None
 
 

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 from typing import TYPE_CHECKING
 
@@ -121,21 +122,23 @@ class IaquaSystem(AqualinkSystem):
 
         LOGGER.debug("Home response: %s", data)
 
-        if data.home_screen[0]["status"] == "Offline":
+        first = dataclasses.asdict(data.home_screen[0])
+        if first.get("status") == "Offline":
             LOGGER.warning(f"Status for system {self.serial} is Offline.")
             raise AqualinkSystemOfflineException
 
-        if data.home_screen[2]["system_type"] == "":
+        if dataclasses.asdict(data.home_screen[2]).get("system_type") == "":
             LOGGER.debug("Skipping home screen update with empty system_type.")
             return
 
-        self.temp_unit = data.home_screen[3]["temp_scale"]
+        self.temp_unit = dataclasses.asdict(data.home_screen[3])["temp_scale"]
 
         # Make the data a bit flatter.
         devices = {}
         for x in data.home_screen[4:]:
-            name = next(iter(x.keys()))
-            state = next(iter(x.values()))
+            d = dataclasses.asdict(x)
+            name = next(iter(d))
+            state = d[name]
             attrs = {"name": name, "state": state}
             devices.update({name: attrs})
 

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -14,6 +14,7 @@ from iaqualink.exception import (
 from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import IaquaDevice
 from iaqualink.systems.iaqua.types import (
+    HomeScreenStatus,
     IaquaDevicesResponse,
     IaquaHomeResponse,
 )
@@ -157,7 +158,8 @@ class IaquaSystem(AqualinkSystem):
 
         LOGGER.debug("Devices response: %s", data)
 
-        if data.devices_screen[0]["status"] == "Offline":
+        first = data.devices_screen[0]
+        if isinstance(first, HomeScreenStatus) and first.status == "Offline":
             LOGGER.warning(f"Status for system {self.serial} is Offline.")
             raise AqualinkSystemOfflineException
 
@@ -172,10 +174,14 @@ class IaquaSystem(AqualinkSystem):
         # Make the data a bit flatter.
         devices = {}
         for x in data.devices_screen[3:]:
-            aux = next(iter(x.keys()))
-            attrs = {"aux": aux.replace("aux_", ""), "name": aux}
-            for y in next(iter(x.values())):
-                attrs.update(y)
+            if not isinstance(x, dict):
+                continue
+            aux = next(iter(x))
+            attrs = {
+                "aux": aux.replace("aux_", ""),
+                "name": aux,
+                **dataclasses.asdict(x[aux]),
+            }
             devices.update({aux: attrs})
 
         for k, v in devices.items():

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -14,6 +14,7 @@ from iaqualink.exception import (
 from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import IaquaDevice
 from iaqualink.systems.iaqua.types import (
+    DevicesScreenAux,
     HomeScreenStatus,
     HomeScreenSystemType,
     HomeScreenTempScale,
@@ -172,27 +173,23 @@ class IaquaSystem(AqualinkSystem):
             raise AqualinkSystemOfflineException
 
         for x in data.devices_screen[3:]:
-            if not isinstance(x, dict):
+            if not isinstance(x, DevicesScreenAux):
                 continue
-            for attrs in x.values():
-                if attrs.state == "NaN":
-                    LOGGER.debug(
-                        "Skipping devices screen update with NaN state."
-                    )
-                    return
+            if x.attrs.state == "NaN":
+                LOGGER.debug("Skipping devices screen update with NaN state.")
+                return
 
         # Make the data a bit flatter.
         devices = {}
         for x in data.devices_screen[3:]:
-            if not isinstance(x, dict):
+            if not isinstance(x, DevicesScreenAux):
                 continue
-            aux = next(iter(x))
             attrs = {
-                "aux": aux.replace("aux_", ""),
-                "name": aux,
-                **dataclasses.asdict(x[aux]),
+                "aux": x.name.replace("aux_", ""),
+                "name": x.name,
+                **dataclasses.asdict(x.attrs),
             }
-            devices.update({aux: attrs})
+            devices.update({x.name: attrs})
 
         for k, v in devices.items():
             if k in self.devices:

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -163,9 +163,11 @@ class IaquaSystem(AqualinkSystem):
             LOGGER.warning(f"Status for system {self.serial} is Offline.")
             raise AqualinkSystemOfflineException
 
-        for x in data["devices_screen"][3:]:
-            for attr in next(iter(x.values())):
-                if attr.get("state") == "NaN":
+        for x in data.devices_screen[3:]:
+            if not isinstance(x, dict):
+                continue
+            for attrs in x.values():
+                if attrs.state == "NaN":
                     LOGGER.debug(
                         "Skipping devices screen update with NaN state."
                     )

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -15,6 +15,8 @@ from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import IaquaDevice
 from iaqualink.systems.iaqua.types import (
     HomeScreenStatus,
+    HomeScreenSystemType,
+    HomeScreenTempScale,
     IaquaDevicesResponse,
     IaquaHomeResponse,
 )
@@ -123,23 +125,29 @@ class IaquaSystem(AqualinkSystem):
 
         LOGGER.debug("Home response: %s", data)
 
-        first = dataclasses.asdict(data.home_screen[0])
-        if first.get("status") == "Offline":
+        first = data.home_screen[0]
+        if isinstance(first, HomeScreenStatus) and first.status == "Offline":
             LOGGER.warning(f"Status for system {self.serial} is Offline.")
             raise AqualinkSystemOfflineException
 
-        if dataclasses.asdict(data.home_screen[2]).get("system_type") == "":
+        second = data.home_screen[2]
+        if (
+            isinstance(second, HomeScreenSystemType)
+            and second.system_type == ""
+        ):
             LOGGER.debug("Skipping home screen update with empty system_type.")
             return
 
-        self.temp_unit = dataclasses.asdict(data.home_screen[3])["temp_scale"]
+        third = data.home_screen[3]
+        if isinstance(third, HomeScreenTempScale):
+            self.temp_unit = third.temp_scale
 
         # Make the data a bit flatter.
         devices = {}
         for x in data.home_screen[4:]:
-            d = dataclasses.asdict(x)
-            name = next(iter(d))
-            state = d[name]
+            f = dataclasses.fields(x)[0]
+            name = f.name
+            state = getattr(x, name)
             attrs = {"name": name, "state": state}
             devices.update({name: attrs})
 

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -111,6 +111,10 @@ class IaquaSystem(AqualinkSystem):
         self.status = SystemStatus.ONLINE
 
     def _parse_home_response(self, response: httpx.Response) -> None:
+        from iaqualink.types import HomeResponse
+        from iaqualink.util import json_to_dataclass
+
+        _data = json_to_dataclass(HomeResponse, response.text)
         data = response.json()
 
         LOGGER.debug("Home response: %s", data)

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -12,11 +12,17 @@ from iaqualink.exception import (
 )
 from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import IaquaDevice
+from iaqualink.systems.iaqua.types import (
+    IaquaDevicesResponse,
+    IaquaHomeResponse,
+)
+from iaqualink.util import json_to_dataclass
 
 if TYPE_CHECKING:
     import httpx
 
     from iaqualink.client import AqualinkClient
+    from iaqualink.types import DevicesResponseElement
     from iaqualink.typing import Payload
 
 IAQUA_SESSION_URL = "https://r-api.iaqualink.net/v2/mobile/session.json"
@@ -40,7 +46,7 @@ LOGGER = logging.getLogger("iaqualink")
 class IaquaSystem(AqualinkSystem):
     NAME = "iaqua"
 
-    def __init__(self, aqualink: AqualinkClient, data: Payload):
+    def __init__(self, aqualink: AqualinkClient, data: DevicesResponseElement):
         super().__init__(aqualink, data)
 
         self.temp_unit: str = ""
@@ -111,27 +117,23 @@ class IaquaSystem(AqualinkSystem):
         self.status = SystemStatus.ONLINE
 
     def _parse_home_response(self, response: httpx.Response) -> None:
-        from iaqualink.types import HomeResponse
-        from iaqualink.util import json_to_dataclass
-
-        _data = json_to_dataclass(HomeResponse, response.text)
-        data = response.json()
+        data = json_to_dataclass(IaquaHomeResponse, response.text)
 
         LOGGER.debug("Home response: %s", data)
 
-        if data["home_screen"][0]["status"] == "Offline":
-            LOGGER.warning("Status for system %s is Offline.", self.serial)
+        if data.home_screen[0]["status"] == "Offline":
+            LOGGER.warning(f"Status for system {self.serial} is Offline.")
             raise AqualinkSystemOfflineException
 
-        if data["home_screen"][2]["system_type"] == "":
+        if data.home_screen[2]["system_type"] == "":
             LOGGER.debug("Skipping home screen update with empty system_type.")
             return
 
-        self.temp_unit = data["home_screen"][3]["temp_scale"]
+        self.temp_unit = data.home_screen[3]["temp_scale"]
 
         # Make the data a bit flatter.
         devices = {}
-        for x in data["home_screen"][4:]:
+        for x in data.home_screen[4:]:
             name = next(iter(x.keys()))
             state = next(iter(x.values()))
             attrs = {"name": name, "state": state}
@@ -148,12 +150,12 @@ class IaquaSystem(AqualinkSystem):
                     LOGGER.debug("Device found was ignored: %s", e)
 
     def _parse_devices_response(self, response: httpx.Response) -> None:
-        data = response.json()
+        data = json_to_dataclass(IaquaDevicesResponse, response.text)
 
         LOGGER.debug("Devices response: %s", data)
 
-        if data["devices_screen"][0]["status"] == "Offline":
-            LOGGER.warning("Status for system %s is Offline.", self.serial)
+        if data.devices_screen[0]["status"] == "Offline":
+            LOGGER.warning(f"Status for system {self.serial} is Offline.")
             raise AqualinkSystemOfflineException
 
         for x in data["devices_screen"][3:]:
@@ -166,7 +168,7 @@ class IaquaSystem(AqualinkSystem):
 
         # Make the data a bit flatter.
         devices = {}
-        for x in data["devices_screen"][3:]:
+        for x in data.devices_screen[3:]:
             aux = next(iter(x.keys()))
             attrs = {"aux": aux.replace("aux_", ""), "name": aux}
             for y in next(iter(x.values())):

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -15,6 +15,7 @@ from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import IaquaDevice
 from iaqualink.systems.iaqua.types import (
     DevicesScreenAux,
+    HomeScreenResponse,
     HomeScreenStatus,
     HomeScreenSystemType,
     HomeScreenTempScale,
@@ -46,6 +47,13 @@ IAQUA_COMMAND_SET_SPA_PUMP = "set_spa_pump"
 IAQUA_COMMAND_SET_TEMPS = "set_temps"
 
 LOGGER = logging.getLogger("iaqualink")
+
+_HOME_SCREEN_HEADER_TYPES = (
+    HomeScreenResponse,
+    HomeScreenStatus,
+    HomeScreenSystemType,
+    HomeScreenTempScale,
+)
 
 
 class IaquaSystem(AqualinkSystem):
@@ -126,26 +134,38 @@ class IaquaSystem(AqualinkSystem):
 
         LOGGER.debug("Home response: %s", data)
 
-        first = data.home_screen[0]
-        if isinstance(first, HomeScreenStatus) and first.status == "Offline":
+        status = next(
+            (x for x in data.home_screen if isinstance(x, HomeScreenStatus)),
+            None,
+        )
+        if status is not None and status.status == "Offline":
             LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
-        second = data.home_screen[2]
-        if (
-            isinstance(second, HomeScreenSystemType)
-            and second.system_type == ""
-        ):
+        system_type = next(
+            (
+                x
+                for x in data.home_screen
+                if isinstance(x, HomeScreenSystemType)
+            ),
+            None,
+        )
+        if system_type is not None and system_type.system_type == "":
             LOGGER.debug("Skipping home screen update with empty system_type.")
             return
 
-        third = data.home_screen[3]
-        if isinstance(third, HomeScreenTempScale):
-            self.temp_unit = third.temp_scale
+        temp_scale = next(
+            (x for x in data.home_screen if isinstance(x, HomeScreenTempScale)),
+            None,
+        )
+        if temp_scale is not None:
+            self.temp_unit = temp_scale.temp_scale
 
         # Make the data a bit flatter.
         devices = {}
-        for x in data.home_screen[4:]:
+        for x in data.home_screen:
+            if isinstance(x, _HOME_SCREEN_HEADER_TYPES):
+                continue
             f = dataclasses.fields(x)[0]
             name = f.name
             state = getattr(x, name)

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -128,7 +128,7 @@ class IaquaSystem(AqualinkSystem):
 
         first = data.home_screen[0]
         if isinstance(first, HomeScreenStatus) and first.status == "Offline":
-            LOGGER.warning(f"Status for system {self.serial} is Offline.")
+            LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
         second = data.home_screen[2]
@@ -169,7 +169,7 @@ class IaquaSystem(AqualinkSystem):
 
         first = data.devices_screen[0]
         if isinstance(first, HomeScreenStatus) and first.status == "Offline":
-            LOGGER.warning(f"Status for system {self.serial} is Offline.")
+            LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
         for x in data.devices_screen[3:]:

--- a/src/iaqualink/systems/iaqua/types.py
+++ b/src/iaqualink/systems/iaqua/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Union
+from typing import Any
 
 from mashumaro import field_options
 from mashumaro.mixins.json import DataClassJSONMixin
@@ -22,26 +22,26 @@ class IaquaDevicesResponse(DataClassJSONMixin):
 
 
 @dataclass
-class HeatpumpInfo(DataClassJSONMixin):
-    isheatpump_present: Optional[bool] = field(
+class HeatpumpInfo:
+    isheatpump_present: bool | None = field(
         default=False, metadata=field_options(alias="isheatpumpPresent")
     )
-    heatpumpstatus: Optional[str] = field(
+    heatpumpstatus: str | None = field(
         default=None, metadata=field_options(alias="heatpumpstatus")
     )
-    is_chill_available: Optional[bool] = field(
+    is_chill_available: bool | None = field(
         default=False, metadata=field_options(alias="isChillAvailable")
     )
-    heatpumpmode: Optional[str] = field(
+    heatpumpmode: str | None = field(
         default=None, metadata=field_options(alias="heatpumpmode")
     )
-    heatpumptype: Optional[str] = field(
+    heatpumptype: str | None = field(
         default=None, metadata=field_options(alias="heatpumptype")
     )
 
 
 @dataclass
-class IclCustomColorInfo(DataClassJSONMixin):
+class IclCustomColorInfo:
     zone_id: int = field(metadata=field_options(alias="zoneId"))
     red_val: int
     green_val: int
@@ -50,159 +50,159 @@ class IclCustomColorInfo(DataClassJSONMixin):
 
 
 @dataclass
-class SwcInfo(DataClassJSONMixin):
+class SwcInfo:
     isswc_present: bool = field(metadata=field_options(alias="isswcPresent"))
-    swc_pool_value: Optional[str] = field(
+    swc_pool_value: str | None = field(
         default=None, metadata=field_options(alias="swcPoolValue")
     )
-    swc_pool_status: Optional[str] = field(
+    swc_pool_status: str | None = field(
         default=None, metadata=field_options(alias="swcPoolStatus")
     )
-    swc_spa_value: Optional[str] = field(
+    swc_spa_value: str | None = field(
         default=None, metadata=field_options(alias="swcSpaValue")
     )
-    swc_spa_status: Optional[str] = field(
+    swc_spa_status: str | None = field(
         default=None, metadata=field_options(alias="swcSpaStatus")
     )
 
 
 @dataclass
-class HomeScreenStatus(DataClassJSONMixin):
+class HomeScreenStatus:
     status: str
 
 
 @dataclass
-class HomeScreenResponse(DataClassJSONMixin):
+class HomeScreenResponse:
     response: str
 
 
 @dataclass
-class HomeScreenSystemType(DataClassJSONMixin):
+class HomeScreenSystemType:
     system_type: str
 
 
 @dataclass
-class HomeScreenTempScale(DataClassJSONMixin):
+class HomeScreenTempScale:
     temp_scale: str
 
 
 @dataclass
-class HomeScreenSpaTemp(DataClassJSONMixin):
+class HomeScreenSpaTemp:
     spa_temp: str
 
 
 @dataclass
-class HomeScreenPoolTemp(DataClassJSONMixin):
+class HomeScreenPoolTemp:
     pool_temp: str
 
 
 @dataclass
-class HomeScreenAirTemp(DataClassJSONMixin):
+class HomeScreenAirTemp:
     air_temp: str
 
 
 @dataclass
-class HomeScreenSetPoint(DataClassJSONMixin):
+class HomeScreenSetPoint:
     spa_set_point: str
 
 
 @dataclass
-class HomeScreenPoolSetPoint(DataClassJSONMixin):
+class HomeScreenPoolSetPoint:
     pool_set_point: str
 
 
 @dataclass
-class HomeScreenCoverPool(DataClassJSONMixin):
+class HomeScreenCoverPool:
     cover_pool: str
 
 
 @dataclass
-class HomeScreenFreezeProtection(DataClassJSONMixin):
+class HomeScreenFreezeProtection:
     freeze_protection: str
 
 
 @dataclass
-class HomeScreenSpaPump(DataClassJSONMixin):
+class HomeScreenSpaPump:
     spa_pump: str
 
 
 @dataclass
-class HomeScreenPoolPump(DataClassJSONMixin):
+class HomeScreenPoolPump:
     pool_pump: str
 
 
 @dataclass
-class HomeScreenSpaHeater(DataClassJSONMixin):
+class HomeScreenSpaHeater:
     spa_heater: str
 
 
 @dataclass
-class HomeScreenPoolHeater(DataClassJSONMixin):
+class HomeScreenPoolHeater:
     pool_heater: str
 
 
 @dataclass
-class HomeScreenSolarHeater(DataClassJSONMixin):
+class HomeScreenSolarHeater:
     solar_heater: str
 
 
 @dataclass
-class HomeScreenSpaSalinity(DataClassJSONMixin):
+class HomeScreenSpaSalinity:
     spa_salinity: str
 
 
 @dataclass
-class HomeScreenPoolSalinity(DataClassJSONMixin):
+class HomeScreenPoolSalinity:
     pool_salinity: str
 
 
 @dataclass
-class HomeScreenOrp(DataClassJSONMixin):
+class HomeScreenOrp:
     orp: str
 
 
 @dataclass
-class HomeScreenPh(DataClassJSONMixin):
+class HomeScreenPh:
     ph: str
 
 
 @dataclass
-class HomeScreenIsIclPresent(DataClassJSONMixin):
+class HomeScreenIsIclPresent:
     is_icl_present: str
 
 
 @dataclass
-class HomeScreenIclCustomColor(DataClassJSONMixin):
-    icl_custom_color_info: List[IclCustomColorInfo]
+class HomeScreenIclCustomColor:
+    icl_custom_color_info: list[IclCustomColorInfo]
 
 
 @dataclass
-class HomeScreenHeatpumpInfo(DataClassJSONMixin):
+class HomeScreenHeatpumpInfo:
     heatpump_info: HeatpumpInfo
 
 
 @dataclass
-class HomeScreenPoolChillSetPoint(DataClassJSONMixin):
+class HomeScreenPoolChillSetPoint:
     pool_chill_set_point: str
 
 
 @dataclass
-class HomeScreenSwcInfo(DataClassJSONMixin):
+class HomeScreenSwcInfo:
     swc_info: SwcInfo
 
 
 @dataclass
-class HomeScreenRelayCount(DataClassJSONMixin):
+class HomeScreenRelayCount:
     relay_count: str
 
 
 @dataclass
-class DevicesScreenGroup(DataClassJSONMixin):
+class DevicesScreenGroup:
     group: str
 
 
 @dataclass
-class DevicesScreenAuxAttrs(DataClassJSONMixin):
+class DevicesScreenAuxAttrs:
     """Aux device attributes, deserialized from a list of single-key dicts.
 
     The API sends: [{"state": "0"}, {"label": "X"}, {"icon": "..."}, ...]
@@ -226,46 +226,41 @@ class DevicesScreenAuxAttrs(DataClassJSONMixin):
         return d
 
 
-DevicesScreenItem = Union[
-    HomeScreenStatus,
-    HomeScreenResponse,
-    DevicesScreenGroup,
-    dict[str, DevicesScreenAuxAttrs],
-]
+DevicesScreenItem = (
+    HomeScreenStatus
+    | HomeScreenResponse
+    | DevicesScreenGroup
+    | dict[str, DevicesScreenAuxAttrs]
+)
 
-
-HomeScreenItem = Union[
-    HomeScreenAirTemp,
-    HomeScreenCoverPool,
-    HomeScreenFreezeProtection,
-    HomeScreenHeatpumpInfo,
-    HomeScreenIclCustomColor,
-    HomeScreenIsIclPresent,
-    HomeScreenOrp,
-    HomeScreenPh,
-    HomeScreenPoolChillSetPoint,
-    HomeScreenPoolHeater,
-    HomeScreenPoolPump,
-    HomeScreenPoolSalinity,
-    HomeScreenPoolSetPoint,
-    HomeScreenPoolTemp,
-    HomeScreenRelayCount,
-    HomeScreenResponse,
-    HomeScreenSetPoint,
-    HomeScreenSolarHeater,
-    HomeScreenSpaHeater,
-    HomeScreenSpaPump,
-    HomeScreenSpaSalinity,
-    HomeScreenSpaTemp,
-    HomeScreenStatus,
-    HomeScreenSwcInfo,
-    HomeScreenSystemType,
-    HomeScreenTempScale,
-]
-
-
-@dataclass
-class HomeResponse(DataClassJSONMixin):
-    message: str
-    serial: str
-    home_screen: List[HomeScreenItem]
+# mashumaro resolves union variants in declaration order. The ordering below
+# is intentional: more specific single-field types are tried before broader
+# ones. Do not reorder without verifying against real API responses.
+HomeScreenItem = (
+    HomeScreenAirTemp
+    | HomeScreenCoverPool
+    | HomeScreenFreezeProtection
+    | HomeScreenHeatpumpInfo
+    | HomeScreenIclCustomColor
+    | HomeScreenIsIclPresent
+    | HomeScreenOrp
+    | HomeScreenPh
+    | HomeScreenPoolChillSetPoint
+    | HomeScreenPoolHeater
+    | HomeScreenPoolPump
+    | HomeScreenPoolSalinity
+    | HomeScreenPoolSetPoint
+    | HomeScreenPoolTemp
+    | HomeScreenRelayCount
+    | HomeScreenResponse
+    | HomeScreenSetPoint
+    | HomeScreenSolarHeater
+    | HomeScreenSpaHeater
+    | HomeScreenSpaPump
+    | HomeScreenSpaSalinity
+    | HomeScreenSpaTemp
+    | HomeScreenStatus
+    | HomeScreenSwcInfo
+    | HomeScreenSystemType
+    | HomeScreenTempScale
+)

--- a/src/iaqualink/systems/iaqua/types.py
+++ b/src/iaqualink/systems/iaqua/types.py
@@ -58,6 +58,12 @@ class SwcInfo(DataClassJSONMixin):
     swc_pool_status: Optional[str] = field(
         default=None, metadata=field_options(alias="swcPoolStatus")
     )
+    swc_spa_value: Optional[str] = field(
+        default=None, metadata=field_options(alias="swcSpaValue")
+    )
+    swc_spa_status: Optional[str] = field(
+        default=None, metadata=field_options(alias="swcSpaStatus")
+    )
 
 
 @dataclass

--- a/src/iaqualink/systems/iaqua/types.py
+++ b/src/iaqualink/systems/iaqua/types.py
@@ -7,7 +7,7 @@ from mashumaro.mixins.json import DataClassJSONMixin
 
 @dataclass
 class IaquaHomeResponse(DataClassJSONMixin):
-    home_screen: list[dict[str, Any]]
+    home_screen: list["HomeScreenItem"]
     message: str = ""
     serial: str = ""
 
@@ -190,37 +190,38 @@ class HomeScreenRelayCount(DataClassJSONMixin):
     relay_count: str
 
 
+HomeScreenItem = Union[
+    HomeScreenAirTemp,
+    HomeScreenCoverPool,
+    HomeScreenFreezeProtection,
+    HomeScreenHeatpumpInfo,
+    HomeScreenIclCustomColor,
+    HomeScreenIsIclPresent,
+    HomeScreenOrp,
+    HomeScreenPh,
+    HomeScreenPoolChillSetPoint,
+    HomeScreenPoolHeater,
+    HomeScreenPoolPump,
+    HomeScreenPoolSalinity,
+    HomeScreenPoolSetPoint,
+    HomeScreenPoolTemp,
+    HomeScreenRelayCount,
+    HomeScreenResponse,
+    HomeScreenSetPoint,
+    HomeScreenSolarHeater,
+    HomeScreenSpaHeater,
+    HomeScreenSpaPump,
+    HomeScreenSpaSalinity,
+    HomeScreenSpaTemp,
+    HomeScreenStatus,
+    HomeScreenSwcInfo,
+    HomeScreenSystemType,
+    HomeScreenTempScale,
+]
+
+
 @dataclass
 class HomeResponse(DataClassJSONMixin):
     message: str
     serial: str
-    home_screen: List[
-        Union[
-            HomeScreenAirTemp
-            | HomeScreenCoverPool
-            | HomeScreenFreezeProtection
-            | HomeScreenHeatpumpInfo
-            | HomeScreenIclCustomColor
-            | HomeScreenIsIclPresent
-            | HomeScreenOrp
-            | HomeScreenPh
-            | HomeScreenPoolChillSetPoint
-            | HomeScreenPoolHeater
-            | HomeScreenPoolPump
-            | HomeScreenPoolSalinity
-            | HomeScreenPoolSetPoint
-            | HomeScreenPoolTemp
-            | HomeScreenRelayCount
-            | HomeScreenResponse
-            | HomeScreenSetPoint
-            | HomeScreenSolarHeater
-            | HomeScreenSpaHeater
-            | HomeScreenSpaPump
-            | HomeScreenSpaSalinity
-            | HomeScreenSpaTemp
-            | HomeScreenStatus
-            | HomeScreenSwcInfo
-            | HomeScreenSystemType
-            | HomeScreenTempScale
-        ]
-    ]
+    home_screen: List[HomeScreenItem]

--- a/src/iaqualink/systems/iaqua/types.py
+++ b/src/iaqualink/systems/iaqua/types.py
@@ -18,7 +18,7 @@ class IaquaDevicesResponse(DataClassJSONMixin):
     message: str = ""
 
 
-### Home Screen Response
+# Home Screen Response
 
 
 @dataclass
@@ -226,11 +226,30 @@ class DevicesScreenAuxAttrs:
         return d
 
 
+@dataclass
+class DevicesScreenAux:
+    """Single aux entry from devices_screen: {"aux_N": [attrs...]}.
+
+    __pre_deserialize__ extracts the aux name and passes attrs to
+    DevicesScreenAuxAttrs for further flattening.
+    """
+
+    name: str
+    attrs: DevicesScreenAuxAttrs
+
+    @classmethod
+    def __pre_deserialize__(cls, d: Any) -> Any:
+        if isinstance(d, dict) and len(d) == 1:
+            name, attrs = next(iter(d.items()))
+            return {"name": name, "attrs": attrs}
+        return d
+
+
 DevicesScreenItem = (
     HomeScreenStatus
     | HomeScreenResponse
     | DevicesScreenGroup
-    | dict[str, DevicesScreenAuxAttrs]
+    | DevicesScreenAux
 )
 
 # mashumaro resolves union variants in declaration order. The ordering below

--- a/src/iaqualink/systems/iaqua/types.py
+++ b/src/iaqualink/systems/iaqua/types.py
@@ -1,0 +1,226 @@
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Union
+
+from mashumaro import field_options
+from mashumaro.mixins.json import DataClassJSONMixin
+
+
+@dataclass
+class IaquaHomeResponse(DataClassJSONMixin):
+    home_screen: list[dict[str, Any]]
+    message: str = ""
+    serial: str = ""
+
+
+@dataclass
+class IaquaDevicesResponse(DataClassJSONMixin):
+    devices_screen: list[dict[str, Any]]
+    message: str = ""
+
+
+### Home Screen Response
+
+
+@dataclass
+class HeatpumpInfo(DataClassJSONMixin):
+    isheatpump_present: Optional[bool] = field(
+        default=False, metadata=field_options(alias="isheatpumpPresent")
+    )
+    heatpumpstatus: Optional[str] = field(
+        default=None, metadata=field_options(alias="heatpumpstatus")
+    )
+    is_chill_available: Optional[bool] = field(
+        default=False, metadata=field_options(alias="isChillAvailable")
+    )
+    heatpumpmode: Optional[str] = field(
+        default=None, metadata=field_options(alias="heatpumpmode")
+    )
+    heatpumptype: Optional[str] = field(
+        default=None, metadata=field_options(alias="heatpumptype")
+    )
+
+
+@dataclass
+class IclCustomColorInfo(DataClassJSONMixin):
+    zone_id: int = field(metadata=field_options(alias="zoneId"))
+    red_val: int
+    green_val: int
+    blue_val: int
+    white_val: int
+
+
+@dataclass
+class SwcInfo(DataClassJSONMixin):
+    isswc_present: bool = field(metadata=field_options(alias="isswcPresent"))
+    swc_pool_value: Optional[str] = field(
+        default=None, metadata=field_options(alias="swcPoolValue")
+    )
+    swc_pool_status: Optional[str] = field(
+        default=None, metadata=field_options(alias="swcPoolStatus")
+    )
+
+
+@dataclass
+class HomeScreenStatus(DataClassJSONMixin):
+    status: str
+
+
+@dataclass
+class HomeScreenResponse(DataClassJSONMixin):
+    response: str
+
+
+@dataclass
+class HomeScreenSystemType(DataClassJSONMixin):
+    system_type: str
+
+
+@dataclass
+class HomeScreenTempScale(DataClassJSONMixin):
+    temp_scale: str
+
+
+@dataclass
+class HomeScreenSpaTemp(DataClassJSONMixin):
+    spa_temp: str
+
+
+@dataclass
+class HomeScreenPoolTemp(DataClassJSONMixin):
+    pool_temp: str
+
+
+@dataclass
+class HomeScreenAirTemp(DataClassJSONMixin):
+    air_temp: str
+
+
+@dataclass
+class HomeScreenSetPoint(DataClassJSONMixin):
+    spa_set_point: str
+
+
+@dataclass
+class HomeScreenPoolSetPoint(DataClassJSONMixin):
+    pool_set_point: str
+
+
+@dataclass
+class HomeScreenCoverPool(DataClassJSONMixin):
+    cover_pool: str
+
+
+@dataclass
+class HomeScreenFreezeProtection(DataClassJSONMixin):
+    freeze_protection: str
+
+
+@dataclass
+class HomeScreenSpaPump(DataClassJSONMixin):
+    spa_pump: str
+
+
+@dataclass
+class HomeScreenPoolPump(DataClassJSONMixin):
+    pool_pump: str
+
+
+@dataclass
+class HomeScreenSpaHeater(DataClassJSONMixin):
+    spa_heater: str
+
+
+@dataclass
+class HomeScreenPoolHeater(DataClassJSONMixin):
+    pool_heater: str
+
+
+@dataclass
+class HomeScreenSolarHeater(DataClassJSONMixin):
+    solar_heater: str
+
+
+@dataclass
+class HomeScreenSpaSalinity(DataClassJSONMixin):
+    spa_salinity: str
+
+
+@dataclass
+class HomeScreenPoolSalinity(DataClassJSONMixin):
+    pool_salinity: str
+
+
+@dataclass
+class HomeScreenOrp(DataClassJSONMixin):
+    orp: str
+
+
+@dataclass
+class HomeScreenPh(DataClassJSONMixin):
+    ph: str
+
+
+@dataclass
+class HomeScreenIsIclPresent(DataClassJSONMixin):
+    is_icl_present: str
+
+
+@dataclass
+class HomeScreenIclCustomColor(DataClassJSONMixin):
+    icl_custom_color_info: List[IclCustomColorInfo]
+
+
+@dataclass
+class HomeScreenHeatpumpInfo(DataClassJSONMixin):
+    heatpump_info: HeatpumpInfo
+
+
+@dataclass
+class HomeScreenPoolChillSetPoint(DataClassJSONMixin):
+    pool_chill_set_point: str
+
+
+@dataclass
+class HomeScreenSwcInfo(DataClassJSONMixin):
+    swc_info: SwcInfo
+
+
+@dataclass
+class HomeScreenRelayCount(DataClassJSONMixin):
+    relay_count: str
+
+
+@dataclass
+class HomeResponse(DataClassJSONMixin):
+    message: str
+    serial: str
+    home_screen: List[
+        Union[
+            HomeScreenAirTemp
+            | HomeScreenCoverPool
+            | HomeScreenFreezeProtection
+            | HomeScreenHeatpumpInfo
+            | HomeScreenIclCustomColor
+            | HomeScreenIsIclPresent
+            | HomeScreenOrp
+            | HomeScreenPh
+            | HomeScreenPoolChillSetPoint
+            | HomeScreenPoolHeater
+            | HomeScreenPoolPump
+            | HomeScreenPoolSalinity
+            | HomeScreenPoolSetPoint
+            | HomeScreenPoolTemp
+            | HomeScreenRelayCount
+            | HomeScreenResponse
+            | HomeScreenSetPoint
+            | HomeScreenSolarHeater
+            | HomeScreenSpaHeater
+            | HomeScreenSpaPump
+            | HomeScreenSpaSalinity
+            | HomeScreenSpaTemp
+            | HomeScreenStatus
+            | HomeScreenSwcInfo
+            | HomeScreenSystemType
+            | HomeScreenTempScale
+        ]
+    ]

--- a/src/iaqualink/systems/iaqua/types.py
+++ b/src/iaqualink/systems/iaqua/types.py
@@ -14,7 +14,7 @@ class IaquaHomeResponse(DataClassJSONMixin):
 
 @dataclass
 class IaquaDevicesResponse(DataClassJSONMixin):
-    devices_screen: list[dict[str, Any]]
+    devices_screen: list["DevicesScreenItem"]
     message: str = ""
 
 
@@ -188,6 +188,44 @@ class HomeScreenSwcInfo(DataClassJSONMixin):
 @dataclass
 class HomeScreenRelayCount(DataClassJSONMixin):
     relay_count: str
+
+
+@dataclass
+class DevicesScreenGroup(DataClassJSONMixin):
+    group: str
+
+
+@dataclass
+class DevicesScreenAuxAttrs(DataClassJSONMixin):
+    """Aux device attributes, deserialized from a list of single-key dicts.
+
+    The API sends: [{"state": "0"}, {"label": "X"}, {"icon": "..."}, ...]
+    __pre_deserialize__ flattens that into a plain dict before mashumaro
+    maps it onto the dataclass fields.
+    """
+
+    state: str
+    label: str
+    icon: str
+    type: str
+    subtype: str
+
+    @classmethod
+    def __pre_deserialize__(cls, d: Any) -> Any:
+        if isinstance(d, list):
+            merged: dict[str, Any] = {}
+            for item in d:
+                merged.update(item)
+            return merged
+        return d
+
+
+DevicesScreenItem = Union[
+    HomeScreenStatus,
+    HomeScreenResponse,
+    DevicesScreenGroup,
+    dict[str, DevicesScreenAuxAttrs],
+]
 
 
 HomeScreenItem = Union[

--- a/src/iaqualink/types.py
+++ b/src/iaqualink/types.py
@@ -1,0 +1,271 @@
+from serde import field, serde, Untagged
+
+from datetime import datetime
+from typing import Union, Optional, List
+from uuid import UUID
+
+
+@serde
+class CognitoPool:
+    app_client_id: str = field(rename="appClientId")
+    domain: str
+    pool_id: str = field(rename="poolId")
+    region: str
+
+
+@serde(rename_all="pascalcase")
+class Credentials:
+    access_key_id: str
+    secret_key: str
+    session_token: str
+    expiration: datetime
+    identity_id: str
+
+
+@serde(rename_all="pascalcase")
+class UserPoolOAuth:
+    expires_in: int
+    token_type: str
+    refresh_token: str
+    id_token: str
+
+
+@serde
+class LoginResponse:
+    username: UUID
+    email: str
+    first_name: str
+    last_name: str
+    address: str
+    address_1: str
+    address_2: None
+    city: str
+    state: None
+    country: str
+    postal_code: str
+    id: int
+    authentication_token: str
+    session_id: str
+    created_at: datetime
+    updated_at: datetime
+    time_zone: None
+    phone: str
+    opt_in_1: str
+    opt_in_2: str
+    role: str
+    cognito_pool: CognitoPool = field(rename="cognitoPool")
+    credentials: Credentials
+    user_pool_o_auth: UserPoolOAuth = field(rename="userPoolOAuth")
+
+
+@serde
+class DevicesResponseElement:
+    id: int
+    serial_number: str
+    created_at: datetime
+    updated_at: datetime
+    name: str
+    device_type: str
+    owner_id: None
+    updating: bool
+    firmware_version: None
+    target_firmware_version: None
+    update_firmware_start_at: None
+    last_activity_at: None
+
+
+DevicesResponse = List[DevicesResponseElement]
+
+
+### Home Screen Response
+
+
+@serde(rename_all="camelcase")
+class HeatpumpInfo:
+    isheatpump_present: Optional[bool] = False
+    heatpumpstatus: Optional[str] = None
+    is_chill_available: Optional[bool] = False
+    heatpumpmode: Optional[str] = None
+    heatpumptype: Optional[str] = None
+
+
+@serde
+class IclCustomColorInfo:
+    zone_id: int = field(rename="zoneId")
+    red_val: int
+    green_val: int
+    blue_val: int
+    white_val: int
+
+
+@serde(rename_all="camelcase")
+class SwcInfo:
+    isswc_present: bool
+    swc_pool_value: Optional[str] = None
+    swc_pool_status: Optional[str] = None
+
+
+@serde
+class HomeScreenStatus:
+    status: str
+
+
+@serde
+class HomeScreenResponse:
+    response: str
+
+
+@serde
+class HomeScreenSystemType:
+    system_type: str
+
+
+@serde
+class HomeScreenTempScale:
+    temp_scale: str
+
+
+@serde
+class HomeScreenSpaTemp:
+    spa_temp: str
+
+
+@serde
+class HomeScreenPoolTemp:
+    pool_temp: str
+
+
+@serde
+class HomeScreenAirTemp:
+    air_temp: str
+
+
+@serde
+class HomeScreenSetPoint:
+    spa_set_point: str
+
+
+@serde
+class HomeScreenPoolSetPoint:
+    pool_set_point: str
+
+
+@serde
+class HomeScreenCoverPool:
+    cover_pool: str
+
+
+@serde
+class HomeScreenFreezeProtection:
+    freeze_protection: str
+
+
+@serde
+class HomeScreenSpaPump:
+    spa_pump: str
+
+
+@serde
+class HomeScreenPoolPump:
+    pool_pump: str
+
+
+@serde
+class HomeScreenSpaHeater:
+    spa_heater: str
+
+
+@serde
+class HomeScreenPoolHeater:
+    pool_heater: str
+
+
+@serde
+class HomeScreenSolarHeater:
+    solar_heater: str
+
+
+@serde
+class HomeScreenSpaSalinity:
+    spa_salinity: str
+
+
+@serde
+class HomeScreenPoolSalinity:
+    pool_salinity: str
+
+
+@serde
+class HomeScreenOrp:
+    orp: str
+
+
+@serde
+class HomeScreenPh:
+    ph: str
+
+
+@serde
+class HomeScreenIsIclPresent:
+    is_icl_present: str
+
+
+@serde
+class HomeScreenIclCustomColor:
+    icl_custom_color_info: List[IclCustomColorInfo]
+
+
+@serde
+class HomeScreenHeatpumpInfo:
+    heatpump_info: HeatpumpInfo
+
+
+@serde
+class HomeScreenPoolChillSetPoint:
+    pool_chill_set_point: str
+
+
+@serde
+class HomeScreenSwcInfo:
+    swc_info: SwcInfo
+
+
+@serde
+class HomeScreenRelayCount:
+    relay_count: str
+
+
+@serde(tagging=Untagged)
+class HomeResponse:
+    message: str
+    serial: str
+    home_screen: List[
+        Union[
+            HomeScreenAirTemp
+            | HomeScreenCoverPool
+            | HomeScreenFreezeProtection
+            | HomeScreenHeatpumpInfo
+            | HomeScreenIclCustomColor
+            | HomeScreenIsIclPresent
+            | HomeScreenOrp
+            | HomeScreenPh
+            | HomeScreenPoolChillSetPoint
+            | HomeScreenPoolHeater
+            | HomeScreenPoolPump
+            | HomeScreenPoolSalinity
+            | HomeScreenPoolSetPoint
+            | HomeScreenPoolTemp
+            | HomeScreenRelayCount
+            | HomeScreenResponse
+            | HomeScreenSetPoint
+            | HomeScreenSolarHeater
+            | HomeScreenSpaHeater
+            | HomeScreenSpaPump
+            | HomeScreenSpaSalinity
+            | HomeScreenSpaTemp
+            | HomeScreenStatus
+            | HomeScreenSwcInfo
+            | HomeScreenSystemType
+            | HomeScreenTempScale
+        ]
+    ]

--- a/src/iaqualink/types.py
+++ b/src/iaqualink/types.py
@@ -1,13 +1,12 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List
 
 from mashumaro import field_options
 from mashumaro.mixins.json import DataClassJSONMixin
 
 
 @dataclass
-class CognitoPool(DataClassJSONMixin):
+class CognitoPool:
     app_client_id: str = field(metadata=field_options(alias="appClientId"))
     domain: str
     pool_id: str = field(metadata=field_options(alias="poolId"))
@@ -15,7 +14,7 @@ class CognitoPool(DataClassJSONMixin):
 
 
 @dataclass
-class Credentials(DataClassJSONMixin):
+class Credentials:
     access_key_id: str = field(metadata=field_options(alias="AccessKeyId"))
     secret_key: str = field(metadata=field_options(alias="SecretKey"))
     session_token: str = field(metadata=field_options(alias="SessionToken"))
@@ -24,7 +23,7 @@ class Credentials(DataClassJSONMixin):
 
 
 @dataclass
-class UserPoolOAuth(DataClassJSONMixin):
+class UserPoolOAuth:
     id_token: str = field(metadata=field_options(alias="IdToken"))
     access_token: str | None = field(
         default=None, metadata=field_options(alias="AccessToken")
@@ -92,4 +91,4 @@ class DevicesResponseElement(DataClassJSONMixin):
     last_activity_at: datetime | None = None
 
 
-DevicesResponse = List[DevicesResponseElement]
+type DevicesResponse = list[DevicesResponseElement]

--- a/src/iaqualink/types.py
+++ b/src/iaqualink/types.py
@@ -45,7 +45,7 @@ class LoginResponse(DataClassJSONMixin):
     id: int
     authentication_token: str
     session_id: str
-    user_pool_o_auth: UserPoolOAuth = field(
+    user_pool_oauth: UserPoolOAuth = field(
         metadata=field_options(alias="userPoolOAuth")
     )
     # Remaining spec fields — optional so minimal test fixtures still parse.

--- a/src/iaqualink/types.py
+++ b/src/iaqualink/types.py
@@ -1,271 +1,95 @@
-from serde import field, serde, Untagged
-
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Union, Optional, List
-from uuid import UUID
+from typing import List
+
+from mashumaro import field_options
+from mashumaro.mixins.json import DataClassJSONMixin
 
 
-@serde
-class CognitoPool:
-    app_client_id: str = field(rename="appClientId")
+@dataclass
+class CognitoPool(DataClassJSONMixin):
+    app_client_id: str = field(metadata=field_options(alias="appClientId"))
     domain: str
-    pool_id: str = field(rename="poolId")
+    pool_id: str = field(metadata=field_options(alias="poolId"))
     region: str
 
 
-@serde(rename_all="pascalcase")
-class Credentials:
-    access_key_id: str
-    secret_key: str
-    session_token: str
-    expiration: datetime
-    identity_id: str
+@dataclass
+class Credentials(DataClassJSONMixin):
+    access_key_id: str = field(metadata=field_options(alias="AccessKeyId"))
+    secret_key: str = field(metadata=field_options(alias="SecretKey"))
+    session_token: str = field(metadata=field_options(alias="SessionToken"))
+    expiration: datetime = field(metadata=field_options(alias="Expiration"))
+    identity_id: str = field(metadata=field_options(alias="IdentityId"))
 
 
-@serde(rename_all="pascalcase")
-class UserPoolOAuth:
-    expires_in: int
-    token_type: str
-    refresh_token: str
-    id_token: str
+@dataclass
+class UserPoolOAuth(DataClassJSONMixin):
+    id_token: str = field(metadata=field_options(alias="IdToken"))
+    access_token: str | None = field(
+        default=None, metadata=field_options(alias="AccessToken")
+    )
+    expires_in: int | None = field(
+        default=None, metadata=field_options(alias="ExpiresIn")
+    )
+    token_type: str | None = field(
+        default=None, metadata=field_options(alias="TokenType")
+    )
+    refresh_token: str | None = field(
+        default=None, metadata=field_options(alias="RefreshToken")
+    )
 
 
-@serde
-class LoginResponse:
-    username: UUID
-    email: str
-    first_name: str
-    last_name: str
-    address: str
-    address_1: str
-    address_2: None
-    city: str
-    state: None
-    country: str
-    postal_code: str
+@dataclass
+class LoginResponse(DataClassJSONMixin):
+    # Fields used by application code — required.
     id: int
     authentication_token: str
     session_id: str
-    created_at: datetime
-    updated_at: datetime
-    time_zone: None
-    phone: str
-    opt_in_1: str
-    opt_in_2: str
-    role: str
-    cognito_pool: CognitoPool = field(rename="cognitoPool")
-    credentials: Credentials
-    user_pool_o_auth: UserPoolOAuth = field(rename="userPoolOAuth")
+    user_pool_o_auth: UserPoolOAuth = field(
+        metadata=field_options(alias="userPoolOAuth")
+    )
+    # Remaining spec fields — optional so minimal test fixtures still parse.
+    username: str = ""
+    email: str = ""
+    first_name: str = ""
+    last_name: str = ""
+    address: str = ""
+    address_1: str = ""
+    address_2: str | None = None
+    city: str = ""
+    state: str | None = None
+    country: str = ""
+    postal_code: str = ""
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    time_zone: str | None = None
+    phone: str = ""
+    opt_in_1: bool = False
+    opt_in_2: bool = False
+    role: str = ""
+    cognito_pool: CognitoPool | None = field(
+        default=None, metadata=field_options(alias="cognitoPool")
+    )
+    credentials: Credentials | None = None
 
 
-@serde
-class DevicesResponseElement:
-    id: int
-    serial_number: str
-    created_at: datetime
-    updated_at: datetime
-    name: str
+@dataclass
+class DevicesResponseElement(DataClassJSONMixin):
+    # Fields used by application code — required.
     device_type: str
-    owner_id: None
-    updating: bool
-    firmware_version: None
-    target_firmware_version: None
-    update_firmware_start_at: None
-    last_activity_at: None
+    serial_number: str
+    # Remaining spec fields — optional so minimal test fixtures still parse.
+    id: int = 0
+    name: str = ""
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    owner_id: int | None = None
+    updating: bool = False
+    firmware_version: str | None = None
+    target_firmware_version: str | None = None
+    update_firmware_start_at: str | None = None
+    last_activity_at: datetime | None = None
 
 
 DevicesResponse = List[DevicesResponseElement]
-
-
-### Home Screen Response
-
-
-@serde(rename_all="camelcase")
-class HeatpumpInfo:
-    isheatpump_present: Optional[bool] = False
-    heatpumpstatus: Optional[str] = None
-    is_chill_available: Optional[bool] = False
-    heatpumpmode: Optional[str] = None
-    heatpumptype: Optional[str] = None
-
-
-@serde
-class IclCustomColorInfo:
-    zone_id: int = field(rename="zoneId")
-    red_val: int
-    green_val: int
-    blue_val: int
-    white_val: int
-
-
-@serde(rename_all="camelcase")
-class SwcInfo:
-    isswc_present: bool
-    swc_pool_value: Optional[str] = None
-    swc_pool_status: Optional[str] = None
-
-
-@serde
-class HomeScreenStatus:
-    status: str
-
-
-@serde
-class HomeScreenResponse:
-    response: str
-
-
-@serde
-class HomeScreenSystemType:
-    system_type: str
-
-
-@serde
-class HomeScreenTempScale:
-    temp_scale: str
-
-
-@serde
-class HomeScreenSpaTemp:
-    spa_temp: str
-
-
-@serde
-class HomeScreenPoolTemp:
-    pool_temp: str
-
-
-@serde
-class HomeScreenAirTemp:
-    air_temp: str
-
-
-@serde
-class HomeScreenSetPoint:
-    spa_set_point: str
-
-
-@serde
-class HomeScreenPoolSetPoint:
-    pool_set_point: str
-
-
-@serde
-class HomeScreenCoverPool:
-    cover_pool: str
-
-
-@serde
-class HomeScreenFreezeProtection:
-    freeze_protection: str
-
-
-@serde
-class HomeScreenSpaPump:
-    spa_pump: str
-
-
-@serde
-class HomeScreenPoolPump:
-    pool_pump: str
-
-
-@serde
-class HomeScreenSpaHeater:
-    spa_heater: str
-
-
-@serde
-class HomeScreenPoolHeater:
-    pool_heater: str
-
-
-@serde
-class HomeScreenSolarHeater:
-    solar_heater: str
-
-
-@serde
-class HomeScreenSpaSalinity:
-    spa_salinity: str
-
-
-@serde
-class HomeScreenPoolSalinity:
-    pool_salinity: str
-
-
-@serde
-class HomeScreenOrp:
-    orp: str
-
-
-@serde
-class HomeScreenPh:
-    ph: str
-
-
-@serde
-class HomeScreenIsIclPresent:
-    is_icl_present: str
-
-
-@serde
-class HomeScreenIclCustomColor:
-    icl_custom_color_info: List[IclCustomColorInfo]
-
-
-@serde
-class HomeScreenHeatpumpInfo:
-    heatpump_info: HeatpumpInfo
-
-
-@serde
-class HomeScreenPoolChillSetPoint:
-    pool_chill_set_point: str
-
-
-@serde
-class HomeScreenSwcInfo:
-    swc_info: SwcInfo
-
-
-@serde
-class HomeScreenRelayCount:
-    relay_count: str
-
-
-@serde(tagging=Untagged)
-class HomeResponse:
-    message: str
-    serial: str
-    home_screen: List[
-        Union[
-            HomeScreenAirTemp
-            | HomeScreenCoverPool
-            | HomeScreenFreezeProtection
-            | HomeScreenHeatpumpInfo
-            | HomeScreenIclCustomColor
-            | HomeScreenIsIclPresent
-            | HomeScreenOrp
-            | HomeScreenPh
-            | HomeScreenPoolChillSetPoint
-            | HomeScreenPoolHeater
-            | HomeScreenPoolPump
-            | HomeScreenPoolSalinity
-            | HomeScreenPoolSetPoint
-            | HomeScreenPoolTemp
-            | HomeScreenRelayCount
-            | HomeScreenResponse
-            | HomeScreenSetPoint
-            | HomeScreenSolarHeater
-            | HomeScreenSpaHeater
-            | HomeScreenSpaPump
-            | HomeScreenSpaSalinity
-            | HomeScreenSpaTemp
-            | HomeScreenStatus
-            | HomeScreenSwcInfo
-            | HomeScreenSystemType
-            | HomeScreenTempScale
-        ]
-    ]

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -1,0 +1,15 @@
+from serde import SerdeError
+from serde.json import from_json
+
+from .exception import AqualinkException
+
+
+def json_to_dataclass(cls, json_str: str):
+    try:
+        res = from_json(cls, json_str)
+    except SerdeError as e:
+        print(json_str)
+        print(e)
+        raise AqualinkException(f"Error parsing JSON: {e}") from e
+    else:
+        return res

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -40,9 +40,5 @@ def json_to_dataclass(cls: type[_T], json_str: str) -> _T:
 
 
 def decode_json(decoder: JSONDecoder[Any], json_str: str) -> Any:
-    """Decode JSON using a pre-built mashumaro JSONDecoder.
-
-    Use this instead of json_to_dataclass when the target type is not a
-    DataClassJSONMixin subclass (e.g. a bare list type alias).
-    """
+    """Decode JSON via a pre-built JSONDecoder (use when target is not a DataClassJSONMixin)."""
     return _parse(lambda: decoder.decode(json_str), "response")

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -1,10 +1,12 @@
 import logging
+from typing import TypeVar
 
 from mashumaro.exceptions import (
     InvalidFieldValue,
     MissingField,
     SuitableVariantNotFoundError,
 )
+from mashumaro.mixins.json import DataClassJSONMixin
 
 from .exception import AqualinkUnexpectedResponseException
 
@@ -16,8 +18,10 @@ _MASHUMARO_ERRORS = (
     SuitableVariantNotFoundError,
 )
 
+_T = TypeVar("_T", bound=DataClassJSONMixin)
 
-def json_to_dataclass(cls, json_str: str):
+
+def json_to_dataclass(cls: type[_T], json_str: str) -> _T:
     try:
         res = cls.from_json(json_str)
     except _MASHUMARO_ERRORS as e:

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -1,15 +1,29 @@
-from serde import SerdeError
-from serde.json import from_json
+import logging
+
+from mashumaro.exceptions import (
+    InvalidFieldValue,
+    MissingField,
+    SuitableVariantNotFoundError,
+)
 
 from .exception import AqualinkException
+
+LOGGER = logging.getLogger("iaqualink")
+
+_MASHUMARO_ERRORS = (
+    MissingField,
+    InvalidFieldValue,
+    SuitableVariantNotFoundError,
+)
 
 
 def json_to_dataclass(cls, json_str: str):
     try:
-        res = from_json(cls, json_str)
-    except SerdeError as e:
-        print(json_str)
-        print(e)
+        res = cls.from_json(json_str)
+    except _MASHUMARO_ERRORS as e:
+        LOGGER.error(
+            "Failed to parse JSON into %s: %s\n%s", cls.__name__, e, json_str
+        )
         raise AqualinkException(f"Error parsing JSON: {e}") from e
     else:
         return res

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, TypeVar
+from typing import Any, Callable, TypeVar
 
 from mashumaro.codecs.json import JSONDecoder
 from mashumaro.exceptions import (
@@ -22,16 +22,21 @@ _MASHUMARO_ERRORS = (
 )
 
 _T = TypeVar("_T", bound=DataClassJSONMixin)
+_D = TypeVar("_D")
 
 
-def json_to_dataclass(cls: type[_T], json_str: str) -> _T:
+def _parse(operation: Callable[[], _D], label: str) -> _D:
     try:
-        return cls.from_json(json_str)
+        return operation()
     except _MASHUMARO_ERRORS as e:
-        LOGGER.error("Failed to parse JSON into %s: %s", cls.__name__, e)
+        LOGGER.error("Failed to parse JSON into %s: %s", label, e)
         raise AqualinkUnexpectedResponseException(
             f"Error parsing JSON: {e}"
         ) from e
+
+
+def json_to_dataclass(cls: type[_T], json_str: str) -> _T:
+    return _parse(lambda: cls.from_json(json_str), cls.__name__)
 
 
 def decode_json(decoder: JSONDecoder[Any], json_str: str) -> Any:
@@ -40,10 +45,4 @@ def decode_json(decoder: JSONDecoder[Any], json_str: str) -> Any:
     Use this instead of json_to_dataclass when the target type is not a
     DataClassJSONMixin subclass (e.g. a bare list type alias).
     """
-    try:
-        return decoder.decode(json_str)
-    except _MASHUMARO_ERRORS as e:
-        LOGGER.error("Failed to decode JSON response: %s", e)
-        raise AqualinkUnexpectedResponseException(
-            f"Error parsing JSON: {e}"
-        ) from e
+    return _parse(lambda: decoder.decode(json_str), "response")

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -29,7 +29,7 @@ def _parse(operation: Callable[[], _D], label: str) -> _D:
     try:
         return operation()
     except _MASHUMARO_ERRORS as e:
-        LOGGER.error("Failed to parse JSON into %s: %s", label, e)
+        LOGGER.debug("Failed to parse JSON into %s: %s", label, e)
         raise AqualinkUnexpectedResponseException(
             f"Error parsing JSON: {e}"
         ) from e

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -6,7 +6,7 @@ from mashumaro.exceptions import (
     SuitableVariantNotFoundError,
 )
 
-from .exception import AqualinkException
+from .exception import AqualinkUnexpectedResponseException
 
 LOGGER = logging.getLogger("iaqualink")
 
@@ -24,6 +24,8 @@ def json_to_dataclass(cls, json_str: str):
         LOGGER.error(
             "Failed to parse JSON into %s: %s\n%s", cls.__name__, e, json_str
         )
-        raise AqualinkException(f"Error parsing JSON: {e}") from e
+        raise AqualinkUnexpectedResponseException(
+            f"Error parsing JSON: {e}"
+        ) from e
     else:
         return res

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -1,6 +1,8 @@
+import json
 import logging
-from typing import TypeVar
+from typing import Any, TypeVar
 
+from mashumaro.codecs.json import JSONDecoder
 from mashumaro.exceptions import (
     InvalidFieldValue,
     MissingField,
@@ -13,6 +15,7 @@ from .exception import AqualinkUnexpectedResponseException
 LOGGER = logging.getLogger("iaqualink")
 
 _MASHUMARO_ERRORS = (
+    json.JSONDecodeError,
     MissingField,
     InvalidFieldValue,
     SuitableVariantNotFoundError,
@@ -23,13 +26,19 @@ _T = TypeVar("_T", bound=DataClassJSONMixin)
 
 def json_to_dataclass(cls: type[_T], json_str: str) -> _T:
     try:
-        res = cls.from_json(json_str)
+        return cls.from_json(json_str)
     except _MASHUMARO_ERRORS as e:
-        LOGGER.error(
-            "Failed to parse JSON into %s: %s\n%s", cls.__name__, e, json_str
-        )
+        LOGGER.error("Failed to parse JSON into %s: %s", cls.__name__, e)
         raise AqualinkUnexpectedResponseException(
             f"Error parsing JSON: {e}"
         ) from e
-    else:
-        return res
+
+
+def decode_json(decoder: JSONDecoder[Any], json_str: str) -> Any:
+    try:
+        return decoder.decode(json_str)
+    except _MASHUMARO_ERRORS as e:
+        LOGGER.error("Failed to decode JSON response: %s", e)
+        raise AqualinkUnexpectedResponseException(
+            f"Error parsing JSON: {e}"
+        ) from e

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -35,6 +35,11 @@ def json_to_dataclass(cls: type[_T], json_str: str) -> _T:
 
 
 def decode_json(decoder: JSONDecoder[Any], json_str: str) -> Any:
+    """Decode JSON using a pre-built mashumaro JSONDecoder.
+
+    Use this instead of json_to_dataclass when the target type is not a
+    DataClassJSONMixin subclass (e.g. a bare list type alias).
+    """
     try:
         return decoder.decode(json_str)
     except _MASHUMARO_ERRORS as e:

--- a/tests/systems/exo/test_device.py
+++ b/tests/systems/exo/test_device.py
@@ -22,6 +22,7 @@ from iaqualink.systems.exo.device import (
     ExoThermostat,
 )
 from iaqualink.systems.exo.system import ExoSystem
+from iaqualink.types import DevicesResponseElement
 
 from ...base_test_device import (
     TestBaseDevice,
@@ -35,7 +36,9 @@ class TestExoDevice(TestBaseDevice):
     def setUp(self) -> None:
         super().setUp()
 
-        data = {"serial_number": "SN123456", "device_type": "exo"}
+        data = DevicesResponseElement(
+            device_type="exo", serial_number="SN123456"
+        )
         self.system = ExoSystem(self.client, data=data)
 
         data = {"name": "Test Device", "state": "42"}

--- a/tests/systems/exo/test_system.py
+++ b/tests/systems/exo/test_system.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +18,7 @@ from iaqualink.systems.exo.device import (
     ExoSensor,
 )
 from iaqualink.systems.exo.system import ExoSystem
+from iaqualink.types import DevicesResponseElement
 
 from ...base_test_system import TestBaseSystem
 
@@ -174,14 +177,23 @@ class TestExoSystem(TestBaseSystem):
     def setUp(self) -> None:
         super().setUp()
 
-        data = {
-            "id": 1,
-            "serial_number": "ABCDEFG",
-            "device_type": "exo",
-            "name": "Pool",
-        }
+        data = DevicesResponseElement(
+            id=1,
+            serial_number="ABCDEFG",
+            device_type="exo",
+            name="Pool",
+        )
         self.sut = AqualinkSystem.from_data(self.client, data=data)
         self.sut_class = ExoSystem
+
+    def test_from_data_exo(self) -> None:
+        aqualink = MagicMock()
+        data = DevicesResponseElement(
+            device_type="exo", serial_number="ABCDEFG"
+        )
+        r = AqualinkSystem.from_data(aqualink, data)
+        assert r is not None
+        assert isinstance(r, ExoSystem)
 
     async def test_update_success(self) -> None:
         with patch.object(self.sut, "_parse_shadow_response"):
@@ -207,7 +219,7 @@ class TestExoSystem(TestBaseSystem):
 
     def test_parse_devices_good(self) -> None:
         response = MagicMock()
-        response.json.return_value = SAMPLE_DATA
+        response.text = json.dumps(SAMPLE_DATA)
         self.sut._parse_shadow_response(response)
 
         assert len(self.sut.devices) > 0
@@ -292,3 +304,34 @@ class TestExoSystem(TestBaseSystem):
             await self.sut.send_reported_state_request()
 
         mock_refresh.assert_awaited_once()
+
+    async def test_update_skipped_within_refresh_interval(self) -> None:
+        aqualink = MagicMock()
+        data = DevicesResponseElement(
+            device_type="exo", serial_number="ABCDEFG"
+        )
+        system = AqualinkSystem.from_data(aqualink, data)
+        system.send_reported_state_request = async_noop
+        system._parse_shadow_response = MagicMock()
+
+        # First update should go through.
+        now = int(time.time())
+        with patch("iaqualink.systems.exo.system.time") as mock_time:
+            mock_time.time.return_value = now
+            await system.update()
+        assert system._parse_shadow_response.call_count == 1
+
+        # Second update within MIN_SECS_TO_REFRESH should be skipped.
+        system._parse_shadow_response.reset_mock()
+        with patch("iaqualink.systems.exo.system.time") as mock_time:
+            mock_time.time.return_value = (
+                now + ExoSystem.MIN_SECS_TO_REFRESH - 1
+            )
+            await system.update()
+        assert system._parse_shadow_response.call_count == 0
+
+        # Update after MIN_SECS_TO_REFRESH should go through.
+        with patch("iaqualink.systems.exo.system.time") as mock_time:
+            mock_time.time.return_value = now + ExoSystem.MIN_SECS_TO_REFRESH
+            await system.update()
+        assert system._parse_shadow_response.call_count == 1

--- a/tests/systems/exo/test_system.py
+++ b/tests/systems/exo/test_system.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -304,34 +303,3 @@ class TestExoSystem(TestBaseSystem):
             await self.sut.send_reported_state_request()
 
         mock_refresh.assert_awaited_once()
-
-    async def test_update_skipped_within_refresh_interval(self) -> None:
-        aqualink = MagicMock()
-        data = DevicesResponseElement(
-            device_type="exo", serial_number="ABCDEFG"
-        )
-        system = AqualinkSystem.from_data(aqualink, data)
-        system.send_reported_state_request = async_noop
-        system._parse_shadow_response = MagicMock()
-
-        # First update should go through.
-        now = int(time.time())
-        with patch("iaqualink.systems.exo.system.time") as mock_time:
-            mock_time.time.return_value = now
-            await system.update()
-        assert system._parse_shadow_response.call_count == 1
-
-        # Second update within MIN_SECS_TO_REFRESH should be skipped.
-        system._parse_shadow_response.reset_mock()
-        with patch("iaqualink.systems.exo.system.time") as mock_time:
-            mock_time.time.return_value = (
-                now + ExoSystem.MIN_SECS_TO_REFRESH - 1
-            )
-            await system.update()
-        assert system._parse_shadow_response.call_count == 0
-
-        # Update after MIN_SECS_TO_REFRESH should go through.
-        with patch("iaqualink.systems.exo.system.time") as mock_time:
-            mock_time.time.return_value = now + ExoSystem.MIN_SECS_TO_REFRESH
-            await system.update()
-        assert system._parse_shadow_response.call_count == 1

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -21,6 +21,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaThermostat,
 )
 from iaqualink.systems.iaqua.system import IaquaSystem
+from iaqualink.types import DevicesResponseElement
 
 from ...base_test_device import (
     TestBaseBinarySensor,
@@ -36,7 +37,9 @@ class TestIaquaDevice(TestBaseDevice):
     def setUp(self) -> None:
         super().setUp()
 
-        data = {"serial_number": "SN123456", "device_type": "iaqua"}
+        data = DevicesResponseElement(
+            device_type="iaqua", serial_number="SN123456"
+        )
         self.system = IaquaSystem(self.client, data=data)
 
         data = {"name": "device", "state": "42"}

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -164,7 +164,7 @@ class TestIaquaSystem(TestBaseSystem):
             ],
         }
         response = MagicMock()
-        response.json.return_value = message
+        response.text = json.dumps(message)
 
         self.sut._parse_devices_response(response)
         assert self.sut.devices == {"aux_existing": existing}
@@ -182,7 +182,7 @@ class TestIaquaSystem(TestBaseSystem):
             ],
         }
         response = MagicMock()
-        response.json.return_value = message
+        response.text = json.dumps(message)
 
         self.sut._parse_home_response(response)
         assert self.sut.devices == {"pool_pump": existing}

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import urllib.parse
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +15,7 @@ from iaqualink.exception import (
 from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import IaquaAuxSwitch
 from iaqualink.systems.iaqua.system import IAQUA_SESSION_URL, IaquaSystem
+from iaqualink.types import DevicesResponseElement
 
 from ...base_test_system import TestBaseSystem
 
@@ -22,20 +24,12 @@ class TestIaquaSystem(TestBaseSystem):
     def setUp(self) -> None:
         super().setUp()
 
-        data = {
-            "id": 123456,
-            "serial_number": "SN123456",
-            "created_at": "2017-09-23T01:00:08.000Z",
-            "updated_at": "2017-09-23T01:00:08.000Z",
-            "name": "Pool",
-            "device_type": "iaqua",
-            "owner_id": None,
-            "updating": False,
-            "firmware_version": None,
-            "target_firmware_version": None,
-            "update_firmware_start_at": None,
-            "last_activity_at": None,
-        }
+        data = DevicesResponseElement(
+            id=123456,
+            serial_number="SN123456",
+            name="Pool",
+            device_type="iaqua",
+        )
         self.sut = AqualinkSystem.from_data(self.client, data=data)
         self.sut_class = IaquaSystem
 
@@ -67,10 +61,44 @@ class TestIaquaSystem(TestBaseSystem):
         ):
             await super().test_get_devices_needs_update()
 
+    async def test_parse_home_offline(self) -> None:
+        message = {
+            "message": "",
+            "serial": "",
+            "home_screen": [{"status": "Offline"}],
+        }
+        response = MagicMock()
+        response.text = json.dumps(message)
+
+        with pytest.raises(AqualinkSystemOfflineException):
+            self.sut._parse_home_response(response)
+        assert self.sut.devices == {}
+
+    async def test_parse_home_good(self) -> None:
+        message = {
+            "message": "",
+            "serial": "",
+            "home_screen": [
+                {"status": "Online"},
+                {"response": ""},
+                {"system_type": "IQPRO+"},
+                {"temp_scale": "F"},
+                {"spa_temp": "90"},
+                {"pool_temp": "85"},
+            ],
+        }
+        response = MagicMock()
+        response.text = json.dumps(message)
+
+        self.sut._parse_home_response(response)
+        assert "spa_temp" in self.sut.devices
+        assert "pool_temp" in self.sut.devices
+        assert self.sut.temp_unit == "F"
+
     async def test_parse_devices_offline(self) -> None:
         message = {"message": "", "devices_screen": [{"status": "Offline"}]}
         response = MagicMock()
-        response.json.return_value = message
+        response.text = json.dumps(message)
 
         with pytest.raises(AqualinkSystemOfflineException):
             self.sut._parse_devices_response(response)
@@ -95,7 +123,7 @@ class TestIaquaSystem(TestBaseSystem):
             ],
         }
         response = MagicMock()
-        response.json.return_value = message
+        response.text = json.dumps(message)
 
         expected = {
             "aux_B1": IaquaAuxSwitch(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 
 from iaqualink.client import AqualinkAuthState
 from iaqualink.system import UnsupportedSystem
+from iaqualink.types import DevicesResponseElement
 
 cli_module = importlib.import_module("iaqualink.cli.app")
 
@@ -23,7 +24,7 @@ class FakeSystem:
     def __init__(self, serial: str, name: str) -> None:
         self.serial = serial
         self.name = name
-        self.data = {"device_type": "iaqua"}
+        self.data = DevicesResponseElement(device_type="iaqua", serial_number=serial)
 
     async def get_devices(self) -> dict[str, object]:
         return {}
@@ -159,7 +160,7 @@ def test_list_devices_reports_ambiguous_system_name(tmp_path: Path) -> None:
 def _make_unsupported_system(
     serial: str = "SN001", name: str = "Pool"
 ) -> UnsupportedSystem:
-    data = {"serial_number": serial, "name": name, "device_type": "foo"}
+    data = DevicesResponseElement(device_type="foo", serial_number=serial, name=name)
     return UnsupportedSystem(MagicMock(), data)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,9 @@ class FakeSystem:
     def __init__(self, serial: str, name: str) -> None:
         self.serial = serial
         self.name = name
-        self.data = DevicesResponseElement(device_type="iaqua", serial_number=serial)
+        self.data = DevicesResponseElement(
+            device_type="iaqua", serial_number=serial
+        )
 
     async def get_devices(self) -> dict[str, object]:
         return {}
@@ -160,7 +162,9 @@ def test_list_devices_reports_ambiguous_system_name(tmp_path: Path) -> None:
 def _make_unsupported_system(
     serial: str = "SN001", name: str = "Pool"
 ) -> UnsupportedSystem:
-    data = DevicesResponseElement(device_type="foo", serial_number=serial, name=name)
+    data = DevicesResponseElement(
+        device_type="foo", serial_number=serial, name=name
+    )
     return UnsupportedSystem(MagicMock(), data)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,14 +26,14 @@ from .base import TestBase
 from .common import async_noop, async_raises
 
 LOGIN_DATA = {
-    "id": "id",
+    "id": 1,
     "authentication_token": "token",
     "session_id": "session_id",
     "userPoolOAuth": {"IdToken": "userPoolOAuth:IdToken"},
 }
 
 LOGIN_DATA_WITH_REFRESH = {
-    "id": "id",
+    "id": 1,
     "authentication_token": "token",
     "session_id": "session_id",
     "userPoolOAuth": {
@@ -43,7 +43,7 @@ LOGIN_DATA_WITH_REFRESH = {
 }
 
 REFRESH_RESPONSE_DATA = {
-    "id": "id",
+    "id": 1,
     "authentication_token": "new-token",
     "session_id": "new-session-id",
     "userPoolOAuth": {
@@ -97,7 +97,7 @@ class TestAqualinkClient(TestBase):
             username="foo",
             client_id="session_id",
             authentication_token="token",
-            user_id="id",
+            user_id="1",
             id_token="userPoolOAuth:IdToken",
             refresh_token="userPoolOAuth:RefreshToken",
         )
@@ -321,7 +321,7 @@ class TestAqualinkClient(TestBase):
         assert systems == {}
         retry_url = mock_request.call_args_list[3][0][1]
         assert "authentication_token=new-token" in retry_url
-        assert "user_id=id" in retry_url
+        assert "user_id=1" in retry_url
 
     @patch("httpx.AsyncClient.request")
     async def test_systems_request_repeated_401_refreshes_only_once(
@@ -496,7 +496,7 @@ class TestAqualinkClient(TestBase):
     ) -> None:
         # If the refresh response omits RefreshToken, keep the existing one.
         refresh_no_new_token = {
-            "id": "id",
+            "id": 1,
             "authentication_token": "new-token",
             "session_id": "new-session-id",
             "userPoolOAuth": {"IdToken": "new-id-token"},

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,14 +25,14 @@ from .base import TestBase
 from .common import async_noop, async_raises
 
 LOGIN_DATA = {
-    "id": "id",
+    "id": 1,
     "authentication_token": "token",
     "session_id": "session_id",
     "userPoolOAuth": {"IdToken": "userPoolOAuth:IdToken"},
 }
 
 LOGIN_DATA_WITH_REFRESH = {
-    "id": "id",
+    "id": 1,
     "authentication_token": "token",
     "session_id": "session_id",
     "userPoolOAuth": {
@@ -42,7 +42,7 @@ LOGIN_DATA_WITH_REFRESH = {
 }
 
 REFRESH_RESPONSE_DATA = {
-    "id": "id",
+    "id": 1,
     "authentication_token": "new-token",
     "session_id": "new-session-id",
     "userPoolOAuth": {
@@ -58,6 +58,7 @@ def _make_resp(status: int, data: dict | None = None) -> MagicMock:
     r.reason_phrase = httpx.codes.get_reason_phrase(status)
     if data is not None:
         r.json = MagicMock(return_value=data)
+        r.text = json.dumps(data)
     if status == httpx.codes.TOO_MANY_REQUESTS:
         r.headers = httpx.Headers({})
     return r
@@ -182,6 +183,7 @@ class TestAqualinkClient(TestBase):
     async def test_login_success(self, mock_request) -> None:
         mock_request.return_value.status_code = 200
         mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
+        mock_request.return_value.text = json.dumps(LOGIN_DATA)
 
         assert self.client.logged is False
 
@@ -252,6 +254,7 @@ class TestAqualinkClient(TestBase):
     async def test_unexpectedly_logged_out(self, mock_request) -> None:
         mock_request.return_value.status_code = 200
         mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
+        mock_request.return_value.text = json.dumps(LOGIN_DATA)
 
         await self.client.login()
 
@@ -271,16 +274,14 @@ class TestAqualinkClient(TestBase):
     ) -> None:
         mock_request.return_value.status_code = 200
         mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
+        mock_request.return_value.text = json.dumps(LOGIN_DATA)
 
         await self.client.login()
 
+        systems_data = [{"device_type": "foo", "serial_number": "SN123456"}]
         mock_request.return_value.status_code = 200
-        mock_request.return_value.json.return_value = [
-            {
-                "device_type": "foo",
-                "serial_number": "SN123456",
-            }
-        ]
+        mock_request.return_value.json.return_value = systems_data
+        mock_request.return_value.text = json.dumps(systems_data)
 
         systems = await self.client.get_systems()
         assert len(systems) == 1
@@ -290,16 +291,14 @@ class TestAqualinkClient(TestBase):
     async def test_systems_request(self, mock_request) -> None:
         mock_request.return_value.status_code = 200
         mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
+        mock_request.return_value.text = json.dumps(LOGIN_DATA)
 
         await self.client.login()
 
+        systems_data = [{"device_type": "iaqua", "serial_number": "SN123456"}]
         mock_request.return_value.status_code = 200
-        mock_request.return_value.json.return_value = [
-            {
-                "device_type": "iaqua",
-                "serial_number": "SN123456",
-            }
-        ]
+        mock_request.return_value.json.return_value = systems_data
+        mock_request.return_value.text = json.dumps(systems_data)
 
         systems = await self.client.get_systems()
         assert len(systems) == 1
@@ -321,7 +320,7 @@ class TestAqualinkClient(TestBase):
         assert systems == {}
         retry_url = mock_request.call_args_list[3][0][1]
         assert "authentication_token=new-token" in retry_url
-        assert "user_id=id" in retry_url
+        assert "user_id=1" in retry_url
 
     @patch("httpx.AsyncClient.request")
     async def test_systems_request_repeated_401_refreshes_only_once(
@@ -471,6 +470,8 @@ class TestAqualinkClient(TestBase):
         assert response.status_code == httpx.codes.OK
         assert mock_request.call_count == 4
 
+
+
     @patch("httpx.AsyncClient.request")
     async def test_systems_request_500_after_refresh_raises_service_exception(
         self, mock_request
@@ -496,7 +497,7 @@ class TestAqualinkClient(TestBase):
     ) -> None:
         # If the refresh response omits RefreshToken, keep the existing one.
         refresh_no_new_token = {
-            "id": "id",
+            "id": 1,
             "authentication_token": "new-token",
             "session_id": "new-session-id",
             "userPoolOAuth": {"IdToken": "new-id-token"},

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -25,14 +26,14 @@ from .base import TestBase
 from .common import async_noop, async_raises
 
 LOGIN_DATA = {
-    "id": 1,
+    "id": "id",
     "authentication_token": "token",
     "session_id": "session_id",
     "userPoolOAuth": {"IdToken": "userPoolOAuth:IdToken"},
 }
 
 LOGIN_DATA_WITH_REFRESH = {
-    "id": 1,
+    "id": "id",
     "authentication_token": "token",
     "session_id": "session_id",
     "userPoolOAuth": {
@@ -42,7 +43,7 @@ LOGIN_DATA_WITH_REFRESH = {
 }
 
 REFRESH_RESPONSE_DATA = {
-    "id": 1,
+    "id": "id",
     "authentication_token": "new-token",
     "session_id": "new-session-id",
     "userPoolOAuth": {
@@ -320,7 +321,7 @@ class TestAqualinkClient(TestBase):
         assert systems == {}
         retry_url = mock_request.call_args_list[3][0][1]
         assert "authentication_token=new-token" in retry_url
-        assert "user_id=1" in retry_url
+        assert "user_id=id" in retry_url
 
     @patch("httpx.AsyncClient.request")
     async def test_systems_request_repeated_401_refreshes_only_once(
@@ -470,8 +471,6 @@ class TestAqualinkClient(TestBase):
         assert response.status_code == httpx.codes.OK
         assert mock_request.call_count == 4
 
-
-
     @patch("httpx.AsyncClient.request")
     async def test_systems_request_500_after_refresh_raises_service_exception(
         self, mock_request
@@ -497,7 +496,7 @@ class TestAqualinkClient(TestBase):
     ) -> None:
         # If the refresh response omits RefreshToken, keep the existing one.
         refresh_no_new_token = {
-            "id": 1,
+            "id": "id",
             "authentication_token": "new-token",
             "session_id": "new-session-id",
             "userPoolOAuth": {"IdToken": "new-id-token"},

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -8,6 +8,7 @@ import pytest
 
 from iaqualink.client import AqualinkClient
 from iaqualink.system import AqualinkSystem, UnsupportedSystem
+from iaqualink.types import DevicesResponseElement
 
 
 class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
@@ -16,12 +17,9 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
 
     def test_repr(self) -> None:
         aqualink = MagicMock()
-        data = {
-            "id": 1,
-            "serial_number": "ABCDEFG",
-            "device_type": "iaqua",
-            "name": "foo",
-        }
+        data = DevicesResponseElement(
+            device_type="iaqua", serial_number="ABCDEFG", name="foo", id=1
+        )
         system = AqualinkSystem(aqualink, data)
         assert (
             repr(system)
@@ -30,18 +28,24 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
 
     def test_from_data_iaqua(self) -> None:
         aqualink = MagicMock()
-        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "iaqua"}
+        data = DevicesResponseElement(
+            device_type="iaqua", serial_number="ABCDEFG"
+        )
         r = AqualinkSystem.from_data(aqualink, data)
         assert r is not None
 
     def test_supported_true_for_known_system(self) -> None:
         aqualink = MagicMock()
-        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "iaqua"}
+        data = DevicesResponseElement(
+            device_type="iaqua", serial_number="ABCDEFG"
+        )
         r = AqualinkSystem.from_data(aqualink, data)
         assert r.supported is True
 
     async def test_get_devices_needs_update(self) -> None:
-        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "fake"}
+        data = DevicesResponseElement(
+            device_type="fake", serial_number="ABCDEFG"
+        )
         aqualink = AqualinkClient("user", "pass")
         system = AqualinkSystem(aqualink, data)
         system.devices = None
@@ -51,7 +55,9 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
             mock_update.assert_called_once()
 
     async def test_get_devices(self) -> None:
-        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "fake"}
+        data = DevicesResponseElement(
+            device_type="fake", serial_number="ABCDEFG"
+        )
         aqualink = AqualinkClient("user", "pass")
         system = AqualinkSystem(aqualink, data)
         system.devices = {"foo": "bar"}
@@ -61,7 +67,9 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
             mock_update.assert_not_called()
 
     async def test_update_not_implemented(self) -> None:
-        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "fake"}
+        data = DevicesResponseElement(
+            device_type="fake", serial_number="ABCDEFG"
+        )
         aqualink = AqualinkClient("user", "pass")
         system = AqualinkSystem(aqualink, data)
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -80,12 +80,12 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
 class TestUnsupportedSystem(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.aqualink = MagicMock()
-        self.data = {
-            "id": 1,
-            "serial_number": "ABCDEFG",
-            "device_type": "unknown_type",
-            "name": "pool",
-        }
+        self.data = DevicesResponseElement(
+            id=1,
+            serial_number="ABCDEFG",
+            device_type="unknown_type",
+            name="pool",
+        )
         self.system = UnsupportedSystem(self.aqualink, self.data)
 
     def test_from_data_returns_unsupported_system(self) -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import unittest
+from dataclasses import dataclass
+
+import pytest
+from mashumaro.codecs.json import JSONDecoder
+from mashumaro.mixins.json import DataClassJSONMixin
+
+from iaqualink.exception import AqualinkUnexpectedResponseException
+from iaqualink.util import decode_json, json_to_dataclass
+
+
+@dataclass
+class _Simple(DataClassJSONMixin):
+    value: int
+
+
+class TestJsonToDataclass(unittest.TestCase):
+    def test_valid_json_returns_dataclass(self) -> None:
+        result = json_to_dataclass(_Simple, '{"value": 42}')
+        assert result == _Simple(value=42)
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises(AqualinkUnexpectedResponseException):
+            json_to_dataclass(_Simple, "not json{{{")
+
+    def test_wrong_schema_raises(self) -> None:
+        with pytest.raises(AqualinkUnexpectedResponseException):
+            json_to_dataclass(_Simple, '{"wrong_field": 1}')
+
+
+class TestDecodeJson(unittest.TestCase):
+    _decoder: JSONDecoder[list[_Simple]] = JSONDecoder(list[_Simple])
+
+    def test_valid_json_returns_list(self) -> None:
+        result = decode_json(self._decoder, '[{"value": 1}, {"value": 2}]')
+        assert result == [_Simple(value=1), _Simple(value=2)]
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises(AqualinkUnexpectedResponseException):
+            decode_json(self._decoder, "not json{{{")
+
+    def test_wrong_schema_raises(self) -> None:
+        with pytest.raises(AqualinkUnexpectedResponseException):
+            decode_json(self._decoder, json.dumps([{"wrong_field": 1}]))

--- a/uv.lock
+++ b/uv.lock
@@ -322,7 +322,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.0" },
-    { name = "mashumaro" },
+    { name = "mashumaro", specifier = ">=3.21" },
     { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0.2" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.5" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,24 @@ wheels = [
 ]
 
 [[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "casefy"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/24/9c732e8e3585a1dc621c9c1349e55e87070c95d3c2d57bd8c5083ec8d731/casefy-1.1.0.tar.gz", hash = "sha256:849d6e0f80506fac70ab8e18999a4ca1eb7d8f70941682383d64aa22a7497f8f", size = 123884, upload-time = "2025-03-07T14:36:44.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/6a/1766f8c163951a3c9aeb30a4e6f5de9b2eed8389e3906c4cf30fcb475be6/casefy-1.1.0-py3-none-any.whl", hash = "sha256:a3dfcb14d85902d90702db1e9835760237f6a73ec0ae3b7e991ad767513a3cbc", size = 6539, upload-time = "2025-03-07T14:36:37.546Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -286,6 +304,7 @@ name = "iaqualink"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
+    { name = "pyserde" },
 ]
 
 [package.optional-dependencies]
@@ -321,6 +340,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.0" },
+    { name = "pyserde" },
     { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0.2" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.5" },
 ]
@@ -713,6 +733,20 @@ wheels = [
 ]
 
 [[package]]
+name = "plum-dispatch"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/84146ae5ff6c40d11357acdb36aafe3db7e104de01c1026d8e1b0ce3e7f1/plum_dispatch-2.9.0.tar.gz", hash = "sha256:fb45c5b2dd4dadd57def51bcf321dfa3a258df5c725f43adea7e7f6db3b79b52", size = 244502, upload-time = "2026-04-28T08:38:34.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl", hash = "sha256:5a516cdac5460343937a2b813562ac00b0eeac973ac023916e538610bdf34397", size = 45328, upload-time = "2026-04-28T08:38:33.022Z" },
+]
+
+[[package]]
 name = "pprintpp"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -757,6 +791,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
+name = "pyserde"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "casefy" },
+    { name = "jinja2" },
+    { name = "plum-dispatch" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/cb/0a6f40a74003cb13845733300f9debdc19fe3d25e5e73e9aaf69ee4e1480/pyserde-0.31.2.tar.gz", hash = "sha256:3ec19498cbd7df40f187565482a40f97bcbd382eba9f7cf2cb29d9b39f6e8ac6", size = 518265, upload-time = "2026-04-01T08:07:16.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/11/7b3d9495a977fbf56cba768b6c0239a6f84c37e3409607ac3572a78f7bb3/pyserde-0.31.2-py3-none-any.whl", hash = "sha256:97c0d3af585c6c664ecabd421290a822dc3910d8d7b842c64fb1f01e6e93a00e", size = 49097, upload-time = "2026-04-01T08:07:17.745Z" },
 ]
 
 [[package]]
@@ -1002,6 +1053,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -51,24 +51,6 @@ wheels = [
 ]
 
 [[package]]
-name = "beartype"
-version = "0.22.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
-]
-
-[[package]]
-name = "casefy"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/24/9c732e8e3585a1dc621c9c1349e55e87070c95d3c2d57bd8c5083ec8d731/casefy-1.1.0.tar.gz", hash = "sha256:849d6e0f80506fac70ab8e18999a4ca1eb7d8f70941682383d64aa22a7497f8f", size = 123884, upload-time = "2025-03-07T14:36:44.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/6a/1766f8c163951a3c9aeb30a4e6f5de9b2eed8389e3906c4cf30fcb475be6/casefy-1.1.0-py3-none-any.whl", hash = "sha256:a3dfcb14d85902d90702db1e9835760237f6a73ec0ae3b7e991ad767513a3cbc", size = 6539, upload-time = "2025-03-07T14:36:37.546Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -304,7 +286,7 @@ name = "iaqualink"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
-    { name = "pyserde" },
+    { name = "mashumaro" },
 ]
 
 [package.optional-dependencies]
@@ -340,7 +322,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.0" },
-    { name = "pyserde" },
+    { name = "mashumaro" },
     { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0.2" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.5" },
 ]
@@ -501,6 +483,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mashumaro"
+version = "3.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/61/bdbd92fd7684f31fe18982f5a3b9a6ab672ae81a7f52b8aceecb56143430/mashumaro-3.21.tar.gz", hash = "sha256:9bc53b0c7dbed0be80e3ccc3efe1d621ce146b4b7a673ec41ba001a417f2c4b4", size = 195595, upload-time = "2026-05-07T16:32:35.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2e/d6a3410c11ac71e6031d7779d20700b43866e8166d56be86cf8bfcbb15de/mashumaro-3.21-py3-none-any.whl", hash = "sha256:b8e11e259a77d1c6e277c17909381448750956acee1eb79014b06704a10053d6", size = 95250, upload-time = "2026-05-07T16:32:34.341Z" },
 ]
 
 [[package]]
@@ -733,20 +727,6 @@ wheels = [
 ]
 
 [[package]]
-name = "plum-dispatch"
-version = "2.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "rich" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/84146ae5ff6c40d11357acdb36aafe3db7e104de01c1026d8e1b0ce3e7f1/plum_dispatch-2.9.0.tar.gz", hash = "sha256:fb45c5b2dd4dadd57def51bcf321dfa3a258df5c725f43adea7e7f6db3b79b52", size = 244502, upload-time = "2026-04-28T08:38:34.442Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl", hash = "sha256:5a516cdac5460343937a2b813562ac00b0eeac973ac023916e538610bdf34397", size = 45328, upload-time = "2026-04-28T08:38:33.022Z" },
-]
-
-[[package]]
 name = "pprintpp"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -791,23 +771,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
-]
-
-[[package]]
-name = "pyserde"
-version = "0.31.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "casefy" },
-    { name = "jinja2" },
-    { name = "plum-dispatch" },
-    { name = "typing-extensions" },
-    { name = "typing-inspect" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/cb/0a6f40a74003cb13845733300f9debdc19fe3d25e5e73e9aaf69ee4e1480/pyserde-0.31.2.tar.gz", hash = "sha256:3ec19498cbd7df40f187565482a40f97bcbd382eba9f7cf2cb29d9b39f6e8ac6", size = 518265, upload-time = "2026-04-01T08:07:16.446Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/11/7b3d9495a977fbf56cba768b6c0239a6f84c37e3409607ac3572a78f7bb3/pyserde-0.31.2-py3-none-any.whl", hash = "sha256:97c0d3af585c6c664ecabd421290a822dc3910d8d7b842c64fb1f01e6e93a00e", size = 49097, upload-time = "2026-04-01T08:07:17.745Z" },
 ]
 
 [[package]]
@@ -1053,19 +1016,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "typing-inspect"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Use`mashumaro` for all response deserialization.
- Adds fully typed response dataclasses for the root API (`LoginResponse`, `DevicesResponseElement`), iAqua home/devices screens (`HomeScreenItem` union, `DevicesScreenItem` union with `__pre_deserialize__` flattening), and eXO shadow state (`ExoSwcDevice` with typed `aux_*`/`sns_*` collection via `__pre_deserialize__`)
- Consolidates reauth retry logic into a shared `send_with_reauth_retry()` helper used by all three request sites (client systems discovery, iAqua session requests, eXO shadow requests); `_refresh_auth` uses `asyncio.Lock` to coalesce concurrent refreshes

## Test plan

- [ ] `uv run pytest` — 464 passed, 10 skipped
- [ ] `uv run pre-commit run --all-files` — ruff, ruff-format, mypy, uv-lock, check-yaml all pass
- [ ] Manual smoke test against a live system

🤖 Generated with [Claude Code](https://claude.com/claude-code)