### PR TITLE
feat(iaqua): add IaquaHeater device type with scoped state enums

### DIFF
--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -30,10 +30,15 @@ LOGGER = logging.getLogger("iaqualink")
 
 
 @unique
-class IaquaAuxState(StrEnum):
+class IaquaState(StrEnum):
     OFF = "0"
     ON = "1"
-    STANDBY = "2"
+
+
+@unique
+class IaquaHeaterState(StrEnum):
+    OFF = "0"
+    ON = "1"
     ENABLED = "3"
 
 
@@ -84,7 +89,9 @@ class IaquaDevice(AqualinkDevice):
         if isinstance(data["state"], dict | list):
             raise AqualinkDeviceNotSupported(data)
 
-        if data["name"].endswith("_heater") or data["name"].endswith("_pump"):
+        if data["name"].endswith("_heater"):
+            class_ = IaquaHeater
+        elif data["name"].endswith("_pump"):
             class_ = IaquaSwitch
         elif data["name"].endswith("_set_point"):
             if data["state"] == "":
@@ -118,11 +125,7 @@ class IaquaBinarySensor(IaquaSensor, AqualinkBinarySensor):
 
     @property
     def is_on(self) -> bool:
-        return (
-            self.state in [IaquaAuxState.ON, IaquaAuxState.ENABLED]
-            if self.state
-            else False
-        )
+        return self.state == IaquaState.ON if self.state else False
 
 
 class IaquaPresenceSensor(IaquaBinarySensor):
@@ -144,10 +147,20 @@ class IaquaSwitch(IaquaBinarySensor, AqualinkSwitch):
             await self._toggle()
 
 
+class IaquaHeater(IaquaSwitch):
+    @property
+    def is_on(self) -> bool:
+        return (
+            self.state in [IaquaHeaterState.ON, IaquaHeaterState.ENABLED]
+            if self.state
+            else False
+        )
+
+
 class IaquaAuxSwitch(IaquaSwitch):
     @property
     def is_on(self) -> bool:
-        return self.state == IaquaAuxState.ON if self.state else False
+        return self.state == IaquaState.ON if self.state else False
 
     async def _toggle(self) -> None:
         await self.system.set_aux(self.data["aux"])
@@ -462,8 +475,8 @@ class IaquaThermostat(IaquaSwitch, AqualinkThermostat):
         await self.system.set_temps(data)
 
     @property
-    def _heater(self) -> IaquaSwitch:
-        return cast(IaquaSwitch, self.system.devices[f"{self._type}_heater"])
+    def _heater(self) -> IaquaHeater:
+        return cast(IaquaHeater, self.system.devices[f"{self._type}_heater"])
 
     @property
     def is_on(self) -> bool:

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -30,7 +30,7 @@ LOGGER = logging.getLogger("iaqualink")
 
 
 @unique
-class IaquaState(StrEnum):
+class IaquaBinaryState(StrEnum):
     OFF = "0"
     ON = "1"
 
@@ -125,7 +125,7 @@ class IaquaBinarySensor(IaquaSensor, AqualinkBinarySensor):
 
     @property
     def is_on(self) -> bool:
-        return self.state == IaquaState.ON if self.state else False
+        return self.state == IaquaBinaryState.ON if self.state else False
 
 
 class IaquaPresenceSensor(IaquaBinarySensor):
@@ -160,7 +160,7 @@ class IaquaHeater(IaquaSwitch):
 class IaquaAuxSwitch(IaquaSwitch):
     @property
     def is_on(self) -> bool:
-        return self.state == IaquaState.ON if self.state else False
+        return self.state == IaquaBinaryState.ON if self.state else False
 
     async def _toggle(self) -> None:
         await self.system.set_aux(self.data["aux"])

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -180,6 +180,10 @@ class TestIaquaHeater(TestIaquaBinarySensor, TestBaseSwitch):
         with patch.object(self.sut.system, "_parse_home_response"):
             await super().test_turn_off_noop()
 
+    def test_property_is_on_enabled(self) -> None:
+        self.sut.data["state"] = "3"
+        assert self.sut.is_on is True
+
 
 class TestIaquaAuxSwitch(TestIaquaSwitch, TestBaseSwitch):
     def setUp(self) -> None:

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -14,6 +14,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaColorLight,
     IaquaDevice,
     IaquaDimmableLight,
+    IaquaHeater,
     IaquaLightSwitch,
     IaquaPresenceSensor,
     IaquaSensor,
@@ -121,11 +122,43 @@ class TestIaquaSwitch(TestIaquaBinarySensor, TestBaseSwitch):
         super().setUp()
 
         data = {
-            "name": "pool_heater",
+            "name": "pool_pump",
             "state": "0",
         }
         self.sut = IaquaDevice.from_data(self.system, data)
         self.sut_class = IaquaSwitch
+
+    async def test_turn_on(self) -> None:
+        self.sut.data["state"] = "0"
+        with patch.object(self.sut.system, "_parse_home_response"):
+            await super().test_turn_on()
+
+    async def test_turn_on_noop(self) -> None:
+        self.sut.data["state"] = "1"
+        with patch.object(self.sut.system, "_parse_home_response"):
+            await super().test_turn_on_noop()
+
+    async def test_turn_off(self) -> None:
+        self.sut.data["state"] = "1"
+        with patch.object(self.sut.system, "_parse_home_response"):
+            await super().test_turn_off()
+
+    async def test_turn_off_noop(self) -> None:
+        self.sut.data["state"] = "0"
+        with patch.object(self.sut.system, "_parse_home_response"):
+            await super().test_turn_off_noop()
+
+
+class TestIaquaHeater(TestIaquaBinarySensor, TestBaseSwitch):
+    def setUp(self) -> None:
+        super().setUp()
+
+        data = {
+            "name": "pool_heater",
+            "state": "0",
+        }
+        self.sut = IaquaDevice.from_data(self.system, data)
+        self.sut_class = IaquaHeater
 
     async def test_turn_on(self) -> None:
         self.sut.data["state"] = "0"


### PR DESCRIPTION
## Summary

- Split `IaquaAuxState` into two scoped enums:
  - `IaquaBinaryState` (OFF/ON) — used by `IaquaBinarySensor` and `IaquaAuxSwitch`
  - `IaquaHeaterState` (OFF/ON/ENABLED) — used by the new `IaquaHeater`
- Add `IaquaHeater(IaquaSwitch)` — overrides `is_on` to treat both `ON` and `ENABLED` as on (actively heating)
- Route `_heater` devices to `IaquaHeater` in the factory; `_pump` stays `IaquaSwitch`
- Update `IaquaThermostat._heater` return type to `IaquaHeater`

## Test plan

- [ ] `uv run pytest tests/systems/iaqua/test_device.py` — 199 passed, 4 skipped
- [ ] `TestIaquaSwitch` updated to use `pool_pump`; `TestIaquaHeater` added for `pool_heater`
- [ ] `test_property_is_on_enabled` exercises `ENABLED="3"` state on `IaquaHeater`
- [ ] `uv run pre-commit run --all-files` — all hooks pass