### PR TITLE
feat(system): expose device type and improve UnsupportedSystem handling

### DIFF
--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -54,6 +54,10 @@ class AqualinkSystem:
         return self.data["serial_number"]
 
     @property
+    def type(self) -> str:
+        return self.data["device_type"]
+
+    @property
     def supported(self) -> bool:
         return True
 
@@ -62,10 +66,6 @@ class AqualinkSystem:
         cls, aqualink: AqualinkClient, data: Payload
     ) -> AqualinkSystem:
         if data["device_type"] not in cls.subclasses:
-            LOGGER.warning(
-                "%s is not a supported system type.", data["device_type"]
-            )
-            # UnsupportedSystem is defined after this class in this module.
             return UnsupportedSystem(aqualink, data)
 
         return cls.subclasses[data["device_type"]](aqualink, data)
@@ -97,4 +97,5 @@ class UnsupportedSystem(AqualinkSystem):
         LOGGER.debug("Skipping update for unsupported system %r", self.serial)
 
     async def get_devices(self) -> dict[str, AqualinkDevice]:
+        LOGGER.debug("Skipping get_devices for unsupported system %r", self.serial)
         return {}

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -97,5 +97,7 @@ class UnsupportedSystem(AqualinkSystem):
         LOGGER.debug("Skipping update for unsupported system %r", self.serial)
 
     async def get_devices(self) -> dict[str, AqualinkDevice]:
-        LOGGER.debug("Skipping get_devices for unsupported system %r", self.serial)
+        LOGGER.debug(
+            "Skipping get_devices for unsupported system %r", self.serial
+        )
         return {}

--- a/tests/base_test_system.py
+++ b/tests/base_test_system.py
@@ -20,6 +20,9 @@ class TestBaseSystem(TestBase):
     def test_property_serial(self) -> None:
         assert isinstance(self.sut.serial, str)
 
+    def test_property_type(self) -> None:
+        assert self.sut.type == self.sut.__class__.NAME
+
     def test_from_data(self) -> None:
         if sut_class := getattr(self, "sut_class", None):
             assert isinstance(self.sut, sut_class)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -84,10 +83,8 @@ class TestUnsupportedSystem(unittest.IsolatedAsyncioTestCase):
         r = AqualinkSystem.from_data(self.aqualink, self.data)
         assert isinstance(r, UnsupportedSystem)
 
-    def test_from_data_logs_warning(self) -> None:
-        with self.assertLogs("iaqualink", level=logging.WARNING) as cm:
-            AqualinkSystem.from_data(self.aqualink, self.data)
-        assert any("unknown_type" in line for line in cm.output)
+    def test_type(self) -> None:
+        assert self.system.type == "unknown_type"
 
     def test_supported_false(self) -> None:
         assert self.system.supported is False


### PR DESCRIPTION
## Summary

- Add `type` property to `AqualinkSystem` base class exposing `data["device_type"]`
- Remove warning log for unsupported system types (callers can check `system.supported`)
- Add debug log in `UnsupportedSystem.get_devices()`

## Test plan

- [ ] Existing tests pass (`uv run pytest`)
- [ ] `system.type` returns correct device type string for iaqua/exo/unsupported systems
- [ ] No warning logged when encountering unknown device type

🤖 Generated with [Claude Code](https://claude.com/claude-code)