### PR TITLE
feat(client): migrate device list to signed v2 endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ The library follows a plugin-style architecture with base classes and system-spe
 
 4. **Request signing** ([util.py](src/iaqualink/util.py)) - HMAC-SHA1 utility
    - `sign(parts, secret)` joins `parts` with `,` and returns lowercase hex HMAC-SHA1
-   - Used by `AqualinkClient` for system discovery; designed to cover all three signature variants (device list, shadow, commands)
+   - Used by `AqualinkClient` for system discovery; designed to cover all three signature variants from the spec (device list — implemented; shadow and commands — future)
 
 5. **CLI package** ([src/iaqualink/cli](src/iaqualink/cli)) - User-facing Typer command line client
    - Entry point is the packaged `iaqualink` script
@@ -130,7 +130,7 @@ The library follows a plugin-style architecture with base classes and system-spe
 
 **System Discovery (all system types):**
 - Uses `https://r-api.iaqualink.net/v2/devices.json`
-- HMAC-SHA1 signature over `"{user_id},{timestamp}"` with `AQUALINK_API_SECRET_KEY`
+- HMAC-SHA1 signature over `"{user_id},{timestamp}"` with `AQUALINK_API_SIGNING_KEY`
 - Auth via `Authorization: Bearer {IdToken}` header and `api_key` header
 
 **iAqua Systems:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,11 @@ The library follows a plugin-style architecture with base classes and system-spe
      - **ExoDevice** ([systems/exo/device.py](src/iaqualink/systems/exo/device.py))
    - Device types include: sensors, pumps, heaters, lights, thermostats, aux toggles
 
-4. **CLI package** ([src/iaqualink/cli](src/iaqualink/cli)) - User-facing Typer command line client
+4. **Request signing** ([util.py](src/iaqualink/util.py)) - HMAC-SHA1 utility
+   - `sign(parts, secret)` joins `parts` with `,` and returns lowercase hex HMAC-SHA1
+   - Used by `AqualinkClient` for system discovery; designed to cover all three signature variants (device list, shadow, commands)
+
+5. **CLI package** ([src/iaqualink/cli](src/iaqualink/cli)) - User-facing Typer command line client
    - Entry point is the packaged `iaqualink` script
    - Centralizes config loading from CLI options, environment variables, and `typer.get_app_dir("iaqualink") / "config.yaml"`
    - Persists session state in a JSON cookie jar at `typer.get_app_dir("iaqualink") / "session.json"` by default
@@ -124,9 +128,14 @@ The library follows a plugin-style architecture with base classes and system-spe
 
 ### API Differences
 
+**System Discovery (all system types):**
+- Uses `https://r-api.iaqualink.net/v2/devices.json`
+- HMAC-SHA1 signature over `"{user_id},{timestamp}"` with `AQUALINK_API_SECRET_KEY`
+- Auth via `Authorization: Bearer {IdToken}` header and `api_key` header
+
 **iAqua Systems:**
 - Authentication returns `session_id` and `authentication_token`
-- Uses query parameters for authentication
+- Device commands use session tokens as query parameters
 - Two API calls for updates: "get_home" and "get_devices"
 - Commands sent as session requests with specific command names
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -81,6 +81,24 @@ AqualinkDevice (base)
 - Command execution
 - Type-specific behavior
 
+### 4. Request Signing Utilities
+
+**Location:** `src/iaqualink/util.py`
+
+Shared HMAC-SHA1 helpers used by `AqualinkClient` and system implementations.
+
+**`sign(parts, secret)`**
+
+Joins `parts` with `,` and returns a lowercase hex HMAC-SHA1 digest:
+
+```python
+sign(["user_id", "timestamp"], api_secret_key)          # device list (v2)
+sign(["serial", "user_id"], api_secret_key)             # device shadow
+sign(["serial", "user_id", "timestamp"], api_secret_key) # commands/writes
+```
+
+Raises `ValueError` if `parts` is empty.
+
 ## System Implementations
 
 ### iAqua Systems
