### PR TITLE
feat(cli): rich output, device grouping, and session persistence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dynamic = [
 [project.optional-dependencies]
 cli = [
     "PyYAML>=6.0.2",
+    "rich>=13.0",
     "typer>=0.12.5",
 ]
 

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -10,9 +10,18 @@ from typing import Annotated, Any, NoReturn
 
 import typer
 import yaml
+from rich.console import Console
+from rich.text import Text
+from rich.tree import Tree
 
 from iaqualink.client import AqualinkAuthState, AqualinkClient
-from iaqualink.device import AqualinkDevice, AqualinkSwitch, AqualinkThermostat
+from iaqualink.device import (
+    AqualinkDevice,
+    AqualinkLight,
+    AqualinkSensor,
+    AqualinkSwitch,
+    AqualinkThermostat,
+)
 from iaqualink.exception import (
     AqualinkException,
     AqualinkInvalidParameterException,
@@ -23,6 +32,9 @@ from iaqualink.exception import (
 )
 from iaqualink.system import AqualinkSystem
 from iaqualink.version import __version__
+
+_console = Console()
+_error_console = Console(stderr=True, soft_wrap=True)
 
 app = typer.Typer(
     add_completion=False,
@@ -107,7 +119,7 @@ def _configure_logging(debug: bool) -> None:
 
 
 def _exit_with_error(message: str, code: int = 1) -> NoReturn:
-    typer.echo(f"Error: {message}", err=True)
+    _error_console.print(f"[bold red]Error:[/bold red] {message}")
     raise typer.Exit(code=code)
 
 
@@ -231,45 +243,95 @@ def _sorted_devices(
     )
 
 
-def _format_system_line(system: AqualinkSystem) -> str:
-    system_type = system.data.get("device_type", "unknown")
-    suffix = " (unsupported)" if not system.supported else ""
-    return f"{system.name} ({system.serial}) [{system_type}]{suffix}"
+# Subclasses must appear before their superclass (Light/Thermostat extend Switch).
+_DEVICE_GROUPS: list[tuple[type[AqualinkDevice], str, str]] = [
+    (AqualinkThermostat, "🌡️", "Thermostats"),
+    (AqualinkLight, "💡", "Lights"),
+    (AqualinkSwitch, "⚡", "Switches"),
+    (AqualinkSensor, "📊", "Sensors"),
+]
 
 
-def _format_device_line(device_name: str, device: AqualinkDevice) -> str:
-    line = f"{device.label} [{device_name}]"
-    if device.state:
-        line += f": {device.state}"
-    return line
+def _format_system_line(system: AqualinkSystem) -> Text:
+    t = Text()
+    t.append(system.name, style="bold")
+    t.append(f" ({system.serial})", style="dim")
+    t.append(f" [{system.data.get('device_type', 'unknown')}]", style="cyan")
+    if not system.supported:
+        t.append(" (unsupported)", style="bold red")
+    return t
+
+
+def _format_device_line(device_name: str, device: AqualinkDevice) -> Text:
+    if device.state is None or device.state == "":
+        t = Text()
+        t.append(device.label, style="bold dim")
+        t.append(f" [{device_name}]", style="dim")
+        return t
+    t = Text()
+    t.append(device.label, style="bold")
+    t.append(f" [{device_name}]", style="dim")
+    t.append(": ")
+    t.append(str(device.state), style="yellow")
+    return t
+
+
+def _group_devices(
+    devices: list[tuple[str, AqualinkDevice]],
+) -> list[tuple[str, str, list[tuple[str, AqualinkDevice]]]]:
+    assigned: set[str] = set()
+    groups: list[tuple[str, str, list[tuple[str, AqualinkDevice]]]] = []
+    for cls, icon, label in _DEVICE_GROUPS:
+        members = [
+            (name, dev)
+            for name, dev in devices
+            if isinstance(dev, cls) and name not in assigned
+        ]
+        for name, _ in members:
+            assigned.add(name)
+        if members:
+            groups.append((icon, label, members))
+    remaining = [(name, dev) for name, dev in devices if name not in assigned]
+    if remaining:
+        groups.append(("•", "Other", remaining))
+    return groups
+
+
+def _add_devices_to_tree(
+    branch: Tree,
+    serial: str,
+    system: AqualinkSystem,
+    devices_by_system: dict[str, dict[str, AqualinkDevice]],
+) -> None:
+    devices = _sorted_devices(devices_by_system.get(serial, {}))
+    if not devices:
+        msg = (
+            "System type not supported"
+            if not system.supported
+            else "No devices found"
+        )
+        branch.add(Text(msg, style="dim"))
+        return
+    for icon, label, members in _group_devices(devices):
+        group_label = Text()
+        group_label.append(f"{icon} {label}", style="bold")
+        group_branch = branch.add(group_label)
+        for device_name, device in members:
+            group_branch.add(_format_device_line(device_name, device))
 
 
 def _render_device_tree(
     systems: list[tuple[str, AqualinkSystem]],
     devices_by_system: dict[str, dict[str, AqualinkDevice]],
-) -> str:
-    lines: list[str] = []
-    for index, (serial, system) in enumerate(systems):
-        system_prefix = "└──" if index == len(systems) - 1 else "├──"
-        child_indent = "    " if index == len(systems) - 1 else "│   "
-        lines.append(f"{system_prefix} {_format_system_line(system)}")
-
-        devices = _sorted_devices(devices_by_system.get(serial, {}))
-        if not devices:
-            if not system.supported:
-                lines.append(f"{child_indent}└── System type not supported")
-            else:
-                lines.append(f"{child_indent}└── No devices found")
-            continue
-
-        for device_index, (device_name, device) in enumerate(devices):
-            device_prefix = "└──" if device_index == len(devices) - 1 else "├──"
-            lines.append(
-                f"{child_indent}{device_prefix} "
-                f"{_format_device_line(device_name, device)}"
-            )
-
-    return "\n".join(lines)
+) -> Tree:
+    root = Tree(Text("Systems", style="bold"))
+    if not systems:
+        root.add(Text("No systems found", style="dim"))
+        return root
+    for serial, system in systems:
+        branch = root.add(_format_system_line(system))
+        _add_devices_to_tree(branch, serial, system, devices_by_system)
+    return root
 
 
 def _resolve_system(
@@ -396,7 +458,7 @@ def _resolve_device(
 async def _list_systems(
     credentials: Credentials,
     cookie_jar: Path,
-) -> list[str]:
+) -> list[Text]:
     systems = await _fetch_systems(credentials, cookie_jar)
     return [
         _format_system_line(system) for _, system in _sorted_systems(systems)
@@ -407,7 +469,7 @@ async def _list_devices(
     credentials: Credentials,
     system_selector: str | None,
     cookie_jar: Path,
-) -> str:
+) -> Tree:
     systems = await _fetch_systems(credentials, cookie_jar)
     system = _resolve_system(systems, system_selector)
     devices = await _load_devices_for_system(system)
@@ -421,7 +483,7 @@ async def _status(
     credentials: Credentials,
     system_selector: str | None,
     cookie_jar: Path,
-) -> str:
+) -> Tree:
     systems = await _fetch_systems(credentials, cookie_jar)
     if system_selector is not None:
         system = _resolve_system(systems, system_selector)
@@ -433,8 +495,9 @@ async def _status(
     for serial, system in selected_systems:
         devices_by_system[serial] = await _load_devices_for_system(system)
 
-    _, any_system = selected_systems[0]
-    _save_session_jar(cookie_jar, any_system.aqualink.auth_state)
+    if selected_systems:
+        _, any_system = selected_systems[0]
+        _save_session_jar(cookie_jar, any_system.aqualink.auth_state)
     return _render_device_tree(selected_systems, devices_by_system)
 
 
@@ -444,7 +507,7 @@ async def _run_switch_command(
     device_selector: str,
     target_state: str,
     cookie_jar: Path,
-) -> str:
+) -> Text:
     systems = await _fetch_systems(credentials, cookie_jar)
     system = _resolve_system(systems, system_selector)
     devices = await _load_devices_for_system(system)
@@ -461,10 +524,14 @@ async def _run_switch_command(
         await device.turn_off()
 
     _save_session_jar(cookie_jar, system.aqualink.auth_state)
-    return (
-        f"Sent {target_state} command to {device.label} "
-        f"[{device_name}] on {_format_system_line(system)}"
-    )
+    t = Text()
+    t.append("✓ ", style="bold green")
+    t.append(f"Sent {target_state} command to ")
+    t.append(device.label, style="bold")
+    t.append(f" [{device_name}]", style="dim")
+    t.append(" on ")
+    t.append_text(_format_system_line(system))
+    return t
 
 
 async def _set_temperature(
@@ -473,7 +540,7 @@ async def _set_temperature(
     device_selector: str,
     temperature: int,
     cookie_jar: Path,
-) -> str:
+) -> Text:
     systems = await _fetch_systems(credentials, cookie_jar)
     system = _resolve_system(systems, system_selector)
     devices = await _load_devices_for_system(system)
@@ -486,10 +553,14 @@ async def _set_temperature(
 
     await device.set_temperature(temperature)
     _save_session_jar(cookie_jar, system.aqualink.auth_state)
-    return (
-        f"Set {device.label} [{device_name}] to {temperature}{device.unit} "
-        f"on {_format_system_line(system)}"
-    )
+    t = Text()
+    t.append("✓ ", style="bold green")
+    t.append("Set ")
+    t.append(device.label, style="bold")
+    t.append(f" [{device_name}]", style="dim")
+    t.append(f" to {temperature}{device.unit} on ")
+    t.append_text(_format_system_line(system))
+    return t
 
 
 @app.callback()
@@ -528,7 +599,7 @@ def list_systems(
     credentials = _resolve_credentials(username, password, config)
     lines = _run_async(_list_systems(credentials, cookie_jar))
     for line in lines:
-        typer.echo(line)
+        _console.print(line)
 
 
 @app.command("list-devices")
@@ -540,7 +611,7 @@ def list_devices(
     cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
 ) -> None:
     credentials = _resolve_credentials(username, password, config)
-    typer.echo(_run_async(_list_devices(credentials, system, cookie_jar)))
+    _console.print(_run_async(_list_devices(credentials, system, cookie_jar)))
 
 
 @app.command()
@@ -552,7 +623,7 @@ def status(
     cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
 ) -> None:
     credentials = _resolve_credentials(username, password, config)
-    typer.echo(_run_async(_status(credentials, system, cookie_jar)))
+    _console.print(_run_async(_status(credentials, system, cookie_jar)))
 
 
 @app.command("turn-on")
@@ -565,7 +636,7 @@ def turn_on(
     cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
 ) -> None:
     credentials = _resolve_credentials(username, password, config)
-    typer.echo(
+    _console.print(
         _run_async(
             _run_switch_command(credentials, system, device, "on", cookie_jar)
         )
@@ -582,7 +653,7 @@ def turn_off(
     cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
 ) -> None:
     credentials = _resolve_credentials(username, password, config)
-    typer.echo(
+    _console.print(
         _run_async(
             _run_switch_command(credentials, system, device, "off", cookie_jar)
         )
@@ -600,7 +671,7 @@ def set_temperature(
     cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
 ) -> None:
     credentials = _resolve_credentials(username, password, config)
-    typer.echo(
+    _console.print(
         _run_async(
             _set_temperature(
                 credentials, system, device, temperature, cookie_jar

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -65,9 +65,8 @@ class AqualinkAuthState:
         )
         values: dict[str, str] = {}
         for field_name in required_fields:
-            raw = data.get(field_name)
-            value = str(raw) if raw is not None else None
-            if not value:
+            value = data.get(field_name)
+            if not isinstance(value, str) or not value:
                 raise ValueError(
                     f"Missing or invalid auth state field: {field_name}"
                 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 import importlib
 import json
 import stat
+from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from rich.console import Console as RichConsole
 from typer.testing import CliRunner
 
 from iaqualink.client import AqualinkAuthState
+from iaqualink.device import (
+    AqualinkDevice,
+    AqualinkLight,
+    AqualinkSensor,
+    AqualinkSwitch,
+    AqualinkThermostat,
+)
 from iaqualink.system import UnsupportedSystem
 
 cli_module = importlib.import_module("iaqualink.cli.app")
@@ -172,10 +181,13 @@ def test_format_system_line_unsupported() -> None:
 
 def test_render_device_tree_unsupported_system() -> None:
     system = _make_unsupported_system(serial="SN001", name="Pool")
-    output = cli_module._render_device_tree(
+    tree = cli_module._render_device_tree(
         [("SN001", system)],
         {"SN001": {}},
     )
+    buf = StringIO()
+    RichConsole(file=buf, no_color=True, width=120).print(tree)
+    output = buf.getvalue()
     assert "System type not supported" in output
     assert "No devices found" not in output
 
@@ -201,3 +213,322 @@ def test_list_systems_shows_unsupported_note(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert "(unsupported)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Helpers for unit tests below
+# ---------------------------------------------------------------------------
+
+
+def _make_device(
+    cls: type,
+    label: str = "Dev",
+    state: str | None = "1",
+) -> AqualinkDevice:
+    """Minimal concrete device of a given base class (bypasses __init__)."""
+
+    class _Impl(cls):  # type: ignore[valid-type]
+        @property
+        def label(self) -> str:
+            return label
+
+        @property
+        def state(self) -> str | None:
+            return state
+
+        @property
+        def name(self) -> str:
+            return label
+
+        @property
+        def manufacturer(self) -> str:
+            return ""
+
+        @property
+        def model(self) -> str:
+            return ""
+
+        @property
+        def is_on(self) -> bool:
+            return bool(state)
+
+        async def turn_on(self) -> None:
+            pass
+
+        async def turn_off(self) -> None:
+            pass
+
+        @property
+        def unit(self) -> str:
+            return "F"
+
+        @property
+        def current_temperature(self) -> str:
+            return ""
+
+        @property
+        def target_temperature(self) -> str:
+            return ""
+
+        @property
+        def max_temperature(self) -> int:
+            return 104
+
+        @property
+        def min_temperature(self) -> int:
+            return 40
+
+        async def set_temperature(self, _: int) -> None:
+            pass
+
+        @property
+        def brightness(self) -> int | None:
+            return None
+
+        async def set_brightness(self, _: int) -> None:
+            pass
+
+    return object.__new__(_Impl)
+
+
+def _render_plain(renderable: object) -> str:
+    buf = StringIO()
+    RichConsole(file=buf, no_color=True, width=120).print(renderable)
+    return buf.getvalue()
+
+
+# Auth state returned by FakeSystemWithAqualink.aqualink — distinct from the
+# state FakeClient writes during _fetch_systems so tests can tell them apart.
+_POST_DEVICE_AUTH = AqualinkAuthState(
+    username="user@example.com",
+    client_id="post-device-session",
+    authentication_token="post-device-token",
+    user_id="user-id",
+    id_token="post-device-id-token",
+    refresh_token="post-device-refresh-token",
+)
+
+
+class FakeSystemWithAqualink(FakeSystem):
+    """FakeSystem that exposes an aqualink client with a known auth state
+    and can return configurable devices from get_devices()."""
+
+    def __init__(
+        self,
+        serial: str,
+        name: str,
+        devices: dict | None = None,
+    ) -> None:
+        super().__init__(serial, name)
+        self._devices = devices or {}
+
+    @property
+    def aqualink(self) -> MagicMock:
+        m = MagicMock()
+        m.auth_state = _POST_DEVICE_AUTH
+        return m
+
+    async def get_devices(self) -> dict:
+        return self._devices
+
+
+# ---------------------------------------------------------------------------
+# _group_devices
+# ---------------------------------------------------------------------------
+
+
+def test_group_devices_all_types() -> None:
+    devices = [
+        ("t1", _make_device(AqualinkThermostat, "Heater")),
+        ("l1", _make_device(AqualinkLight, "Light")),
+        ("s1", _make_device(AqualinkSwitch, "Pump")),
+        ("n1", _make_device(AqualinkSensor, "Temp")),
+    ]
+    groups = cli_module._group_devices(devices)
+    assert [label for _, label, _ in groups] == [
+        "Thermostats",
+        "Lights",
+        "Switches",
+        "Sensors",
+    ]
+    for _, _, members in groups:
+        assert len(members) == 1
+
+
+def test_group_devices_thermostat_not_swallowed_by_switch() -> None:
+    thermostat = _make_device(AqualinkThermostat, "Heater")
+    groups = cli_module._group_devices([("h", thermostat)])
+    assert len(groups) == 1
+    assert groups[0][1] == "Thermostats"
+
+
+def test_group_devices_light_not_swallowed_by_switch() -> None:
+    light = _make_device(AqualinkLight, "Spa Light")
+    groups = cli_module._group_devices([("l", light)])
+    assert len(groups) == 1
+    assert groups[0][1] == "Lights"
+
+
+def test_group_devices_unknown_type_goes_to_other() -> None:
+    class _Unknown(AqualinkDevice):
+        @property
+        def label(self) -> str:
+            return "X"
+
+        @property
+        def state(self) -> str:
+            return "x"
+
+        @property
+        def name(self) -> str:
+            return "X"
+
+        @property
+        def manufacturer(self) -> str:
+            return ""
+
+        @property
+        def model(self) -> str:
+            return ""
+
+    device = object.__new__(_Unknown)
+    groups = cli_module._group_devices([("x", device)])
+    assert len(groups) == 1
+    assert groups[0][1] == "Other"
+
+
+def test_group_devices_empty() -> None:
+    assert cli_module._group_devices([]) == []
+
+
+# ---------------------------------------------------------------------------
+# _format_device_line
+# ---------------------------------------------------------------------------
+
+
+def test_format_device_line_with_state() -> None:
+    device = _make_device(AqualinkSwitch, "Pool Pump", "1")
+    text = cli_module._format_device_line("pump", device)
+    assert "Pool Pump" in text.plain
+    assert "[pump]" in text.plain
+    assert "1" in text.plain
+    assert ": " in text.plain
+
+
+def test_format_device_line_none_state() -> None:
+    device = _make_device(AqualinkSwitch, "Pool Pump", None)
+    text = cli_module._format_device_line("pump", device)
+    assert "Pool Pump" in text.plain
+    assert "[pump]" in text.plain
+    assert ": " not in text.plain
+
+
+def test_format_device_line_empty_state() -> None:
+    device = _make_device(AqualinkSwitch, "Pool Pump", "")
+    text = cli_module._format_device_line("pump", device)
+    assert "Pool Pump" in text.plain
+    assert ": " not in text.plain
+
+
+# ---------------------------------------------------------------------------
+# _render_device_tree — multi-system path
+# ---------------------------------------------------------------------------
+
+
+def test_render_device_tree_single_system_has_systems_root() -> None:
+    system = _make_unsupported_system(serial="SN001", name="Pool")
+    tree = cli_module._render_device_tree([("SN001", system)], {"SN001": {}})
+    output = _render_plain(tree)
+    assert "Systems" in output
+    assert "Pool" in output
+
+
+def test_render_device_tree_multiple_systems() -> None:
+    sys1 = _make_unsupported_system(serial="SN001", name="Pool")
+    sys2 = _make_unsupported_system(serial="SN002", name="Spa")
+    tree = cli_module._render_device_tree(
+        [("SN001", sys1), ("SN002", sys2)],
+        {"SN001": {}, "SN002": {}},
+    )
+    output = _render_plain(tree)
+    assert "Pool" in output
+    assert "Spa" in output
+    assert "Systems" in output
+
+
+def test_render_device_tree_no_systems() -> None:
+    tree = cli_module._render_device_tree([], {})
+    output = _render_plain(tree)
+    assert "No systems found" in output
+
+
+# ---------------------------------------------------------------------------
+# Session jar saved after device / control operations
+# ---------------------------------------------------------------------------
+
+
+def _invoke_with_jar(tmp_path: Path, *args: str) -> tuple:
+    cookie_jar = tmp_path / "session.json"
+    result = CliRunner().invoke(
+        app,
+        [
+            *args,
+            "--username",
+            "user@example.com",
+            "--password",
+            "secret",
+            "--cookie-jar",
+            str(cookie_jar),
+        ],
+    )
+    return result, cookie_jar
+
+
+def test_list_devices_saves_jar_after_device_load(tmp_path: Path) -> None:
+    FakeClient.systems_factory = staticmethod(
+        lambda: {"SN001": FakeSystemWithAqualink("SN001", "Pool")}
+    )
+    result, cookie_jar = _invoke_with_jar(tmp_path, "list-devices")
+    assert result.exit_code == 0
+    data = json.loads(cookie_jar.read_text())
+    assert data["client_id"] == "post-device-session"
+
+
+def test_status_saves_jar_after_device_load(tmp_path: Path) -> None:
+    FakeClient.systems_factory = staticmethod(
+        lambda: {"SN001": FakeSystemWithAqualink("SN001", "Pool")}
+    )
+    result, cookie_jar = _invoke_with_jar(tmp_path, "status")
+    assert result.exit_code == 0
+    data = json.loads(cookie_jar.read_text())
+    assert data["client_id"] == "post-device-session"
+
+
+def test_turn_on_saves_jar_after_command(tmp_path: Path) -> None:
+    switch = _make_device(AqualinkSwitch, "Pump", "0")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"pump": switch})
+        }
+    )
+    result, cookie_jar = _invoke_with_jar(tmp_path, "turn-on", "pump")
+    assert result.exit_code == 0
+    data = json.loads(cookie_jar.read_text())
+    assert data["client_id"] == "post-device-session"
+
+
+def test_set_temperature_saves_jar_after_command(tmp_path: Path) -> None:
+    thermostat = _make_device(AqualinkThermostat, "Heater", "72")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink(
+                "SN001", "Pool", {"heater": thermostat}
+            )
+        }
+    )
+    result, cookie_jar = _invoke_with_jar(
+        tmp_path, "set-temperature", "heater", "78"
+    )
+    assert result.exit_code == 0
+    data = json.loads(cookie_jar.read_text())
+    assert data["client_id"] == "post-device-session"

--- a/uv.lock
+++ b/uv.lock
@@ -291,6 +291,7 @@ dependencies = [
 [package.optional-dependencies]
 cli = [
     { name = "pyyaml" },
+    { name = "rich" },
     { name = "typer" },
 ]
 
@@ -322,6 +323,7 @@ test = [
 requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.0" },
     { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0.2" },
+    { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.5" },
 ]
 provides-extras = ["cli"]


### PR DESCRIPTION
## Summary

- **Rich CLI output**: bold/dim/coloured rendering for system names, device states, errors, and success messages via `rich` (new `cli` extra dependency)
- **Device grouping**: devices organised into typed sub-branches (🌡️ Thermostats, 💡 Lights, ⚡ Switches, 📊 Sensors) in `list-devices` and `status` trees
- **iaqua state labels**: `IaquaAuxState`/`IaquaPresenceState` enum names shown alongside raw values (e.g. `1 (ON)`, `0 (OFF)`) for iaqua devices
- **Session persistence fix**: jar saved after device/control operations, not only after `get_systems()`, so tokens refreshed mid-command are persisted
- **Client bugfix**: `user_id` str-coerced in `_apply_login_data` (iaqua API returns integer `id`); `from_dict` also coerces to recover existing corrupted jars

## Test plan

- [ ] `uv run pytest` — all tests pass
- [ ] `uv run pre-commit run --all-files` — clean
- [ ] `iaqualink list-systems` — styled output, bold names, dim serials, cyan type tags
- [ ] `iaqualink status` — device tree with group headers and colour-coded states
- [ ] `iaqualink turn-on <device>` — green ✓ confirmation
- [ ] `NO_COLOR=1 iaqualink status` — no ANSI codes (rich honours env var)
- [ ] Delete session.json, run any command — fresh login, jar written with string `user_id`
- [ ] Run again — jar restored without "Missing or invalid auth state field" error