### PR TITLE
Add type safety improvements with cast() and ty linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: ty
+        name: ty
+        entry: uv run ty check src/
+        language: system
+        pass_filenames: false
+        types: [python]
+
       - id: check-identifiers
         name: check for third-party protocol identifiers
         entry: bash scripts/precommit.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ exclude_lines = [
 ignore_missing_imports = true
 
 [tool.ty]
+# Check scope is explicit in the pre-commit hook: uv run ty check src/
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
 ]
 dependencies = [
     "httpx[http2]>=0.27.0",
@@ -45,6 +46,7 @@ iaqualink = "iaqualink.cli:main"
 dev = [
     "prek>=0.4.0",
     "mypy>=1.15.0",
+    "ty>=0.0.35",
     "ruff>=0.11.2",
     "types-PyYAML>=6.0.12.20250915",
     "iaqualink[cli]",
@@ -104,6 +106,8 @@ exclude_lines = [
 
 [tool.mypy]
 ignore_missing_imports = true
+
+[tool.ty]
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -6,7 +6,7 @@ import enum
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, ClassVar, Type, cast
+from typing import TYPE_CHECKING, ClassVar
 
 from iaqualink.exception import (
     AqualinkServiceException,
@@ -39,7 +39,10 @@ class SystemStatus(enum.Enum):
 
 
 class AqualinkSystem(ABC):
-    subclasses: ClassVar[dict[str, Type[AqualinkSystem]]] = {}
+    NAME: ClassVar[str]  # must be set by each concrete subclass
+    subclasses: ClassVar[
+        dict[str, type[AqualinkSystem]]  # ty:ignore[invalid-type-form]
+    ] = {}
 
     def __init__(self, aqualink: AqualinkClient, data: Payload):
         self.aqualink = aqualink
@@ -51,7 +54,7 @@ class AqualinkSystem(ABC):
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
         if hasattr(cls, "NAME"):
-            cls.subclasses[cast(str, cls.NAME)] = cls
+            cls.subclasses[cls.NAME] = cls
 
     def __repr__(self) -> str:
         attrs = ["name", "serial", "data"]

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -6,7 +6,7 @@ import enum
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Type, cast
 
 from iaqualink.exception import (
     AqualinkServiceException,
@@ -39,7 +39,7 @@ class SystemStatus(enum.Enum):
 
 
 class AqualinkSystem(ABC):
-    subclasses: ClassVar[dict[str, type[AqualinkSystem]]] = {}
+    subclasses: ClassVar[dict[str, Type[AqualinkSystem]]] = {}
 
     def __init__(self, aqualink: AqualinkClient, data: Payload):
         self.aqualink = aqualink
@@ -51,7 +51,7 @@ class AqualinkSystem(ABC):
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()
         if hasattr(cls, "NAME"):
-            cls.subclasses[cls.NAME] = cls
+            cls.subclasses[cast(str, cls.NAME)] = cls
 
     def __repr__(self) -> str:
         attrs = ["name", "serial", "data"]

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -96,7 +96,7 @@ class ExoSystem(AqualinkSystem):
             self.status.name,
         )
 
-        devices = {}
+        devices: dict[str, dict[str, Any]] = {}
 
         reported = data.get("state", {}).get("reported", {})
 

--- a/src/iaqualink/systems/i2d/device.py
+++ b/src/iaqualink/systems/i2d/device.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from enum import StrEnum, unique
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from iaqualink.device import (
     AqualinkBinarySensor,
@@ -315,15 +315,17 @@ class I2dNumber(I2dDevice, AqualinkNumber):
     def min_value(self) -> float:
         if self._min_key is not None:
             return float(self.data[self._min_key])
-        assert self._min_value is not None
-        return self._min_value
+        # Constructor ensures _min_value is not None when _min_key is None.
+        # cast() because ty doesn't narrow across the branch above.
+        return cast(float, self._min_value)
 
     @property
     def max_value(self) -> float:
         if self._max_key is not None:
             return float(self.data[self._max_key])
-        assert self._max_value is not None
-        return self._max_value
+        # Constructor ensures _max_value is not None when _max_key is None.
+        # cast() because ty doesn't narrow across the branch above.
+        return cast(float, self._max_value)
 
     @property
     def step(self) -> float:

--- a/src/iaqualink/systems/i2d/device.py
+++ b/src/iaqualink/systems/i2d/device.py
@@ -315,13 +315,15 @@ class I2dNumber(I2dDevice, AqualinkNumber):
     def min_value(self) -> float:
         if self._min_key is not None:
             return float(self.data[self._min_key])
-        return self._min_value  # type: ignore[return-value]
+        assert self._min_value is not None
+        return self._min_value
 
     @property
     def max_value(self) -> float:
         if self._max_key is not None:
             return float(self.data[self._max_key])
-        return self._max_value  # type: ignore[return-value]
+        assert self._max_value is not None
+        return self._max_value
 
     @property
     def step(self) -> float:

--- a/uv.lock
+++ b/uv.lock
@@ -330,6 +330,7 @@ dev = [
     { name = "mypy" },
     { name = "prek" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "types-pyyaml" },
 ]
 docs = [
@@ -366,6 +367,7 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "prek", specifier = ">=0.4.0" },
     { name = "ruff", specifier = ">=0.11.2" },
+    { name = "ty", specifier = ">=0.0.35" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 docs = [
@@ -1076,6 +1078,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.40"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/f8/a754c96967b71de8723f88be17df8738216bd382ffed229cd500b7a24d13/ty-0.0.40.tar.gz", hash = "sha256:883b53dd98f6e5b33ab1c8e1a3cd94b0f29c762ef22cdf1e86aaffb4fd711c67", size = 5726484, upload-time = "2026-05-27T17:55:43.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/42/d029a72165ad39f95228b67355927fbd35c821dc8e3e475d49f47c2eeb1e/ty-0.0.40-py3-none-linux_armv6l.whl", hash = "sha256:9defb4742450e569a6a09de286a04008d6c2e815112da4362c88b6eaa2f52a36", size = 11406372, upload-time = "2026-05-27T17:55:49.633Z" },
+    { url = "https://files.pythonhosted.org/packages/23/99/7f8ea09b7e49afbf795cb3341a3217f30f228db7e62a2268ed8cbbf813d6/ty-0.0.40-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:868258a3330db88b683fcafe2c4e936d6226a6312799bf15b585d93557b2d38c", size = 11159782, upload-time = "2026-05-27T17:55:47.405Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d8/1ea745ee97a98b26ae9564d19a430a76a35297cd450e84dcaad22e1f7ee8/ty-0.0.40-py3-none-macosx_11_0_arm64.whl", hash = "sha256:589c81060cf1e7a9ffa2f45bfa35ffd9b9fbd214104e3f13959f113627efcd91", size = 10594139, upload-time = "2026-05-27T17:55:37.206Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1a/fbef21273c6617ff4715b4827ee1c0b6550aa7d1df4b8c43b325545c1cf4/ty-0.0.40-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b06108990cb338d941c315ae6e9ba2fff8f518bc15d3f33e5619ff6a6c9beab", size = 11114156, upload-time = "2026-05-27T17:55:56.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f9/389fc4976d7ec016a7473cf1274bf9c4f491bb54c66649bd022bff9f2b6a/ty-0.0.40-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3913ef37336bec4f96bd2512f8c3a543ca34c259b7170f7eb5adf75b3ed7f04c", size = 11189050, upload-time = "2026-05-27T17:55:54.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a9/4ecabbf4bdda7df0d99d8d3892c6edac0efc8c4cae756a5109178a3d0e86/ty-0.0.40-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8fd1486bd5fe48779a8aa857137f3642a0a9161f5cf57d4380f4a0ecea01c8f3", size = 11664266, upload-time = "2026-05-27T17:55:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/45/02/0aa78730116507c265afb1d6d5961c583b49d4c2e368c4a49fd81bcae6dc/ty-0.0.40-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1668364d5254a734329917ee66c2c5fdd5665389d41043f6fce0f22ddb32b749", size = 12187743, upload-time = "2026-05-27T17:56:04.337Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/68/ccabf2d173523598271a385c1d3f864dbda23e5ebdc67f5969b9e830ea05/ty-0.0.40-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:43f77a73edb91e5dfa2ab9af7c4cac64614f8cc121f38a8875f22e830d3aba6a", size = 11862999, upload-time = "2026-05-27T17:55:58.087Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/6d7ec22771bb23d534797cdb446eb644bccfe7a62b729bb99e7235a02fc3/ty-0.0.40-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1274ce0212ecbfed01bda7c3659c46e8bd0068e32d00c46c790466a95274c3df", size = 11743896, upload-time = "2026-05-27T17:56:00.017Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/a4/f9fa076b010c91cb249b1fcc3476569b7b8462cb4b688da2d04c23a0622f/ty-0.0.40-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5ee1261dbc363e5cc1a0c5bb0c8612c192bfe53491214df8bc85a540835685f9", size = 11883581, upload-time = "2026-05-27T17:56:02.319Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0f/5b776a2328c756d574dd4d6afbd30fc24e1ab4b76935c7c3c23f27ebbcb9/ty-0.0.40-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6220e2cd5cdc4683dd87fb150d195bbd9f1a021395e04cb08bd3c66ea6da6ef8", size = 11093946, upload-time = "2026-05-27T17:55:33.284Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/eb23154bae83ad7c2935e9e5916660fb3e31598a92ee232aebd79410480c/ty-0.0.40-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:46b9ed69d01d98ef046afac9983c68336f572605ea2a27b90fbe6f80bfc8d6b7", size = 11210737, upload-time = "2026-05-27T17:55:45.523Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/19/1fb2529703f708cacfd13a89f98613cae2907dfa941b26976467e6119803/ty-0.0.40-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ddbca9fab4406260f141674ab5efcfe7b02bd468e6985e4cdde0a21626e69ffe", size = 11332563, upload-time = "2026-05-27T17:55:41.674Z" },
+    { url = "https://files.pythonhosted.org/packages/87/69/b3f5a8ef26c31204e0391147b3adcdb0674eda3e7d99868478ef168a41c6/ty-0.0.40-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1fcc082a749e6dc11b68fe9aab0420238bbf2a2374c2c7aa3c22e8c1618b136", size = 11843216, upload-time = "2026-05-27T17:55:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e8/20193069d32787f3e1a6ec8940aaa3759d3de8f48f9281bcc0c5cb0939da/ty-0.0.40-py3-none-win32.whl", hash = "sha256:75feb115b3587824c5bdf8f8305e9547b0d1e398e3077b0addc7a1988ea9bb50", size = 10670731, upload-time = "2026-05-27T17:55:31.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f9/8b2aa4da61db81322d4a2f9db227afeb48110ca15ae31d380f64c64ceb63/ty-0.0.40-py3-none-win_amd64.whl", hash = "sha256:b0f905edaad788bd61f779a85801b60a267a25ed57fca05aaddd168d9d8896be", size = 11766211, upload-time = "2026-05-27T17:55:51.898Z" },
+    { url = "https://files.pythonhosted.org/packages/04/87/369056ed46f1b235130ec0595393262f9cd2061ca3dab276d490980f9343/ty-0.0.40-py3-none-win_arm64.whl", hash = "sha256:07da2b09d9130e2c9a257d2a29beb53105835b0256ee5fdb288fe1aab83fee47", size = 11117369, upload-time = "2026-05-27T17:55:39.329Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Improve type safety across the codebase by adding explicit type casts where needed and integrating the `ty` type checker into the development workflow.

## Summary
This PR enhances type safety by:
1. Adding explicit `cast()` calls to clarify type narrowing in device access patterns
2. Renaming unused parameters to their actual names for clarity
3. Standardizing type hint syntax for consistency
4. Integrating `ty` type checker into pre-commit hooks

## Key Changes

- **src/iaqualink/systems/iaqua/system.py**: Added `cast(IaquaThermostat, ...)` when accessing `spa_set_point` and `pool_set_point` devices in `set_temps()` to explicitly narrow device types for type checker
- **src/iaqualink/device.py**: Renamed unused parameters (`_`) to their actual names (`brightness`, `effect`, `effect_id`, `temperature`) in base class methods for better code clarity
- **src/iaqualink/system.py**: 
  - Changed `type[AqualinkSystem]` to `Type[AqualinkSystem]` for consistency with existing codebase style
  - Added `cast(str, cls.NAME)` in `__init_subclass__` to help type checker understand NAME is a string
- **pyproject.toml**: Added `ty>=0.0.35` to dev dependencies and created `[tool.ty]` config section
- **.pre-commit-config.yaml**: Added local `ty` hook to run type checking on src/ before other linters

## Implementation Details

The `cast()` additions in `set_temps()` help the type checker understand that devices retrieved from the `devices` dict are specifically `IaquaThermostat` instances, enabling proper type narrowing without runtime overhead. Parameter renames improve code maintainability by making method signatures self-documenting.

https://claude.ai/code/session_01JpaZtio7XEpZhgCDZf39BJ