@@ -188,6 +206,7 @@ tests/
 ├── test_client.py             # Client tests
 ├── test_system.py             # System tests
 ├── test_device.py             # Device tests
+├── test_util.py               # Signing utility tests
 └── systems/
     ├── iaqua/
     │   ├── base_test_system.py   # Abstract iAqua tests

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -92,9 +92,9 @@ Shared HMAC-SHA1 helpers used by `AqualinkClient` and system implementations.
 Joins `parts` with `,` and returns a lowercase hex HMAC-SHA1 digest:
 
 ```python
-sign(["user_id", "timestamp"], api_secret_key)          # device list (v2)
-sign(["serial", "user_id"], api_secret_key)             # device shadow
-sign(["serial", "user_id", "timestamp"], api_secret_key) # commands/writes
+sign(["user_id", "timestamp"], api_signing_key)           # device list (v2) — implemented
+sign(["serial", "user_id"], api_signing_key)              # device shadow — future
+sign(["serial", "user_id", "timestamp"], api_signing_key) # commands/writes — future
 ```
 
 Raises `ValueError` if `parts` is empty.

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -81,7 +81,7 @@ AqualinkDevice (base)
 - Command execution
 - Type-specific behavior
 
-### 4. Request Signing Utilities
+### 4. Utilities
 
 **Location:** `src/iaqualink/util.py`
 

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -40,7 +40,7 @@ The library automatically detects whether you have an iAqua or eXO system and us
 
 - Uses iaqualink.net API
 - Authentication returns `session_id` and `authentication_token`
-- Credentials passed as query parameters
+- Device commands use session tokens as query parameters
 
 ### eXO Systems
 

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import time
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Self
 
