### PR TITLE
refactor(system)!: replace online bool property with SystemStatus enum

### DIFF
--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -23,7 +23,9 @@ async with AqualinkClient(username, password) as client:
 await system.update()
 
 # Check if online
-if system.online:
+from iaqualink.system import SystemStatus
+
+if system.status is SystemStatus.ONLINE:
     print(f"System {system.name} is online")
 ```
 
@@ -51,11 +53,17 @@ Unique serial number identifying the system.
 
 **Type:** `str`
 
-### online
+### status
 
-Whether the system is currently online.
+Current connectivity state of the system.
 
-**Type:** `bool`
+**Type:** `SystemStatus`
+
+One of:
+
+- `SystemStatus.ONLINE` — last update succeeded
+- `SystemStatus.OFFLINE` — system is definitively offline
+- `SystemStatus.UNKNOWN` — never successfully fetched, or last update raised a service error
 
 ### data
 

--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -63,7 +63,8 @@ One of:
 
 - `SystemStatus.ONLINE` — last update succeeded
 - `SystemStatus.OFFLINE` — system is definitively offline
-- `SystemStatus.UNKNOWN` — never successfully fetched, or last update raised a service error
+- `SystemStatus.UNKNOWN` — initial state, or last update was rate-limited
+- `SystemStatus.ERROR` — last update failed with a non-recoverable service error
 
 ### data
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -80,7 +80,9 @@ if pool_thermostat:
 await system.update()
 
 # Check if system is online
-if system.online:
+from iaqualink.system import SystemStatus
+
+if system.status is SystemStatus.ONLINE:
     print(f"System {system.name} is online")
 
     # Get all temperature readings

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -90,6 +90,7 @@ Generate a comprehensive status report:
 ```python
 import asyncio
 from iaqualink import AqualinkClient
+from iaqualink.system import SystemStatus
 
 async def system_status_report():
     async with AqualinkClient('user@example.com', 'password') as client:
@@ -100,10 +101,10 @@ async def system_status_report():
             print(f"System: {system.name}")
             print(f"Serial: {serial}")
             print(f"Type: {system.data.get('device_type')}")
-            print(f"Online: {system.online}")
+            print(f"Status: {system.status}")
             print(f"{'='*60}")
 
-            if not system.online:
+            if system.status is not SystemStatus.ONLINE:
                 print("System is offline")
                 continue
 
