### PR TITLE
refactor!: replace state enums with StrEnum/IntEnum

### DIFF
--- a/src/iaqualink/systems/exo/device.py
+++ b/src/iaqualink/systems/exo/device.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from enum import Enum, unique
+from enum import IntEnum, unique
 from typing import TYPE_CHECKING, Any, cast
 
 from iaqualink.device import (
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger("iaqualink")
 
 
 @unique
-class ExoState(Enum):
+class ExoState(IntEnum):
     OFF = 0
     ON = 1
 
@@ -87,7 +87,7 @@ class ExoSensor(ExoDevice, AqualinkSensor):
 
     @property
     def is_on(self) -> bool:
-        return ExoState(self.data["state"]) == ExoState.ON
+        return self.data["state"] == ExoState.ON
 
     @property
     def state(self) -> str:
@@ -122,7 +122,7 @@ class ExoSwitch(ExoDevice, AqualinkSwitch):
 
     @property
     def is_on(self) -> bool:
-        return ExoState(self.data["state"]) == ExoState.ON
+        return self.data["state"] == ExoState.ON
 
     @property
     def _command(self) -> Callable[[str, int], Coroutine[Any, Any, None]]:
@@ -206,7 +206,7 @@ class ExoThermostat(ExoSwitch, AqualinkThermostat):
 
     @property
     def is_on(self) -> bool:
-        return ExoState(self.data["enabled"]) == ExoState.ON
+        return self.data["enabled"] == ExoState.ON
 
     async def turn_on(self) -> None:
         if self.is_on is False:

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -38,7 +38,7 @@ class IaquaAuxState(StrEnum):
 
 
 @unique
-class IaquaDevicePresence(StrEnum):
+class IaquaPresenceState(StrEnum):
     ABSENT = "absent"
     PRESENT = "present"
 
@@ -128,7 +128,7 @@ class IaquaBinarySensor(IaquaSensor, AqualinkBinarySensor):
 class IaquaPresenceSensor(IaquaBinarySensor):
     @property
     def is_on(self) -> bool:
-        return self.state == IaquaDevicePresence.PRESENT
+        return self.state == IaquaPresenceState.PRESENT
 
 
 class IaquaSwitch(IaquaBinarySensor, AqualinkSwitch):

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -37,6 +37,12 @@ class IaquaAuxState(StrEnum):
     ENABLED = "3"
 
 
+@unique
+class IaquaDevicePresence(StrEnum):
+    ABSENT = "absent"
+    PRESENT = "present"
+
+
 class IaquaDevice(AqualinkDevice):
     def __init__(self, system: IaquaSystem, data: DeviceData):
         super().__init__(system, data)
@@ -87,7 +93,7 @@ class IaquaDevice(AqualinkDevice):
         elif data["name"] == "freeze_protection":
             class_ = IaquaBinarySensor
         elif data["name"].endswith("_present"):
-            class_ = IaquaSensor
+            class_ = IaquaPresenceSensor
         elif data["name"].startswith("aux_"):
             if data["type"] == "2":
                 class_ = light_subtype_to_class[data["subtype"]]
@@ -117,6 +123,12 @@ class IaquaBinarySensor(IaquaSensor, AqualinkBinarySensor):
             if self.state
             else False
         )
