### PR TITLE
fix(iaqua): skip full update on invalid API responses after light commands

### DIFF
--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -130,6 +130,10 @@ class IaquaSystem(AqualinkSystem):
             LOGGER.warning(f"Status for system {self.serial} is Offline.")
             raise AqualinkSystemOfflineException
 
+        if data["home_screen"][2]["system_type"] == "":
+            LOGGER.debug("Skipping home screen update with empty system_type.")
+            return
+
         self.temp_unit = data["home_screen"][3]["temp_scale"]
 
         # Make the data a bit flatter.
@@ -143,11 +147,7 @@ class IaquaSystem(AqualinkSystem):
         for k, v in devices.items():
             if k in self.devices:
                 for dk, dv in v.items():
-                    # Don't allow empty updates through, except current temperature which can be empty depending on if it is in pool mode or spa mode
-                    if (dv != '') or (k == 'spa_temp') or (k == 'pool_temp'):
-                        self.devices[k].data[dk] = dv
-                    else:
-                        LOGGER.debug(f"Received empty update for home screen device {k}: {dk}, skipping")
+                    self.devices[k].data[dk] = dv
             else:
                 try:
                     self.devices[k] = IaquaDevice.from_data(self, v)
@@ -163,15 +163,20 @@ class IaquaSystem(AqualinkSystem):
             LOGGER.warning(f"Status for system {self.serial} is Offline.")
             raise AqualinkSystemOfflineException
 
+        for x in data["devices_screen"][3:]:
+            for attr in next(iter(x.values())):
+                if attr.get("state") == "NaN":
+                    LOGGER.debug(
+                        "Skipping devices screen update with NaN state."
+                    )
+                    return
+
         # Make the data a bit flatter.
         devices = {}
         for x in data["devices_screen"][3:]:
             aux = next(iter(x.keys()))
             attrs = {"aux": aux.replace("aux_", ""), "name": aux}
             for y in next(iter(x.values())):
-                if 'NaN' in y.values():
-                    LOGGER.debug("Received invalid devices screen state update, skipping")
-                    return
                 attrs.update(y)
             devices.update({aux: attrs})
 

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -143,7 +143,11 @@ class IaquaSystem(AqualinkSystem):
         for k, v in devices.items():
             if k in self.devices:
                 for dk, dv in v.items():
-                    self.devices[k].data[dk] = dv
+                    # Don't allow empty updates through, except current temperature which can be empty depending on if it is in pool mode or spa mode
+                    if (dv != '') or (k == 'spa_temp') or (k == 'pool_temp'):
+                        self.devices[k].data[dk] = dv
+                    else:
+                        LOGGER.debug(f"Received empty update for home screen device {k}: {dk}, skipping")
             else:
                 try:
                     self.devices[k] = IaquaDevice.from_data(self, v)
@@ -165,6 +169,9 @@ class IaquaSystem(AqualinkSystem):
             aux = next(iter(x.keys()))
             attrs = {"aux": aux.replace("aux_", ""), "name": aux}
             for y in next(iter(x.values())):
+                if 'NaN' in y.values():
+                    LOGGER.debug("Received invalid devices screen state update, skipping")
+                    return
                 attrs.update(y)
             devices.update({aux: attrs})
 

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -115,6 +115,9 @@ class TestIaquaSystem(TestBaseSystem):
         assert self.sut.devices == expected
 
     async def test_parse_devices_skipped_on_nan_state(self) -> None:
+        existing = MagicMock()
+        self.sut.devices["aux_existing"] = existing
+
         message = {
             "message": "",
             "devices_screen": [
@@ -136,9 +139,12 @@ class TestIaquaSystem(TestBaseSystem):
         response.json.return_value = message
 
         self.sut._parse_devices_response(response)
-        assert self.sut.devices == {}
+        assert self.sut.devices == {"aux_existing": existing}
 
     async def test_parse_home_skipped_on_empty_system_type(self) -> None:
+        existing = MagicMock()
+        self.sut.devices["pool_pump"] = existing
+
         message = {
             "message": "",
             "home_screen": [
@@ -151,7 +157,7 @@ class TestIaquaSystem(TestBaseSystem):
         response.json.return_value = message
 
         self.sut._parse_home_response(response)
-        assert self.sut.devices == {}
+        assert self.sut.devices == {"pool_pump": existing}
 
     @patch("httpx.AsyncClient.request")
     async def test_home_request(self, mock_request) -> None:

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -114,6 +114,45 @@ class TestIaquaSystem(TestBaseSystem):
         self.sut._parse_devices_response(response)
         assert self.sut.devices == expected
 
+    async def test_parse_devices_skipped_on_nan_state(self) -> None:
+        message = {
+            "message": "",
+            "devices_screen": [
+                {"status": "Online"},
+                {"response": ""},
+                {"group": "1"},
+                {
+                    "aux_1": [
+                        {"state": "NaN"},
+                        {"label": "AUX 1"},
+                        {"icon": "aux_NaN_NaN.png"},
+                        {"type": "NaN"},
+                        {"subtype": "NaN"},
+                    ]
+                },
+            ],
+        }
+        response = MagicMock()
+        response.json.return_value = message
+
+        self.sut._parse_devices_response(response)
+        assert self.sut.devices == {}
+
+    async def test_parse_home_skipped_on_empty_system_type(self) -> None:
+        message = {
+            "message": "",
+            "home_screen": [
+                {"status": "Online"},
+                {"response": ""},
+                {"system_type": ""},
+            ],
+        }
+        response = MagicMock()
+        response.json.return_value = message
+
+        self.sut._parse_home_response(response)
+        assert self.sut.devices == {}
+
     @patch("httpx.AsyncClient.request")
     async def test_home_request(self, mock_request) -> None:
         mock_request.return_value.status_code = 200


### PR DESCRIPTION
## Summary

Supersedes #116 — credit to @anderjoshai for identifying the issue and providing the initial fix.

The Jandy API sends a garbage state after toggling a light. The home screen arrives with `system_type == ""` and the devices screen contains aux entries with `state: "NaN"`. Without handling these, the corrupted state causes subsequent commands to fail for ~30 seconds with errors like `'NaN' is not a valid Aqualink state` or `ValueError: could not convert string to float: ''` (see https://github.com/home-assistant/core/issues/156960).

Changes from the original PR:
- Replace per-field empty-value filtering in `_parse_home_response` with a single early return when `system_type == ""`
- Replace inline `'NaN' in y.values()` check in `_parse_devices_response` with a dedicated pre-pass that returns early when any aux device has `state == "NaN"`
- Add tests for both skip paths

## Test plan

- [ ] `test_parse_devices_skipped_on_nan_state` — devices screen with NaN state leaves `self.devices` unchanged
- [ ] `test_parse_home_skipped_on_empty_system_type` — home screen with empty `system_type` leaves `self.devices` unchanged
- [ ] Full test suite passes (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)