### PR TITLE
feat(system): add UnsupportedSystem stub for unknown device types

### DIFF
--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -9,7 +9,8 @@ AqualinkException (base)
 ├── AqualinkInvalidParameterException
 ├── AqualinkServiceException
 │   ├── AqualinkServiceUnauthorizedException
-│   └── AqualinkSystemOfflineException
+│   ├── AqualinkSystemOfflineException
+│   └── AqualinkSystemUnsupportedException (deprecated)
 ├── AqualinkOperationNotSupportedException
 └── AqualinkDeviceNotSupported
 ```
@@ -33,6 +34,14 @@ AqualinkException (base)
 ## AqualinkSystemOfflineException
 
 ::: iaqualink.exception.AqualinkSystemOfflineException
+
+## AqualinkSystemUnsupportedException
+
+!!! warning "Deprecated"
+    This exception is no longer raised. Unknown device types now return
+    [`UnsupportedSystem`](system.md#unsupportedsystem) instead.
+    `AqualinkSystemUnsupportedException` will be removed in a future release.
+    Importing it emits a `DeprecationWarning`.
 
 ## AqualinkOperationNotSupportedException
 

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -9,8 +9,7 @@ AqualinkException (base)
 ├── AqualinkInvalidParameterException
 ├── AqualinkServiceException
 │   ├── AqualinkServiceUnauthorizedException
-│   ├── AqualinkSystemOfflineException
-│   └── AqualinkSystemUnsupportedException
+│   └── AqualinkSystemOfflineException
 ├── AqualinkOperationNotSupportedException
 └── AqualinkDeviceNotSupported
 ```
@@ -34,10 +33,6 @@ AqualinkException (base)
 ## AqualinkSystemOfflineException
 
 ::: iaqualink.exception.AqualinkSystemOfflineException
-
-## AqualinkSystemUnsupportedException
-
-::: iaqualink.exception.AqualinkSystemUnsupportedException
 
 ## AqualinkOperationNotSupportedException
 

--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -92,6 +92,22 @@ Get all devices associated with this system.
 **Raises:**
 - `AqualinkServiceException` - Service error occurred
 
+## UnsupportedSystem
+
+::: iaqualink.system.UnsupportedSystem
+
+Returned by `AqualinkSystem.from_data()` when the `device_type` is not recognised.
+`get_devices()` returns `{}` and `update()` is a no-op. `supported` is `False`.
+
+```python
+from iaqualink import UnsupportedSystem
+
+systems = await client.get_systems()
+for system in systems.values():
+    if not system.supported:
+        print(f"{system.name} uses an unrecognised device type")
+```
+
 ## System Types
 
 The library includes two system implementations:

--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -100,7 +100,7 @@ Returned by `AqualinkSystem.from_data()` when the `device_type` is not recognise
 `get_devices()` returns `{}` and `update()` is a no-op. `supported` is `False`.
 
 ```python
-from iaqualink import UnsupportedSystem
+from iaqualink.system import UnsupportedSystem
 
 systems = await client.get_systems()
 for system in systems.values():

--- a/src/iaqualink/__init__.py
+++ b/src/iaqualink/__init__.py
@@ -1,3 +1,0 @@
-from iaqualink.system import UnsupportedSystem
-
-__all__ = ["UnsupportedSystem"]

--- a/src/iaqualink/__init__.py
+++ b/src/iaqualink/__init__.py
@@ -1,0 +1,3 @@
+from iaqualink.system import UnsupportedSystem
+
+__all__ = ["UnsupportedSystem"]

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -21,7 +21,7 @@ from iaqualink.exception import (
     AqualinkServiceUnauthorizedException,
     AqualinkSystemOfflineException,
 )
-from iaqualink.system import AqualinkSystem, UnsupportedSystem
+from iaqualink.system import AqualinkSystem
 from iaqualink.version import __version__
 
 app = typer.Typer(
@@ -233,7 +233,7 @@ def _sorted_devices(
 
 def _format_system_line(system: AqualinkSystem) -> str:
     system_type = system.data.get("device_type", "unknown")
-    suffix = " (unsupported)" if isinstance(system, UnsupportedSystem) else ""
+    suffix = " (unsupported)" if not system.supported else ""
     return f"{system.name} ({system.serial}) [{system_type}]{suffix}"
 
 
@@ -256,7 +256,7 @@ def _render_device_tree(
 
         devices = _sorted_devices(devices_by_system.get(serial, {}))
         if not devices:
-            if isinstance(system, UnsupportedSystem):
+            if not system.supported:
                 lines.append(f"{child_indent}└── System type not supported")
             else:
                 lines.append(f"{child_indent}└── No devices found")

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -21,7 +21,7 @@ from iaqualink.exception import (
     AqualinkServiceUnauthorizedException,
     AqualinkSystemOfflineException,
 )
-from iaqualink.system import AqualinkSystem
+from iaqualink.system import AqualinkSystem, UnsupportedSystem
 from iaqualink.version import __version__
 
 app = typer.Typer(
@@ -233,7 +233,8 @@ def _sorted_devices(
 
 def _format_system_line(system: AqualinkSystem) -> str:
     system_type = system.data.get("device_type", "unknown")
-    return f"{system.name} ({system.serial}) [{system_type}]"
+    suffix = " (unsupported)" if isinstance(system, UnsupportedSystem) else ""
+    return f"{system.name} ({system.serial}) [{system_type}]{suffix}"
 
 
 def _format_device_line(device_name: str, device: AqualinkDevice) -> str:
@@ -255,7 +256,10 @@ def _render_device_tree(
 
         devices = _sorted_devices(devices_by_system.get(serial, {}))
         if not devices:
-            lines.append(f"{child_indent}└── No devices found")
+            if isinstance(system, UnsupportedSystem):
+                lines.append(f"{child_indent}└── System type not supported")
+            else:
+                lines.append(f"{child_indent}└── No devices found")
             continue
 
         for device_index, (device_name, device) in enumerate(devices):

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import importlib
 import logging
 from dataclasses import asdict, dataclass
@@ -26,7 +25,6 @@ from iaqualink.exception import (
     AqualinkServiceException,
     AqualinkServiceThrottledException,
     AqualinkServiceUnauthorizedException,
-    AqualinkSystemUnsupportedException,
 )
 from iaqualink.reauth import send_with_reauth_retry
 from iaqualink.system import AqualinkSystem
@@ -353,9 +351,5 @@ class AqualinkClient:
 
         data = r.json()
 
-        systems = []
-        for x in data:
-            with contextlib.suppress(AqualinkSystemUnsupportedException):
-                systems += [AqualinkSystem.from_data(self, x)]
-
-        return {x.serial: x for x in systems if x is not None}
+        systems = [AqualinkSystem.from_data(self, x) for x in data]
+        return {x.serial: x for x in systems}

--- a/src/iaqualink/exception.py
+++ b/src/iaqualink/exception.py
@@ -25,10 +25,6 @@ class AqualinkServiceThrottledException(AqualinkServiceException):
     """Exception raised when the service returns 429 Too Many Requests."""
 
 
-class AqualinkSystemUnsupportedException(AqualinkServiceException):
-    """Deprecated: no longer raised. Unknown systems return UnsupportedSystem."""
-
-
 class AqualinkOperationNotSupportedException(AqualinkException):
     """Exception raised when trying to issue an unsupported operation."""
 

--- a/src/iaqualink/exception.py
+++ b/src/iaqualink/exception.py
@@ -26,7 +26,7 @@ class AqualinkServiceThrottledException(AqualinkServiceException):
 
 
 class AqualinkSystemUnsupportedException(AqualinkServiceException):
-    """Exception raised when a system isn't supported by the library."""
+    """Deprecated: no longer raised. Unknown systems return UnsupportedSystem."""
 
 
 class AqualinkOperationNotSupportedException(AqualinkException):

--- a/src/iaqualink/exception.py
+++ b/src/iaqualink/exception.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 
 class AqualinkException(Exception):  # noqa: N818
     """Base exception for iAqualink library."""
@@ -34,10 +36,10 @@ class AqualinkDeviceNotSupported(AqualinkException):
 
 
 class _AqualinkSystemUnsupportedDeprecated(AqualinkServiceException):
-    """Deprecated stub; see AqualinkSystemUnsupportedException."""
+    """Backward-compat stub; use iaqualink.system.UnsupportedSystem instead."""
 
 
-def __getattr__(name: str) -> type[_AqualinkSystemUnsupportedDeprecated]:
+def __getattr__(name: str) -> Any:
     if name == "AqualinkSystemUnsupportedException":
         import warnings
 

--- a/src/iaqualink/exception.py
+++ b/src/iaqualink/exception.py
@@ -31,3 +31,22 @@ class AqualinkOperationNotSupportedException(AqualinkException):
 
 class AqualinkDeviceNotSupported(AqualinkException):
     """Exception raised when a device isn't known-unsupported."""
+
+
+class _AqualinkSystemUnsupportedDeprecated(AqualinkServiceException):
+    """Deprecated stub; see AqualinkSystemUnsupportedException."""
+
+
+def __getattr__(name: str) -> type[_AqualinkSystemUnsupportedDeprecated]:
+    if name == "AqualinkSystemUnsupportedException":
+        import warnings
+
+        warnings.warn(
+            "AqualinkSystemUnsupportedException is deprecated and will be removed "
+            "in a future release. Unknown device types now return "
+            "iaqualink.system.UnsupportedSystem instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _AqualinkSystemUnsupportedDeprecated
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -82,7 +82,7 @@ class AqualinkSystem:
 
 class UnsupportedSystem(AqualinkSystem):
     async def update(self) -> None:
-        pass
+        LOGGER.debug("Skipping update for unsupported system %r", self.serial)
 
     async def get_devices(self) -> dict[str, AqualinkDevice]:
         return {}

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -60,8 +60,9 @@ class AqualinkSystem:
     ) -> AqualinkSystem:
         if data["device_type"] not in cls.subclasses:
             LOGGER.warning(
-                f"{data['device_type']} is not a supported system type."
+                "%s is not a supported system type.", data["device_type"]
             )
+            # UnsupportedSystem is defined after this class in this module.
             return UnsupportedSystem(aqualink, data)
 
         return cls.subclasses[data["device_type"]](aqualink, data)

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -50,6 +50,10 @@ class AqualinkSystem:
     def serial(self) -> str:
         return self.data["serial_number"]
 
+    @property
+    def supported(self) -> bool:
+        return True
+
     @classmethod
     def from_data(
         cls, aqualink: AqualinkClient, data: Payload
@@ -81,6 +85,10 @@ class AqualinkSystem:
 
 
 class UnsupportedSystem(AqualinkSystem):
+    @property
+    def supported(self) -> bool:
+        return False
+
     async def update(self) -> None:
         LOGGER.debug("Skipping update for unsupported system %r", self.serial)
 

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -4,7 +4,6 @@ from collections.abc import Awaitable, Callable
 import logging
 from typing import TYPE_CHECKING, ClassVar
 
-from iaqualink.exception import AqualinkSystemUnsupportedException
 from iaqualink.reauth import send_with_reauth_retry
 
 if TYPE_CHECKING:
@@ -56,9 +55,10 @@ class AqualinkSystem:
         cls, aqualink: AqualinkClient, data: Payload
     ) -> AqualinkSystem:
         if data["device_type"] not in cls.subclasses:
-            m = f"{data['device_type']} is not a supported system type."
-            LOGGER.warning(m)
-            raise AqualinkSystemUnsupportedException(m)
+            LOGGER.warning(
+                f"{data['device_type']} is not a supported system type."
+            )
+            return UnsupportedSystem(aqualink, data)
 
         return cls.subclasses[data["device_type"]](aqualink, data)
 
@@ -78,3 +78,11 @@ class AqualinkSystem:
 
     async def update(self) -> None:
         raise NotImplementedError
+
+
+class UnsupportedSystem(AqualinkSystem):
+    async def update(self) -> None:
+        pass
+
+    async def get_devices(self) -> dict[str, AqualinkDevice]:
+        return {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,11 +4,13 @@ import importlib
 import json
 import stat
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from typer.testing import CliRunner
 
 from iaqualink.client import AqualinkAuthState
+from iaqualink.system import UnsupportedSystem
 
 cli_module = importlib.import_module("iaqualink.cli.app")
 
@@ -150,3 +152,50 @@ def test_list_devices_reports_ambiguous_system_name(tmp_path: Path) -> None:
         "System name 'Backyard' matches multiple systems. "
         "Use --system with the serial number instead."
     ) in result.stderr
+
+
+def _make_unsupported_system(
+    serial: str = "SN001", name: str = "Pool"
+) -> UnsupportedSystem:
+    data = {"serial_number": serial, "name": name, "device_type": "foo"}
+    return UnsupportedSystem(MagicMock(), data)
+
+
+def test_format_system_line_unsupported() -> None:
+    system = _make_unsupported_system()
+    line = cli_module._format_system_line(system)
+    assert "(unsupported)" in line
+    assert "foo" in line
+
+
+def test_render_device_tree_unsupported_system() -> None:
+    system = _make_unsupported_system(serial="SN001", name="Pool")
+    output = cli_module._render_device_tree(
+        [("SN001", system)],
+        {"SN001": {}},
+    )
+    assert "System type not supported" in output
+    assert "No devices found" not in output
+
+
+def test_list_systems_shows_unsupported_note(tmp_path: Path) -> None:
+    cookie_jar = tmp_path / "session.json"
+    FakeClient.systems_factory = staticmethod(
+        lambda: {"SN001": _make_unsupported_system()}
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "list-systems",
+            "--username",
+            "user@example.com",
+            "--password",
+            "secret",
+            "--cookie-jar",
+            str(cookie_jar),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "(unsupported)" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,8 @@ app = cli_module.app
 
 
 class FakeSystem:
+    supported = True
+
     def __init__(self, serial: str, name: str) -> None:
         self.serial = serial
         self.name = name

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,6 @@ from iaqualink.client import (
     AqualinkClient,
     AqualinkRetry,
 )
-from iaqualink.system import UnsupportedSystem
 from iaqualink.const import (
     DEFAULT_REQUEST_TIMEOUT,
     RETRY_AFTER_MAX_DELAY,
@@ -25,6 +24,7 @@ from iaqualink.exception import (
     AqualinkServiceThrottledException,
     AqualinkServiceUnauthorizedException,
 )
+from iaqualink.system import UnsupportedSystem
 
 from .base import TestBase
 from .common import async_noop, async_raises

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,7 @@ from iaqualink.client import (
     AqualinkClient,
     AqualinkRetry,
 )
+from iaqualink.system import UnsupportedSystem
 from iaqualink.const import (
     DEFAULT_REQUEST_TIMEOUT,
     RETRY_AFTER_MAX_DELAY,
@@ -287,7 +288,8 @@ class TestAqualinkClient(TestBase):
         ]
 
         systems = await self.client.get_systems()
-        assert len(systems) == 0
+        assert len(systems) == 1
+        assert isinstance(next(iter(systems.values())), UnsupportedSystem)
 
     @patch("httpx.AsyncClient.request")
     async def test_systems_request(self, mock_request) -> None:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -34,6 +34,12 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
         r = AqualinkSystem.from_data(aqualink, data)
         assert r is not None
 
+    def test_supported_true_for_known_system(self) -> None:
+        aqualink = MagicMock()
+        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "iaqua"}
+        r = AqualinkSystem.from_data(aqualink, data)
+        assert r.supported is True
+
     async def test_get_devices_needs_update(self) -> None:
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "fake"}
         aqualink = AqualinkClient("user", "pass")
@@ -82,6 +88,9 @@ class TestUnsupportedSystem(unittest.IsolatedAsyncioTestCase):
         with self.assertLogs("iaqualink", level=logging.WARNING) as cm:
             AqualinkSystem.from_data(self.aqualink, self.data)
         assert any("unknown_type" in line for line in cm.output)
+
+    def test_supported_false(self) -> None:
+        assert self.system.supported is False
 
     async def test_update_is_noop(self) -> None:
         await self.system.update()

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -34,12 +34,6 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
         r = AqualinkSystem.from_data(aqualink, data)
         assert r is not None
 
-    def test_from_data_unsupported(self) -> None:
-        aqualink = MagicMock()
-        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "foo"}
-        r = AqualinkSystem.from_data(aqualink, data)
-        assert isinstance(r, UnsupportedSystem)
-
     async def test_get_devices_needs_update(self) -> None:
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "fake"}
         aqualink = AqualinkClient("user", "pass")

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import logging
 import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from iaqualink.client import AqualinkClient
-from iaqualink.exception import AqualinkSystemUnsupportedException
-from iaqualink.system import AqualinkSystem
+from iaqualink.system import AqualinkSystem, UnsupportedSystem
 
 
 class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
@@ -37,8 +37,8 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
     def test_from_data_unsupported(self) -> None:
         aqualink = MagicMock()
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "foo"}
-        with pytest.raises(AqualinkSystemUnsupportedException):
-            AqualinkSystem.from_data(aqualink, data)
+        r = AqualinkSystem.from_data(aqualink, data)
+        assert isinstance(r, UnsupportedSystem)
 
     async def test_get_devices_needs_update(self) -> None:
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "fake"}
@@ -67,3 +67,31 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
 
         with pytest.raises(NotImplementedError):
             await system.update()
+
+
+class TestUnsupportedSystem(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.aqualink = MagicMock()
+        self.data = {
+            "id": 1,
+            "serial_number": "ABCDEFG",
+            "device_type": "unknown_type",
+            "name": "pool",
+        }
+        self.system = UnsupportedSystem(self.aqualink, self.data)
+
+    def test_from_data_returns_unsupported_system(self) -> None:
+        r = AqualinkSystem.from_data(self.aqualink, self.data)
+        assert isinstance(r, UnsupportedSystem)
+
+    def test_from_data_logs_warning(self) -> None:
+        with self.assertLogs("iaqualink", level=logging.WARNING) as cm:
+            AqualinkSystem.from_data(self.aqualink, self.data)
+        assert any("unknown_type" in line for line in cm.output)
+
+    async def test_update_is_noop(self) -> None:
+        await self.system.update()
+
+    async def test_get_devices_returns_empty(self) -> None:
+        devices = await self.system.get_devices()
+        assert devices == {}

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -34,7 +34,6 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
         r = AqualinkSystem.from_data(aqualink, data)
         assert r is not None
 
-    # Counterpart: TestUnsupportedSystem.test_supported_false covers supported=False.
     def test_supported_true_for_known_system(self) -> None:
         aqualink = MagicMock()
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "iaqua"}

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -34,6 +34,7 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
         r = AqualinkSystem.from_data(aqualink, data)
         assert r is not None
 
+    # Counterpart: TestUnsupportedSystem.test_supported_false covers supported=False.
     def test_supported_true_for_known_system(self) -> None:
         aqualink = MagicMock()
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "iaqua"}


### PR DESCRIPTION
## Summary

- Unknown `device_type` values now return an `UnsupportedSystem` instance instead of raising `AqualinkSystemUnsupportedException`
- `UnsupportedSystem.get_devices()` returns `{}` and `update()` is a no-op; warning log is preserved
- `get_systems()` in client simplified — no longer needs `contextlib.suppress` wrapper

## Test plan

- [ ] `TestUnsupportedSystem` — 4 new tests: `from_data` returns correct type, warning is logged, `update()` is no-op, `get_devices()` returns `{}`
- [ ] `test_from_data_unsupported` — updated to assert `UnsupportedSystem` returned (not exception raised)
- [ ] `test_systems_request_system_unsupported` — updated to assert 1 system returned, is `UnsupportedSystem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)