+
+
+class IaquaPresenceSensor(IaquaBinarySensor):
+    @property
+    def is_on(self) -> bool:
+        return self.state == IaquaDevicePresence.PRESENT
 
 
 class IaquaSwitch(IaquaBinarySensor, AqualinkSwitch):

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from enum import Enum, unique
+from enum import StrEnum, unique
 from typing import TYPE_CHECKING, cast
 
 from iaqualink.device import (
@@ -30,13 +30,11 @@ LOGGER = logging.getLogger("iaqualink")
 
 
 @unique
-class AqualinkState(Enum):
+class IaquaAuxState(StrEnum):
     OFF = "0"
     ON = "1"
     STANDBY = "2"
     ENABLED = "3"
-    ABSENT = "absent"
-    PRESENT = "present"
 
 
 class IaquaDevice(AqualinkDevice):
@@ -86,10 +84,10 @@ class IaquaDevice(AqualinkDevice):
             if data["state"] == "":
                 raise AqualinkDeviceNotSupported(data)
             class_ = IaquaThermostat
-        elif data["name"] == "freeze_protection" or data["name"].endswith(
-            "_present"
-        ):
+        elif data["name"] == "freeze_protection":
             class_ = IaquaBinarySensor
+        elif data["name"].endswith("_present"):
+            class_ = IaquaSensor
         elif data["name"].startswith("aux_"):
             if data["type"] == "2":
                 class_ = light_subtype_to_class[data["subtype"]]
@@ -115,8 +113,7 @@ class IaquaBinarySensor(IaquaSensor, AqualinkBinarySensor):
     @property
     def is_on(self) -> bool:
         return (
-            AqualinkState(self.state)
-            in [AqualinkState.ON, AqualinkState.ENABLED, AqualinkState.PRESENT]
+            self.state in [IaquaAuxState.ON, IaquaAuxState.ENABLED]
             if self.state
             else False
         )
@@ -138,11 +135,7 @@ class IaquaSwitch(IaquaBinarySensor, AqualinkSwitch):
 class IaquaAuxSwitch(IaquaSwitch):
     @property
     def is_on(self) -> bool:
-        return (
-            AqualinkState(self.state) == AqualinkState.ON
-            if self.state
-            else False
-        )
+        return self.state == IaquaAuxState.ON if self.state else False
 
     async def _toggle(self) -> None:
         await self.system.set_aux(self.data["aux"])

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -15,6 +15,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaDevice,
     IaquaDimmableLight,
     IaquaLightSwitch,
+    IaquaPresenceSensor,
     IaquaSensor,
     IaquaSwitch,
     IaquaThermostat,
@@ -92,6 +93,27 @@ class TestIaquaBinarySensor(TestIaquaSensor, TestBaseBinarySensor):
         self.sut.data["state"] = "1"
         super().test_property_is_on_true()
         assert self.sut.is_on is True
+
+
+class TestIaquaPresenceSensor(TestIaquaBinarySensor):
+    def setUp(self) -> None:
+        super().setUp()
+
+        data = {"name": "spa_present", "state": "present"}
+        self.sut_class = IaquaPresenceSensor
+        self.sut = IaquaDevice.from_data(self.system, data)
+
+    def test_property_is_on_true(self) -> None:
+        self.sut.data["state"] = "present"
+        assert self.sut.is_on is True
+
+    def test_property_is_on_false(self) -> None:
+        self.sut.data["state"] = "absent"
+        assert self.sut.is_on is False
+
+    def test_property_is_on_false_empty(self) -> None:
+        self.sut.data["state"] = ""
+        assert self.sut.is_on is False
 
 
 class TestIaquaSwitch(TestIaquaBinarySensor, TestBaseSwitch):


### PR DESCRIPTION
## Summary

- `AqualinkState(Enum)` removed; replaced by `IaquaAuxState(StrEnum)` (numeric switch states only)
- `IaquaPresenceState(StrEnum)` added to document `"present"`/`"absent"` values
- `*_present` devices now dispatch to `IaquaPresenceSensor(IaquaBinarySensor)`; `is_on` returns `True` only when state is `"present"`, `False` otherwise — `isinstance(device, IaquaBinarySensor)` still holds
- `ExoState(Enum)` → `ExoState(IntEnum)`; all three `is_on` call sites drop the constructor wrap and compare raw data values directly against enum members

## Breaking Changes

- `AqualinkState` removed — import `IaquaAuxState` instead
- `ExoState` is now `IntEnum`; members now compare equal to `int` values
- `*_present` device `is_on` semantics changed: previously evaluated against numeric states (`"1"`/`"3"`), now returns `True` only for `"present"`

## Test plan

- [x] `uv run pytest tests/systems/iaqua/ tests/systems/exo/`
- [x] `uv run pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)