@@ -194,6 +195,7 @@ Manage multiple pool systems:
 ```python
 import asyncio
 from iaqualink import AqualinkClient
+from iaqualink.system import SystemStatus
 
 async def manage_multiple_systems():
     async with AqualinkClient('user@example.com', 'password') as client:
@@ -208,7 +210,7 @@ async def manage_multiple_systems():
         for serial, system in systems.items():
             print(f"\nSystem: {system.name}")
 
-            if not system.online:
+            if system.status is not SystemStatus.ONLINE:
                 print("  Status: OFFLINE")
                 continue
 

--- a/docs/guide/systems.md
+++ b/docs/guide/systems.md
@@ -49,7 +49,7 @@ system.name          # User-friendly name
 system.serial        # Unique serial number
 
 # System status
-system.status        # SystemStatus enum: ONLINE, OFFLINE, or UNKNOWN
+system.status        # SystemStatus enum: ONLINE, OFFLINE, UNKNOWN, or ERROR
 system.data          # Raw system data from API
 
 # Last update time

--- a/docs/guide/systems.md
+++ b/docs/guide/systems.md
@@ -49,7 +49,7 @@ system.name          # User-friendly name
 system.serial        # Unique serial number
 
 # System status
-system.online        # Boolean indicating if system is online
+system.status        # SystemStatus enum: ONLINE, OFFLINE, or UNKNOWN
 system.data          # Raw system data from API
 
 # Last update time

--- a/src/iaqualink/__init__.py
+++ b/src/iaqualink/__init__.py
@@ -1,3 +1,0 @@
-from iaqualink.system import SystemStatus
-
-__all__ = ["SystemStatus"]

--- a/src/iaqualink/__init__.py
+++ b/src/iaqualink/__init__.py
@@ -1,0 +1,3 @@
+from iaqualink.system import SystemStatus
+
+__all__ = ["SystemStatus"]

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -22,6 +22,7 @@ class SystemStatus(enum.StrEnum):
     UNKNOWN = "unknown"
     OFFLINE = "offline"
     ONLINE = "online"
+    ERROR = "error"
 
 
 class AqualinkSystem:

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+import enum
 import logging
 from typing import TYPE_CHECKING, ClassVar
 
@@ -17,6 +18,12 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("iaqualink")
 
 
+class SystemStatus(enum.Enum):
+    UNKNOWN = "unknown"
+    OFFLINE = "offline"
+    ONLINE = "online"
+
+
 class AqualinkSystem:
     subclasses: ClassVar[dict[str, type[AqualinkSystem]]] = {}
 
@@ -24,10 +31,7 @@ class AqualinkSystem:
         self.aqualink = aqualink
         self.data = data
         self.devices: dict[str, AqualinkDevice] = {}
-
-        # Semantics here are somewhat odd.
-        # True/False are obvious, None means "unknown".
-        self.online: bool | None = None
+        self.status: SystemStatus = SystemStatus.UNKNOWN
 
     @classmethod
     def __init_subclass__(cls) -> None:

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 import enum
 import logging
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, ClassVar
 
 from iaqualink.reauth import send_with_reauth_retry
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("iaqualink")
 
 
-class SystemStatus(enum.Enum):
+class SystemStatus(enum.StrEnum):
     UNKNOWN = "unknown"
     OFFLINE = "offline"
     ONLINE = "online"

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -8,7 +8,7 @@ from iaqualink.exception import (
     AqualinkServiceThrottledException,
     AqualinkSystemOfflineException,
 )
-from iaqualink.system import AqualinkSystem
+from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.exo.device import ExoDevice
 
 if TYPE_CHECKING:
@@ -62,16 +62,16 @@ class ExoSystem(AqualinkSystem):
         except AqualinkServiceThrottledException:
             raise
         except AqualinkServiceException:
-            self.online = None
+            self.status = SystemStatus.UNKNOWN
             raise
 
         try:
             self._parse_shadow_response(r)
         except AqualinkSystemOfflineException:
-            self.online = False
+            self.status = SystemStatus.OFFLINE
             raise
 
-        self.online = True
+        self.status = SystemStatus.ONLINE
 
     def _parse_shadow_response(self, response: httpx.Response) -> None:
         data = response.json()

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -60,9 +60,10 @@ class ExoSystem(AqualinkSystem):
         try:
             r = await self.send_reported_state_request()
         except AqualinkServiceThrottledException:
+            self.status = SystemStatus.UNKNOWN
             raise
         except AqualinkServiceException:
-            self.status = SystemStatus.UNKNOWN
+            self.status = SystemStatus.ERROR
             raise
 
         try:

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -10,7 +10,7 @@ from iaqualink.exception import (
     AqualinkServiceThrottledException,
     AqualinkSystemOfflineException,
 )
-from iaqualink.system import AqualinkSystem
+from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import IaquaDevice
 
 if TYPE_CHECKING:
@@ -97,17 +97,17 @@ class IaquaSystem(AqualinkSystem):
         except AqualinkServiceThrottledException:
             raise
         except AqualinkServiceException:
-            self.online = None
+            self.status = SystemStatus.UNKNOWN
             raise
 
         try:
             self._parse_home_response(r1)
             self._parse_devices_response(r2)
         except AqualinkSystemOfflineException:
-            self.online = False
+            self.status = SystemStatus.OFFLINE
             raise
 
-        self.online = True
+        self.status = SystemStatus.ONLINE
 
     def _parse_home_response(self, response: httpx.Response) -> None:
         data = response.json()

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -95,9 +95,10 @@ class IaquaSystem(AqualinkSystem):
             r1 = await self._send_home_screen_request()
             r2 = await self._send_devices_screen_request()
         except AqualinkServiceThrottledException:
+            self.status = SystemStatus.UNKNOWN
             raise
         except AqualinkServiceException:
-            self.status = SystemStatus.UNKNOWN
+            self.status = SystemStatus.ERROR
             raise
 
         try:

--- a/tests/base_test_system.py
+++ b/tests/base_test_system.py
@@ -8,6 +8,7 @@ from iaqualink.exception import (
     AqualinkServiceException,
     AqualinkServiceUnauthorizedException,
 )
+from iaqualink.system import SystemStatus
 
 from .base import TestBase, dotstar, resp_200
 
@@ -30,6 +31,7 @@ class TestBaseSystem(TestBase):
         respx_mock.route(dotstar).mock(resp_200)
         await self.sut.update()
         assert len(respx_mock.calls) > 0
+        assert self.sut.status is SystemStatus.ONLINE
         self.respx_calls = copy.copy(respx_mock.calls)
 
     @respx.mock

--- a/tests/systems/exo/test_system.py
+++ b/tests/systems/exo/test_system.py
@@ -11,7 +11,7 @@ from iaqualink.exception import (
     AqualinkServiceUnauthorizedException,
     AqualinkSystemOfflineException,
 )
-from iaqualink.system import AqualinkSystem
+from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.exo.device import (
     ExoAttributeSwitch,
     ExoAuxSwitch,
@@ -190,7 +190,7 @@ class TestExoSystem(unittest.IsolatedAsyncioTestCase):
         r.send_reported_state_request = async_noop
         r._parse_shadow_response = MagicMock()
         await r.update()
-        assert r.online is True
+        assert r.status is SystemStatus.ONLINE
 
     async def test_update_service_exception(self):
         aqualink = MagicMock()
@@ -199,7 +199,7 @@ class TestExoSystem(unittest.IsolatedAsyncioTestCase):
         r.send_reported_state_request = async_raises(AqualinkServiceException)
         with pytest.raises(AqualinkServiceException):
             await r.update()
-        assert r.online is None
+        assert r.status is SystemStatus.UNKNOWN
 
     async def test_update_offline(self):
         aqualink = MagicMock()
@@ -213,7 +213,7 @@ class TestExoSystem(unittest.IsolatedAsyncioTestCase):
 
         with pytest.raises(AqualinkSystemOfflineException):
             await r.update()
-        assert r.online is False
+        assert r.status is SystemStatus.OFFLINE
 
     def test_parse_devices_good(self):
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "exo"}

--- a/tests/systems/exo/test_system.py
+++ b/tests/systems/exo/test_system.py
@@ -8,6 +8,7 @@ import pytest
 from iaqualink.client import AqualinkClient
 from iaqualink.exception import (
     AqualinkServiceException,
+    AqualinkServiceThrottledException,
     AqualinkServiceUnauthorizedException,
     AqualinkSystemOfflineException,
 )
@@ -198,6 +199,17 @@ class TestExoSystem(unittest.IsolatedAsyncioTestCase):
         r = AqualinkSystem.from_data(aqualink, data)
         r.send_reported_state_request = async_raises(AqualinkServiceException)
         with pytest.raises(AqualinkServiceException):
+            await r.update()
+        assert r.status is SystemStatus.ERROR
+
+    async def test_update_throttled(self):
+        aqualink = MagicMock()
+        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "exo"}
+        r = AqualinkSystem.from_data(aqualink, data)
+        r.send_reported_state_request = async_raises(
+            AqualinkServiceThrottledException
+        )
+        with pytest.raises(AqualinkServiceThrottledException):
             await r.update()
         assert r.status is SystemStatus.UNKNOWN
 

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -10,7 +10,7 @@ from iaqualink.exception import (
     AqualinkServiceUnauthorizedException,
     AqualinkSystemOfflineException,
 )
-from iaqualink.system import AqualinkSystem
+from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import IaquaAuxSwitch
 from iaqualink.systems.iaqua.system import IAQUA_SESSION_URL, IaquaSystem
 
@@ -50,7 +50,7 @@ class TestIaquaSystem(TestBaseSystem):
             mock_parse.side_effect = AqualinkSystemOfflineException
             with pytest.raises(AqualinkSystemOfflineException):
                 await super().test_update_success()
-            assert self.sut.online is False
+            assert self.sut.status is SystemStatus.OFFLINE
 
     async def test_get_devices_needs_update(self) -> None:
         with (

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -7,6 +7,7 @@ import pytest
 
 from iaqualink.const import AQUALINK_API_KEY
 from iaqualink.exception import (
+    AqualinkServiceThrottledException,
     AqualinkServiceUnauthorizedException,
     AqualinkSystemOfflineException,
 )
@@ -51,6 +52,17 @@ class TestIaquaSystem(TestBaseSystem):
             with pytest.raises(AqualinkSystemOfflineException):
                 await super().test_update_success()
             assert self.sut.status is SystemStatus.OFFLINE
+
+    async def test_update_service_exception(self) -> None:
+        await super().test_update_service_exception()
+        assert self.sut.status is SystemStatus.ERROR
+
+    async def test_update_throttled(self) -> None:
+        with patch.object(self.sut, "_send_home_screen_request") as mock_req:
+            mock_req.side_effect = AqualinkServiceThrottledException
+            with pytest.raises(AqualinkServiceThrottledException):
+                await self.sut.update()
+        assert self.sut.status is SystemStatus.UNKNOWN
 
     async def test_get_devices_needs_update(self) -> None:
         with (


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

`AqualinkSystem.online: bool | None` is removed. Replace with `AqualinkSystem.status: SystemStatus`.

```python
# Before
if system.online:        # True
if not system.online:    # False or None

