### PR TITLE
test(base): fix pre-existing bugs in TestBaseSystem

### DIFF
--- a/tests/base_test_system.py
+++ b/tests/base_test_system.py
@@ -14,11 +14,11 @@ from .base import TestBase, dotstar, resp_200
 
 
 class TestBaseSystem(TestBase):
-    def test_propery_name(self) -> None:
+    def test_property_name(self) -> None:
         assert isinstance(self.sut.name, str)
 
     def test_property_serial(self) -> None:
-        assert isinstance(self.sut.name, str)
+        assert isinstance(self.sut.serial, str)
 
     def test_from_data(self) -> None:
         if sut_class := getattr(self, "sut_class", None):
@@ -42,6 +42,7 @@ class TestBaseSystem(TestBase):
         respx_mock.route(dotstar).mock(resp_500)
         with pytest.raises(AqualinkServiceException):
             await self.sut.update()
+        assert self.sut.status is SystemStatus.ERROR
         self.respx_calls = copy.copy(respx_mock.calls)
 
     @respx.mock

--- a/tests/systems/exo/test_system.py
+++ b/tests/systems/exo/test_system.py
@@ -187,10 +187,6 @@ class TestExoSystem(TestBaseSystem):
         with patch.object(self.sut, "_parse_shadow_response"):
             await super().test_update_success()
 
-    async def test_update_service_exception(self) -> None:
-        await super().test_update_service_exception()
-        assert self.sut.status is SystemStatus.ERROR
-
     async def test_update_throttled(self) -> None:
         with patch.object(self.sut, "send_reported_state_request") as mock_req:
             mock_req.side_effect = AqualinkServiceThrottledException

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -53,10 +53,6 @@ class TestIaquaSystem(TestBaseSystem):
                 await super().test_update_success()
             assert self.sut.status is SystemStatus.OFFLINE
 
-    async def test_update_service_exception(self) -> None:
-        await super().test_update_service_exception()
-        assert self.sut.status is SystemStatus.ERROR
-
     async def test_update_throttled(self) -> None:
         with patch.object(self.sut, "_send_home_screen_request") as mock_req:
             mock_req.side_effect = AqualinkServiceThrottledException


### PR DESCRIPTION
## Summary

- Fix typo `test_propery_name` → `test_property_name`
- Fix `test_property_serial` asserting `.name` instead of `.serial` (serial was never actually tested)
- Push `status is SystemStatus.ERROR` assertion into `TestBaseSystem.test_update_service_exception`; remove identical overrides from `TestIaquaSystem` and `TestExoSystem`

All three issues pre-existed; none introduced by recent PRs.

## Test plan

- [ ] `uv run pytest tests/base_test_system.py tests/systems/iaqua/test_system.py tests/systems/exo/test_system.py` — 37 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)