@@ -10,6 +11,7 @@ import httpx
 
 from iaqualink.const import (
     AQUALINK_API_KEY,
+    AQUALINK_API_SECRET_KEY,
     AQUALINK_DEVICES_URL,
     AQUALINK_LOGIN_URL,
     AQUALINK_REFRESH_URL,
@@ -22,6 +24,7 @@ from iaqualink.exception import (
     AqualinkServiceUnauthorizedException,
 )
 from iaqualink.reauth import send_with_reauth_retry
+from iaqualink.util import sign
 from iaqualink.system import AqualinkSystem
 
 if TYPE_CHECKING:
@@ -300,14 +303,20 @@ class AqualinkClient:
 
     async def _send_systems_request(self) -> httpx.Response:
         async def do_request() -> httpx.Response:
-            params = {
-                "api_key": AQUALINK_API_KEY,
-                "authentication_token": self.authentication_token,
-                "user_id": self.user_id,
-            }
-            params_str = "&".join(f"{k}={v}" for k, v in params.items())
-            url = f"{AQUALINK_DEVICES_URL}?{params_str}"
-            return await self.send_request(url)
+            timestamp = str(int(time.time()))
+            signature = sign([self.user_id, timestamp], AQUALINK_API_SECRET_KEY)
+            return await self.send_request(
+                AQUALINK_DEVICES_URL,
+                params={
+                    "user_id": self.user_id,
+                    "signature": signature,
+                    "timestamp": timestamp,
+                },
+                headers={
+                    "api_key": AQUALINK_API_KEY,
+                    "Authorization": f"Bearer {self.id_token}",
+                },
+            )
 
         return await send_with_reauth_retry(
             do_request,
@@ -323,6 +332,7 @@ class AqualinkClient:
             raise
 
         data = r.json()
+        LOGGER.debug("Systems response: %s", data)
 
         systems = [AqualinkSystem.from_data(self, x) for x in data]
         return {x.serial: x for x in systems}

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -11,7 +11,7 @@ import httpx
 
 from iaqualink.const import (
     AQUALINK_API_KEY,
-    AQUALINK_API_SECRET_KEY,
+    AQUALINK_API_SIGNING_KEY,
     AQUALINK_DEVICES_URL,
     AQUALINK_LOGIN_URL,
     AQUALINK_REFRESH_URL,
@@ -295,6 +295,8 @@ class AqualinkClient:
         self.authentication_token = data["authentication_token"]
         self.user_id = str(data["id"])
         self.id_token = data["userPoolOAuth"]["IdToken"]
+        if not self.id_token:
+            raise AqualinkServiceException("Login response missing IdToken")
         self.refresh_token = data["userPoolOAuth"].get(
             "RefreshToken", refresh_token_fallback
         )
@@ -304,7 +306,9 @@ class AqualinkClient:
     async def _send_systems_request(self) -> httpx.Response:
         async def do_request() -> httpx.Response:
             timestamp = str(int(time.time()))
-            signature = sign([self.user_id, timestamp], AQUALINK_API_SECRET_KEY)
+            signature = sign(
+                [self.user_id, timestamp], AQUALINK_API_SIGNING_KEY
+            )
             return await self.send_request(
                 AQUALINK_DEVICES_URL,
                 params={

--- a/src/iaqualink/const.py
+++ b/src/iaqualink/const.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 AQUALINK_API_KEY = "EOOEMOW4YR6QNB07"
-AQUALINK_API_SECRET_KEY = "cj7iYKjiKxOqiLcN65PffA"
+AQUALINK_API_SIGNING_KEY = "cj7iYKjiKxOqiLcN65PffA"
 
 AQUALINK_LOGIN_URL = "https://prod.zodiac-io.com/users/v1/login"
 AQUALINK_REFRESH_URL = "https://prod.zodiac-io.com/users/v1/refresh"

--- a/src/iaqualink/const.py
+++ b/src/iaqualink/const.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 AQUALINK_API_KEY = "EOOEMOW4YR6QNB07"
+AQUALINK_API_SECRET_KEY = "cj7iYKjiKxOqiLcN65PffA"
 
 AQUALINK_LOGIN_URL = "https://prod.zodiac-io.com/users/v1/login"
 AQUALINK_REFRESH_URL = "https://prod.zodiac-io.com/users/v1/refresh"
-AQUALINK_DEVICES_URL = "https://r-api.iaqualink.net/devices.json"
+AQUALINK_DEVICES_URL = "https://r-api.iaqualink.net/v2/devices.json"
 
 KEEPALIVE_EXPIRY = 30
 DEFAULT_REQUEST_TIMEOUT = 10.0

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+from collections.abc import Sequence
 
 
-def sign(parts: list[str], secret: str) -> str:
+def sign(parts: Sequence[str], secret: str) -> str:
     if not parts:
         raise ValueError("parts must be non-empty")
     message = ",".join(parts)

--- a/src/iaqualink/util.py
+++ b/src/iaqualink/util.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+
+def sign(parts: list[str], secret: str) -> str:
+    if not parts:
+        raise ValueError("parts must be non-empty")
+    message = ",".join(parts)
+    return hmac.new(secret.encode(), message.encode(), hashlib.sha1).hexdigest()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,6 +68,14 @@ def _make_resp(status: int, data: dict | None = None) -> MagicMock:
     return r
 
 
+def _expected_sig(user_id: str, timestamp: str) -> str:
+    return hmac.new(
+        AQUALINK_API_SIGNING_KEY.encode(),
+        f"{user_id},{timestamp}".encode(),
+        hashlib.sha1,
+    ).hexdigest()
+
+
 class TestAqualinkClient(TestBase):
     def setUp(self) -> None:
         super().setUp()
@@ -282,7 +290,7 @@ class TestAqualinkClient(TestBase):
         assert self.client.logged is False
 
     @patch("httpx.AsyncClient.request")
-    async def test_login_fails_when_id_token_missing(
+    async def test_login_fails_when_id_token_empty(
         self, mock_request
     ) -> None:
         data = {**LOGIN_DATA, "userPoolOAuth": {"IdToken": ""}}
@@ -371,14 +379,7 @@ class TestAqualinkClient(TestBase):
         params = retry_call.kwargs["params"]
         assert params["user_id"] == "id"
         assert params["timestamp"] == "1000000000"
-        assert (
-            params["signature"]
-            == hmac.new(
-                AQUALINK_API_SIGNING_KEY.encode(),
-                b"id,1000000000",
-                hashlib.sha1,
-            ).hexdigest()
-        )
+        assert params["signature"] == _expected_sig("id", "1000000000")
         # Bearer token must use the refreshed IdToken, not the original.
         new_id_token = REFRESH_RESPONSE_DATA["userPoolOAuth"]["IdToken"]
         assert (
@@ -407,14 +408,7 @@ class TestAqualinkClient(TestBase):
         assert systems_call[0][1] == AQUALINK_DEVICES_URL
         assert params["user_id"] == "id"
         assert params["timestamp"] == "1234567890"
-        assert (
-            params["signature"]
-            == hmac.new(
-                AQUALINK_API_SIGNING_KEY.encode(),
-                b"id,1234567890",
-                hashlib.sha1,
-            ).hexdigest()
-        )
+        assert params["signature"] == _expected_sig("id", "1234567890")
         assert headers["Authorization"] == "Bearer userPoolOAuth:IdToken"
         assert headers["api_key"] == AQUALINK_API_KEY
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -357,12 +357,12 @@ class TestAqualinkClient(TestBase):
         systems = await self.client.get_systems()
         assert len(systems) == 1
 
-    @patch("iaqualink.client.time")
+    @patch("iaqualink.client.time.time")
     @patch("httpx.AsyncClient.request")
     async def test_systems_request_retries_after_refresh(
         self, mock_request, mock_time
     ) -> None:
-        mock_time.time.return_value = 1_000_000_000
+        mock_time.return_value = 1_000_000_000
         mock_request.side_effect = [
             _make_resp(200, LOGIN_DATA_WITH_REFRESH),
             _make_resp(401),
@@ -387,12 +387,12 @@ class TestAqualinkClient(TestBase):
             == f"Bearer {new_id_token}"
         )
 
-    @patch("iaqualink.client.time")
+    @patch("iaqualink.client.time.time")
     @patch("httpx.AsyncClient.request")
     async def test_systems_request_v2_params_and_headers(
         self, mock_request, mock_time
     ) -> None:
-        mock_time.time.return_value = 1_234_567_890
+        mock_time.return_value = 1_234_567_890
         mock_request.side_effect = [
             _make_resp(200, LOGIN_DATA_WITH_REFRESH),
             _make_resp(200, []),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import hmac as _hmac
+import hmac
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -15,7 +15,7 @@ from iaqualink.client import (
 )
 from iaqualink.const import (
     AQUALINK_API_KEY,
-    AQUALINK_API_SECRET_KEY,
+    AQUALINK_API_SIGNING_KEY,
     AQUALINK_DEVICES_URL,
     DEFAULT_REQUEST_TIMEOUT,
 )
@@ -282,6 +282,18 @@ class TestAqualinkClient(TestBase):
         assert self.client.logged is False
 
     @patch("httpx.AsyncClient.request")
+    async def test_login_fails_when_id_token_missing(
+        self, mock_request
+    ) -> None:
+        data = {**LOGIN_DATA, "userPoolOAuth": {"IdToken": ""}}
+        mock_request.return_value = _make_resp(200, data)
+
+        with pytest.raises(AqualinkServiceException):
+            await self.client.login()
+
+        assert self.client.logged is False
+
+    @patch("httpx.AsyncClient.request")
     async def test_unexpectedly_logged_out(self, mock_request) -> None:
         mock_request.return_value.status_code = 200
         mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
@@ -361,8 +373,10 @@ class TestAqualinkClient(TestBase):
         assert params["timestamp"] == "1000000000"
         assert (
             params["signature"]
-            == _hmac.new(
-                AQUALINK_API_SECRET_KEY.encode(), b"id,1000000000", hashlib.sha1
+            == hmac.new(
+                AQUALINK_API_SIGNING_KEY.encode(),
+                b"id,1000000000",
+                hashlib.sha1,
             ).hexdigest()
         )
         # Bearer token must use the refreshed IdToken, not the original.
@@ -395,8 +409,10 @@ class TestAqualinkClient(TestBase):
         assert params["timestamp"] == "1234567890"
         assert (
             params["signature"]
-            == _hmac.new(
-                AQUALINK_API_SECRET_KEY.encode(), b"id,1234567890", hashlib.sha1
+            == hmac.new(
+                AQUALINK_API_SIGNING_KEY.encode(),
+                b"id,1234567890",
+                hashlib.sha1,
             ).hexdigest()
         )
         assert headers["Authorization"] == "Bearer userPoolOAuth:IdToken"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac as _hmac
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -12,6 +14,9 @@ from iaqualink.client import (
     AqualinkClient,
 )
 from iaqualink.const import (
+    AQUALINK_API_KEY,
+    AQUALINK_API_SECRET_KEY,
+    AQUALINK_DEVICES_URL,
     DEFAULT_REQUEST_TIMEOUT,
 )
 from iaqualink.exception import (
@@ -332,10 +337,12 @@ class TestAqualinkClient(TestBase):
         systems = await self.client.get_systems()
         assert len(systems) == 1
 
+    @patch("iaqualink.client.time")
     @patch("httpx.AsyncClient.request")
     async def test_systems_request_retries_after_refresh(
-        self, mock_request
+        self, mock_request, mock_time
     ) -> None:
+        mock_time.time.return_value = 1_000_000_000
         mock_request.side_effect = [
             _make_resp(200, LOGIN_DATA_WITH_REFRESH),
             _make_resp(401),
@@ -347,9 +354,53 @@ class TestAqualinkClient(TestBase):
         systems = await self.client.get_systems()
 
         assert systems == {}
-        retry_url = mock_request.call_args_list[3][0][1]
-        assert "authentication_token=new-token" in retry_url
-        assert "user_id=id" in retry_url
+        retry_call = mock_request.call_args_list[3]
+        assert retry_call[0][1] == AQUALINK_DEVICES_URL
+        params = retry_call.kwargs["params"]
+        assert params["user_id"] == "id"
+        assert params["timestamp"] == "1000000000"
+        assert (
+            params["signature"]
+            == _hmac.new(
+                AQUALINK_API_SECRET_KEY.encode(), b"id,1000000000", hashlib.sha1
+            ).hexdigest()
+        )
+        # Bearer token must use the refreshed IdToken, not the original.
+        new_id_token = REFRESH_RESPONSE_DATA["userPoolOAuth"]["IdToken"]
+        assert (
+            retry_call.kwargs["headers"]["Authorization"]
+            == f"Bearer {new_id_token}"
+        )
+
+    @patch("iaqualink.client.time")
+    @patch("httpx.AsyncClient.request")
+    async def test_systems_request_v2_params_and_headers(
+        self, mock_request, mock_time
+    ) -> None:
+        mock_time.time.return_value = 1_234_567_890
+        mock_request.side_effect = [
+            _make_resp(200, LOGIN_DATA_WITH_REFRESH),
+            _make_resp(200, []),
+        ]
+
+        await self.client.login()
+        await self.client.get_systems()
+
+        systems_call = mock_request.call_args_list[1]
+        params = systems_call.kwargs["params"]
+        headers = systems_call.kwargs["headers"]
+
+        assert systems_call[0][1] == AQUALINK_DEVICES_URL
+        assert params["user_id"] == "id"
+        assert params["timestamp"] == "1234567890"
+        assert (
+            params["signature"]
+            == _hmac.new(
+                AQUALINK_API_SECRET_KEY.encode(), b"id,1234567890", hashlib.sha1
+            ).hexdigest()
+        )
+        assert headers["Authorization"] == "Bearer userPoolOAuth:IdToken"
+        assert headers["api_key"] == AQUALINK_API_KEY
 
     @patch("httpx.AsyncClient.request")
     async def test_systems_request_repeated_401_refreshes_only_once(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -290,9 +290,7 @@ class TestAqualinkClient(TestBase):
         assert self.client.logged is False
 
     @patch("httpx.AsyncClient.request")
-    async def test_login_fails_when_id_token_empty(
-        self, mock_request
-    ) -> None:
+    async def test_login_fails_when_id_token_empty(self, mock_request) -> None:
         data = {**LOGIN_DATA, "userPoolOAuth": {"IdToken": ""}}
         mock_request.return_value = _make_resp(200, data)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,15 +7,24 @@ import pytest
 from iaqualink.util import sign
 
 
-class TestSign(unittest.IsolatedAsyncioTestCase):
+class TestSign(unittest.TestCase):
     def test_single_part(self) -> None:
-        assert sign(["foo"], "secret") == "9baed91be7f58b57c824b60da7cb262b2ecafbd2"
+        assert (
+            sign(["foo"], "secret")
+            == "9baed91be7f58b57c824b60da7cb262b2ecafbd2"
+        )
 
     def test_two_parts_joined_with_comma(self) -> None:
-        assert sign(["foo", "bar"], "secret") == "f8a1d5f86b75816db3efe1e2f0ae961e721b5cb7"
+        assert (
+            sign(["foo", "bar"], "secret")
+            == "f8a1d5f86b75816db3efe1e2f0ae961e721b5cb7"
+        )
 
     def test_three_parts(self) -> None:
-        assert sign(["a", "b", "c"], "secret") == "86cbb34b4f6bf6e24b6524c2d5e6c6c9490a5615"
+        assert (
+            sign(["a", "b", "c"], "secret")
+            == "86cbb34b4f6bf6e24b6524c2d5e6c6c9490a5615"
+        )
 
     def test_empty_parts_raises(self) -> None:
         with pytest.raises(ValueError):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import unittest
+
+import pytest
+
+from iaqualink.util import sign
+
+
+class TestSign(unittest.IsolatedAsyncioTestCase):
+    def test_single_part(self) -> None:
+        assert sign(["foo"], "secret") == "9baed91be7f58b57c824b60da7cb262b2ecafbd2"
+
+    def test_two_parts_joined_with_comma(self) -> None:
+        assert sign(["foo", "bar"], "secret") == "f8a1d5f86b75816db3efe1e2f0ae961e721b5cb7"
+
+    def test_three_parts(self) -> None:
+        assert sign(["a", "b", "c"], "secret") == "86cbb34b4f6bf6e24b6524c2d5e6c6c9490a5615"
+
+    def test_empty_parts_raises(self) -> None:
+        with pytest.raises(ValueError):
+            sign([], "secret")


### PR DESCRIPTION
## Summary

- Replace v1 device list endpoint (`/devices.json` with `api_key`, `authentication_token`, `user_id` query params) with v2 (`/v2/devices.json`) using HMAC-SHA1 request signing and `Authorization: Bearer {IdToken}`
- Add `util.sign(parts, secret)` helper that joins `parts` with `,` before signing — designed to cover all three signature variants from the spec (device list, device shadow, commands)
- Update `AQUALINK_DEVICES_URL` in place; add `AQUALINK_API_SECRET_KEY` constant

## Test plan

- [ ] `test_systems_request_v2_params_and_headers` — verifies correct URL, `user_id`/`timestamp`/`signature` params and `Authorization`/`api_key` headers with frozen timestamp
- [ ] `test_systems_request_retries_after_refresh` — verifies retry carries refreshed `IdToken` in `Authorization` and correct HMAC signature
- [ ] `tests/test_util.py` — pins `sign()` output against known HMAC-SHA1 values for 1-, 2-, 3-part inputs; asserts empty parts raises `ValueError`
- [ ] Full suite: 585 passed, 10 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)