### PR TITLE
refactor(logging): replace f-string logging with % formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ line-length = 80
 [tool.ruff.lint]
 ignore = [
     "SLF001",  # Some tests currently use private members
-    "G004",    # Will fix all f-string logging calls later
 ]
 
 [tool.coverage.run]

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -77,7 +77,7 @@ class ExoSystem(AqualinkSystem):
     def _parse_shadow_response(self, response: httpx.Response) -> None:
         data = response.json()
 
-        LOGGER.debug(f"Shadow response: {data}")
+        LOGGER.debug("Shadow response: %s", data)
 
         devices = {}
 
@@ -113,7 +113,7 @@ class ExoSystem(AqualinkSystem):
             )
             devices.update({name: attrs})
 
-        LOGGER.debug(f"devices: {devices}")
+        LOGGER.debug("devices: %s", devices)
 
         for k, v in devices.items():
             if k in self.devices:

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -113,10 +113,10 @@ class IaquaSystem(AqualinkSystem):
     def _parse_home_response(self, response: httpx.Response) -> None:
         data = response.json()
 
-        LOGGER.debug(f"Home response: {data}")
+        LOGGER.debug("Home response: %s", data)
 
         if data["home_screen"][0]["status"] == "Offline":
-            LOGGER.warning(f"Status for system {self.serial} is Offline.")
+            LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
         if data["home_screen"][2]["system_type"] == "":
@@ -146,10 +146,10 @@ class IaquaSystem(AqualinkSystem):
     def _parse_devices_response(self, response: httpx.Response) -> None:
         data = response.json()
 
-        LOGGER.debug(f"Devices response: {data}")
+        LOGGER.debug("Devices response: %s", data)
 
         if data["devices_screen"][0]["status"] == "Offline":
-            LOGGER.warning(f"Status for system {self.serial} is Offline.")
+            LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
         for x in data["devices_screen"][3:]:


### PR DESCRIPTION
## Summary

- Convert 6 f-string logging calls to `%`-style lazy formatting
- Remove G004 suppression from ruff config (no longer needed)

## Why

F-strings evaluate eagerly — string is built even when log level suppresses output. `%`-style args defer formatting to the logging framework.

## Test plan

- [ ] `uv run ruff check src/` passes with G004 no longer suppressed
- [ ] `uv run pytest` — 482 passed