### PR TITLE
refactor(iaqua): replace from_data() heuristics with explicit device map

### DIFF
--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -11,8 +11,7 @@ AqualinkException (base)
 │   ├── AqualinkServiceUnauthorizedException
 │   ├── AqualinkSystemOfflineException
 │   └── AqualinkSystemUnsupportedException (deprecated)
-├── AqualinkOperationNotSupportedException
-└── AqualinkDeviceNotSupported
+└── AqualinkOperationNotSupportedException
 ```
 
 ## AqualinkException
@@ -46,10 +45,6 @@ AqualinkException (base)
 ## AqualinkOperationNotSupportedException
 
 ::: iaqualink.exception.AqualinkOperationNotSupportedException
-
-## AqualinkDeviceNotSupported
-
-::: iaqualink.exception.AqualinkDeviceNotSupported
 
 ## Usage Examples
 

--- a/src/iaqualink/exception.py
+++ b/src/iaqualink/exception.py
@@ -31,10 +31,6 @@ class AqualinkOperationNotSupportedException(AqualinkException):
     """Exception raised when trying to issue an unsupported operation."""
 
 
-class AqualinkDeviceNotSupported(AqualinkException):
-    """Exception raised when a device isn't known-unsupported."""
-
-
 class _AqualinkSystemUnsupportedDeprecated(AqualinkServiceException):
     """Backward-compat stub; use iaqualink.system.UnsupportedSystem instead."""
 

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -12,10 +12,7 @@ from iaqualink.device import (
     AqualinkSwitch,
     AqualinkThermostat,
 )
-from iaqualink.exception import (
-    AqualinkDeviceNotSupported,
-    AqualinkInvalidParameterException,
-)
+from iaqualink.exception import AqualinkInvalidParameterException
 
 if TYPE_CHECKING:
     from iaqualink.systems.iaqua.system import IaquaSystem
@@ -79,41 +76,6 @@ class IaquaDevice(AqualinkDevice):
     @property
     def model(self) -> str:
         return self.__class__.__name__.replace("Iaqua", "")
-
-    @classmethod
-    def from_data(cls, system: IaquaSystem, data: DeviceData) -> IaquaDevice:
-        class_: type[IaquaDevice]
-
-        # I don't have a system where these fields get populated.
-        # No idea what they are and what to do with them.
-        if isinstance(data["state"], dict | list):
-            raise AqualinkDeviceNotSupported(data)
-
-        if data["name"].endswith("_heater"):
-            class_ = IaquaHeater
-        elif data["name"].endswith("_pump"):
-            class_ = IaquaSwitch
-        elif data["name"].endswith("_set_point"):
-            if data["state"] == "":
-                raise AqualinkDeviceNotSupported(data)
-            class_ = IaquaThermostat
-        elif data["name"] == "freeze_protection":
-            class_ = IaquaBinarySensor
-        elif data["name"].endswith("_present"):
-            class_ = IaquaPresenceSensor
-        elif data["name"].startswith("aux_"):
-            if data["type"] == "2":
-                class_ = light_subtype_to_class[data["subtype"]]
-            elif data["type"] == "1":
-                class_ = IaquaDimmableLight
-            elif "LIGHT" in data["label"]:
-                class_ = IaquaLightSwitch
-            else:
-                class_ = IaquaAuxSwitch
-        else:
-            class_ = IaquaSensor
-
-        return class_(system, data)
 
 
 class IaquaSensor(IaquaDevice, AqualinkSensor):
@@ -501,3 +463,26 @@ class IaquaThermostat(IaquaSwitch, AqualinkThermostat):
     async def turn_off(self) -> None:
         if self._heater.is_on is True:
             await self._heater.turn_off()
+
+
+_HOME_DEVICE_MAP: dict[str, type[IaquaDevice]] = {
+    "spa_temp": IaquaSensor,
+    "pool_temp": IaquaSensor,
+    "air_temp": IaquaSensor,
+    "cover_pool": IaquaSensor,
+    "freeze_protection": IaquaBinarySensor,
+    "spa_pump": IaquaSwitch,
+    "pool_pump": IaquaSwitch,
+    "spa_heater": IaquaHeater,
+    "pool_heater": IaquaHeater,
+    "solar_heater": IaquaHeater,
+    "spa_salinity": IaquaSensor,
+    "pool_salinity": IaquaSensor,
+    "orp": IaquaSensor,
+    "ph": IaquaSensor,
+    "is_icl_present": IaquaPresenceSensor,
+    "spa_set_point": IaquaThermostat,
+    "pool_set_point": IaquaThermostat,
+    "pool_chill_set_point": IaquaThermostat,
+    "relay_count": IaquaSensor,
+}

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -5,13 +5,19 @@ from typing import TYPE_CHECKING
 
 from iaqualink.const import AQUALINK_API_KEY
 from iaqualink.exception import (
-    AqualinkDeviceNotSupported,
     AqualinkServiceException,
     AqualinkServiceThrottledException,
     AqualinkSystemOfflineException,
 )
 from iaqualink.system import AqualinkSystem, SystemStatus
-from iaqualink.systems.iaqua.device import IaquaDevice
+from iaqualink.systems.iaqua.device import (
+    IaquaAuxSwitch,
+    IaquaDimmableLight,
+    IaquaLightSwitch,
+    IaquaThermostat,
+    _HOME_DEVICE_MAP,
+    light_subtype_to_class,
+)
 
 if TYPE_CHECKING:
     import httpx
@@ -115,33 +121,34 @@ class IaquaSystem(AqualinkSystem):
 
         LOGGER.debug("Home response: %s", data)
 
-        if data["home_screen"][0]["status"] == "Offline":
+        home: dict = {}
+        for x in data["home_screen"]:
+            home.update(x)
+
+        if home["status"] == "Offline":
             LOGGER.warning("Status for system %s is Offline.", self.serial)
             raise AqualinkSystemOfflineException
 
-        if data["home_screen"][2]["system_type"] == "":
+        if home["system_type"] == "":
             LOGGER.debug("Skipping home screen update with empty system_type.")
             return
 
-        self.temp_unit = data["home_screen"][3]["temp_scale"]
+        self.temp_unit = home["temp_scale"]
 
-        # Make the data a bit flatter.
-        devices = {}
-        for x in data["home_screen"][4:]:
-            name = next(iter(x.keys()))
-            state = next(iter(x.values()))
-            attrs = {"name": name, "state": state}
-            devices.update({name: attrs})
+        for name, device_class in _HOME_DEVICE_MAP.items():
+            if name not in home:
+                continue
 
-        for k, v in devices.items():
-            if k in self.devices:
-                for dk, dv in v.items():
-                    self.devices[k].data[dk] = dv
+            state = home[name]
+
+            if name in self.devices:
+                self.devices[name].data["state"] = state
             else:
-                try:
-                    self.devices[k] = IaquaDevice.from_data(self, v)
-                except AqualinkDeviceNotSupported as e:
-                    LOGGER.debug("Device found was ignored: %s", e)
+                if device_class is IaquaThermostat and not state:
+                    continue
+                self.devices[name] = device_class(
+                    self, {"name": name, "state": state}
+                )
 
     def _parse_devices_response(self, response: httpx.Response) -> None:
         data = response.json()
@@ -160,24 +167,27 @@ class IaquaSystem(AqualinkSystem):
                     )
                     return
 
-        # Make the data a bit flatter.
-        devices = {}
         for x in data["devices_screen"][3:]:
             aux = next(iter(x.keys()))
             attrs = {"aux": aux.replace("aux_", ""), "name": aux}
             for y in next(iter(x.values())):
                 attrs.update(y)
-            devices.update({aux: attrs})
 
-        for k, v in devices.items():
-            if k in self.devices:
-                for dk, dv in v.items():
-                    self.devices[k].data[dk] = dv
+            if aux in self.devices:
+                for dk, dv in attrs.items():
+                    self.devices[aux].data[dk] = dv
             else:
-                try:
-                    self.devices[k] = IaquaDevice.from_data(self, v)
-                except AqualinkDeviceNotSupported as e:
-                    LOGGER.info("Device found was ignored: %s", e)
+                device_type = attrs.get("type", "0")
+                label = attrs.get("label", "")
+                if device_type == "2":
+                    device_class = light_subtype_to_class[attrs["subtype"]]
+                elif device_type == "1":
+                    device_class = IaquaDimmableLight
+                elif "LIGHT" in label:
+                    device_class = IaquaLightSwitch
+                else:
+                    device_class = IaquaAuxSwitch
+                self.devices[aux] = device_class(self, attrs)
 
     async def set_switch(self, command: str) -> None:
         r = await self._send_session_request(command)

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -106,7 +106,7 @@ class TestIaquaPresenceSensor(TestIaquaBinarySensor):
     def setUp(self) -> None:
         super().setUp()
 
-        data = {"name": "spa_present", "state": "present"}
+        data = {"name": "is_icl_present", "state": "present"}
         self.sut_class = IaquaPresenceSensor
         self.sut = IaquaPresenceSensor(self.system, data)
 
@@ -166,7 +166,7 @@ class TestIaquaHeater(TestIaquaBinarySensor, TestBaseSwitch):
             "name": "pool_heater",
             "state": "0",
         }
-        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut = IaquaHeater(self.system, data)
         self.sut_class = IaquaHeater
 
     async def test_turn_on(self) -> None:

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-from typing import cast
 from unittest.mock import patch
 
 from iaqualink.systems.iaqua.device import (
@@ -13,6 +12,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaBinaryState,
     IaquaBinarySensor,
     IaquaColorLight,
+    IaquaColorLightIB,
     IaquaDevice,
     IaquaDimmableLight,
     IaquaHeater,
@@ -76,7 +76,7 @@ class TestIaquaSensor(TestIaquaDevice, TestBaseSensor):
         super().setUp()
 
         data = {"name": "orp", "state": "42"}
-        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut = IaquaSensor(self.system, data)
         self.sut_class = IaquaSensor
 
 
@@ -86,7 +86,7 @@ class TestIaquaBinarySensor(TestIaquaSensor, TestBaseBinarySensor):
 
         data = {"name": "freeze_protection", "state": "0"}
         self.sut_class = IaquaBinarySensor
-        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut = IaquaBinarySensor(self.system, data)
 
     def test_property_is_on_false(self) -> None:
         self.sut.data["state"] = "0"
@@ -108,7 +108,7 @@ class TestIaquaPresenceSensor(TestIaquaBinarySensor):
 
         data = {"name": "spa_present", "state": "present"}
         self.sut_class = IaquaPresenceSensor
-        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut = IaquaPresenceSensor(self.system, data)
 
     def test_property_is_on_true(self) -> None:
         self.sut.data["state"] = "present"
@@ -134,7 +134,7 @@ class TestIaquaSwitch(TestIaquaBinarySensor, TestBaseSwitch):
             "name": "pool_pump",
             "state": "0",
         }
-        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut = IaquaSwitch(self.system, data)
         self.sut_class = IaquaSwitch
 
     async def test_turn_on(self) -> None:
@@ -208,7 +208,7 @@ class TestIaquaAuxSwitch(TestIaquaSwitch, TestBaseSwitch):
             "type": "0",
             "label": "CLEANER",
         }
-        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut = IaquaAuxSwitch(self.system, data)
         self.sut_class = IaquaAuxSwitch
 
     async def test_turn_on(self) -> None:
@@ -244,7 +244,7 @@ class TestIaquaLightSwitch(TestIaquaAuxSwitch, TestBaseLight):
             "label": "POOL LIGHT",
             "type": "0",
         }
-        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut = IaquaLightSwitch(self.system, data)
         self.sut_class = IaquaLightSwitch
 
     def test_property_brightness(self) -> None:
@@ -266,7 +266,7 @@ class TestIaquaDimmableLight(TestIaquaAuxSwitch, TestBaseLight):
             "type": "1",
             "label": "SPA LIGHT",
         }
-        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut = IaquaDimmableLight(self.system, data)
         self.sut_class = IaquaDimmableLight
 
     def test_property_name(self) -> None:
@@ -343,7 +343,7 @@ class TestIaquaColorLight(TestIaquaAuxSwitch, TestBaseLight):
             "subtype": "5",
             "label": "POOL LIGHT",
         }
-        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut = IaquaColorLightIB(self.system, data)
         self.sut_class = IaquaColorLight
 
     def test_property_name(self) -> None:
@@ -406,20 +406,16 @@ class TestIaquaThermostat(TestIaquaDevice, TestBaseThermostat):
         super().setUp()
 
         pool_set_point = {"name": "pool_set_point", "state": "86"}
-        self.pool_set_point = cast(
-            IaquaThermostat, IaquaDevice.from_data(self.system, pool_set_point)
-        )
+        self.pool_set_point = IaquaThermostat(self.system, pool_set_point)
 
         pool_temp = {"name": "pool_temp", "state": "65"}
-        self.pool_temp = IaquaDevice.from_data(self.system, pool_temp)
+        self.pool_temp = IaquaSensor(self.system, pool_temp)
 
         pool_heater = {"name": "pool_heater", "state": "0"}
-        self.pool_heater = IaquaDevice.from_data(self.system, pool_heater)
+        self.pool_heater = IaquaSwitch(self.system, pool_heater)
 
         spa_set_point = {"name": "spa_set_point", "state": "102"}
-        self.spa_set_point = cast(
-            IaquaThermostat, IaquaDevice.from_data(self.system, spa_set_point)
-        )
+        self.spa_set_point = IaquaThermostat(self.system, spa_set_point)
 
         devices = [
             self.pool_set_point,


### PR DESCRIPTION
## Summary

- Removes `IaquaDevice.from_data()` and its name-suffix/prefix heuristics for home screen devices
- `_parse_home_response` now flattens `home_screen` list → dict, then iterates `_HOME_DEVICE_MAP` (key → device class) to create devices explicitly; unknown API keys are silently ignored
- `_parse_devices_response` inlines aux type dispatch (was previously delegated to `from_data()`)
- Tests updated to construct device instances directly instead of going through `from_data()`

## Test plan

- [x] `uv run pytest tests/systems/iaqua/` — 204 passed, 4 skipped
- [x] `uv run pre-commit run --all-files` — all hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)