### PR TITLE
fix: set a default 10 second request timeout

### DIFF
--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -14,6 +14,7 @@ from iaqualink.const import (
     AQUALINK_DEVICES_URL,
     AQUALINK_LOGIN_URL,
     AQUALINK_REFRESH_URL,
+    DEFAULT_REQUEST_TIMEOUT,
     KEEPALIVE_EXPIRY,
     RETRY_AFTER_MAX_DELAY,
     RETRY_BASE_DELAY,
@@ -138,6 +139,7 @@ class AqualinkClient:
 
         headers = AQUALINK_HTTP_HEADERS.copy()
         headers.update(kwargs.pop("headers", {}))
+        kwargs.setdefault("timeout", DEFAULT_REQUEST_TIMEOUT)
 
         LOGGER.debug("-> %s %s %s", method.upper(), url, kwargs)
         r = await client.request(method, url, headers=headers, **kwargs)

--- a/src/iaqualink/const.py
+++ b/src/iaqualink/const.py
@@ -7,6 +7,7 @@ AQUALINK_REFRESH_URL = "https://prod.zodiac-io.com/users/v1/refresh"
 AQUALINK_DEVICES_URL = "https://r-api.iaqualink.net/devices.json"
 
 KEEPALIVE_EXPIRY = 30
+DEFAULT_REQUEST_TIMEOUT = 10.0
 
 RETRY_MAX_ATTEMPTS = 5
 RETRY_BASE_DELAY = 1.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,6 +11,7 @@ import respx
 
 from iaqualink.client import AqualinkClient, AqualinkRetry
 from iaqualink.const import (
+    DEFAULT_REQUEST_TIMEOUT,
     RETRY_AFTER_MAX_DELAY,
     RETRY_MAX_ATTEMPTS,
 )
@@ -100,6 +101,19 @@ class TestAqualinkClient(TestBase):
         await self.client.login()
 
         assert self.client.logged is True
+        assert (
+            mock_request.call_args.kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT
+        )
+
+    @patch("httpx.AsyncClient.request")
+    async def test_send_request_preserves_explicit_timeout(
+        self, mock_request
+    ) -> None:
+        mock_request.return_value.status_code = 200
+
+        await self.client.send_request("https://example.com", timeout=3.0)
+
+        assert mock_request.call_args.kwargs["timeout"] == 3.0
 
     @patch("httpx.AsyncClient.request")
     async def test_login_failed(self, mock_request) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -101,6 +101,15 @@ class TestAqualinkClient(TestBase):
         await self.client.login()
 
         assert self.client.logged is True
+
+    @patch("httpx.AsyncClient.request")
+    async def test_send_request_uses_default_timeout(
+        self, mock_request
+    ) -> None:
+        mock_request.return_value.status_code = 200
+
+        await self.client.send_request("https://example.com")
+
         assert (
             mock_request.call_args.kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT
         )


### PR DESCRIPTION
Apply a shared 10 second default timeout to requests sent through
AqualinkClient.send_request() while preserving explicit per-call timeout
overrides. Add a dedicated regression test for the default-timeout behavior
and keep the explicit-timeout override check in place.

Validation: pytest; uv run pre-commit run --all-files.
