### PR TITLE
chore(release): mark RC GitHub Releases as pre-release, finals as latest

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -91,8 +91,9 @@ Notable commits:
   fix: update iAqua session URL to v2 r-api endpoint
   ... (only feat/fix/breaking — skip build/chore/ci/docs bumps)
 
-Note: RC tags are published to the real PyPI (pre-release status).
-      pip install iaqualink won't pick them up; pip install --pre will.
+Note: RC tags create a pre-release GitHub Release (not marked as latest) and publish
+      to the real PyPI with pre-release status. pip install iaqualink won't pick them
+      up; pip install --pre will. Final releases are marked as the latest GitHub Release.
 
 Shall I create and push tag <proposed-tag>? (yes/no)
 ```
@@ -114,8 +115,8 @@ Tell the user:
 - The tag that was created and pushed
 - That the GitHub Actions release workflow has been triggered
 - The GitHub Actions URL to monitor progress: `https://github.com/flz/iaqualink-py/actions`
-- For RCs: this publishes to the real PyPI as a pre-release (`pip install --pre iaqualink` to install)
-- For final releases: this publishes to PyPI as a stable release
+- For RCs: the GitHub Release is marked as **pre-release** (not latest); PyPI publishes as a pre-release (`pip install --pre iaqualink` to install)
+- For final releases: the GitHub Release is marked as **latest**; PyPI publishes as a stable release
 
 ## Error Handling
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Detect release type
+        id: type
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "$TAG" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "make_latest=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+          prerelease: ${{ steps.type.outputs.prerelease }}
+          make_latest: ${{ steps.type.outputs.make_latest }}
 
   pypi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `Detect release type` step in `release.yaml` that checks whether the pushed tag contains a `-` (e.g. `-rc.1`) to determine pre-release vs final
- RC tags: GitHub Release is marked as `prerelease=true` and `make_latest=false`
- Final tags: GitHub Release is marked as `prerelease=false` and `make_latest=true`
- Updates the `/release` command docs to reflect the GitHub Release pre-release/latest behavior

## Test plan

- [ ] Push an RC tag (e.g. `v0.8.0-rc.1`) and verify the GitHub Release is marked as pre-release and not latest
- [ ] Push a final tag (e.g. `v0.8.0`) and verify the GitHub Release is marked as latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)