# After
from iaqualink.system import SystemStatus

if system.status is SystemStatus.ONLINE:
if system.status is not SystemStatus.ONLINE:
```

**Throttle behavior change**: previously `AqualinkServiceThrottledException` preserved the last-known status (no assignment made). Now it explicitly sets `status = SystemStatus.UNKNOWN`, discarding prior state. Callers that relied on status being preserved across rate-limited calls must account for this.

## Summary

- `bool | None` conflated states: "never fetched" and "service error" both mapped to `None`
- Adds `SystemStatus` enum to `iaqualink.system` with four explicit states:
  - `UNKNOWN` — initial state, or last update was rate-limited
  - `OFFLINE` — system is definitively offline
  - `ONLINE` — last update succeeded
  - `ERROR` — last update failed with a non-recoverable service error
- Renames attribute `online` → `status` on `AqualinkSystem`
- Uses `enum.StrEnum` so members compare equal to their string values (`SystemStatus.ONLINE == "online"`)
- Updates all assignments in iaqua and exo implementations
- Updates all test assertions; adds `test_update_service_exception` and `test_update_throttled` for both system types; moves `ONLINE` assertion into `TestBaseSystem.test_update_success` as a subclass contract
- Updates all doc pages referencing `system.online`

## Test plan

- [x] `uv run pytest tests/systems/` — 342 passed, 7 skipped
- [x] `uv run pre-commit run --all-files` — all hooks pass