### PR TITLE
feat(device): add AqualinkPump base class

### DIFF
--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -186,7 +186,7 @@ class AqualinkNumber(AqualinkDevice):
         raise NotImplementedError
 
 
-class AqualinkPump(AqualinkBinarySensor):
+class AqualinkPump(AqualinkDevice):
     @property
     def supports_turn_on(self) -> bool:
         return False
@@ -213,13 +213,13 @@ class AqualinkPump(AqualinkBinarySensor):
     def supported_presets(self) -> list[str]:
         if self.supports_presets:
             raise NotImplementedError
-        return []
+        raise AqualinkOperationNotSupportedException
 
     @property
     def current_preset(self) -> str | None:
         if self.supports_presets:
             raise NotImplementedError
-        return None
+        raise AqualinkOperationNotSupportedException
 
     @property
     def supports_set_speed_percentage(self) -> bool:

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -187,6 +187,10 @@ class AqualinkNumber(AqualinkDevice):
 
 
 class AqualinkPump(AqualinkSwitch, AqualinkDevice):
+    # Some pump models are always-on; supports_turn_off=False signals this.
+    # Unlike AqualinkSwitch (which raises NotImplementedError unconditionally),
+    # AqualinkPump gates turn_on/turn_off behind capability flags so subclasses
+    # can advertise non-switchable pumps without overriding both methods.
     @property
     def supports_turn_on(self) -> bool:
         return True
@@ -226,7 +230,20 @@ class AqualinkPump(AqualinkSwitch, AqualinkDevice):
         return False
 
     async def set_speed(self, _: int) -> None:
+        """Set absolute speed (e.g. RPM). Valid range is device-specific."""
         if self.supports_set_speed:
+            raise NotImplementedError
+        raise AqualinkOperationNotSupportedException
+
+    @property
+    def supports_set_speed_percentage(self) -> bool:
+        return False
+
+    async def set_speed_percentage(self, percentage: int) -> None:
+        """Set speed as a percentage (0-100)."""
+        if self.supports_set_speed_percentage:
+            if not 0 <= percentage <= 100:
+                raise AqualinkInvalidParameterException(percentage)
             raise NotImplementedError
         raise AqualinkOperationNotSupportedException
 

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -195,6 +195,12 @@ class AqualinkPump(AqualinkDevice):
     def supports_turn_off(self) -> bool:
         return False
 
+    @property
+    def is_on(self) -> bool:
+        if self.supports_turn_on or self.supports_turn_off:
+            raise NotImplementedError
+        raise AqualinkOperationNotSupportedException
+
     async def turn_on(self) -> None:
         if self.supports_turn_on:
             raise NotImplementedError

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -4,7 +4,10 @@ import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from iaqualink.exception import AqualinkOperationNotSupportedException
+from iaqualink.exception import (
+    AqualinkInvalidParameterException,
+    AqualinkOperationNotSupportedException,
+)
 
 if TYPE_CHECKING:
     from iaqualink.typing import DeviceData
@@ -183,11 +186,7 @@ class AqualinkNumber(AqualinkDevice):
         raise NotImplementedError
 
 
-class AqualinkPump(AqualinkSwitch, AqualinkDevice):
-    # Pumps default to non-switchable; subclasses opt in by returning True.
-    # Unlike AqualinkSwitch (raises NotImplementedError unconditionally),
-    # AqualinkPump gates turn_on/turn_off so callers can check capability
-    # before attempting control.
+class AqualinkPump(AqualinkBinarySensor):
     @property
     def supports_turn_on(self) -> bool:
         return False
@@ -229,10 +228,14 @@ class AqualinkPump(AqualinkSwitch, AqualinkDevice):
     async def set_speed_percentage(self, percentage: int) -> None:
         """Set speed as a percentage (0-100)."""
         if self.supports_set_speed_percentage:
+            if not 0 <= percentage <= 100:
+                raise AqualinkInvalidParameterException(percentage)
             raise NotImplementedError
         raise AqualinkOperationNotSupportedException
 
-    async def set_preset(self, _: str) -> None:
+    async def set_preset(self, preset: str) -> None:
         if self.supports_presets:
+            if preset not in self.supported_presets:
+                raise AqualinkInvalidParameterException(preset)
             raise NotImplementedError
         raise AqualinkOperationNotSupportedException

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -217,6 +217,7 @@ class AqualinkPump(AqualinkDevice):
 
     @property
     def supported_presets(self) -> list[str]:
+        # subclasses must override this when supports_presets returns True
         if self.supports_presets:
             raise NotImplementedError
         raise AqualinkOperationNotSupportedException
@@ -232,7 +233,6 @@ class AqualinkPump(AqualinkDevice):
         return False
 
     async def set_speed_percentage(self, percentage: int) -> None:
-        """Set speed as a percentage (0-100)."""
         if self.supports_set_speed_percentage:
             if not 0 <= percentage <= 100:
                 raise AqualinkInvalidParameterException(percentage)

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -226,16 +226,6 @@ class AqualinkPump(AqualinkSwitch, AqualinkDevice):
         return None
 
     @property
-    def supports_set_speed(self) -> bool:
-        return False
-
-    async def set_speed(self, _: int) -> None:
-        """Set absolute speed (e.g. RPM). Valid range is device-specific."""
-        if self.supports_set_speed:
-            raise NotImplementedError
-        raise AqualinkOperationNotSupportedException
-
-    @property
     def supports_set_speed_percentage(self) -> bool:
         return False
 

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -184,3 +184,53 @@ class AqualinkNumber(AqualinkDevice):
 
     async def _set_value(self, value: float) -> None:
         raise NotImplementedError
+
+
+class AqualinkPump(AqualinkSwitch, AqualinkDevice):
+    @property
+    def supports_turn_on(self) -> bool:
+        return True
+
+    @property
+    def supports_turn_off(self) -> bool:
+        return True
+
+    async def turn_on(self) -> None:
+        if self.supports_turn_on:
+            raise NotImplementedError
+        raise AqualinkOperationNotSupportedException
+
+    async def turn_off(self) -> None:
+        if self.supports_turn_off:
+            raise NotImplementedError
+        raise AqualinkOperationNotSupportedException
+
+    @property
+    def supports_presets(self) -> bool:
+        return False
+
+    @property
+    def supported_presets(self) -> list[str]:
+        if self.supports_presets:
+            raise NotImplementedError
+        return []
+
+    @property
+    def current_preset(self) -> str | None:
+        if self.supports_presets:
+            raise NotImplementedError
+        return None
+
+    @property
+    def supports_set_speed(self) -> bool:
+        return False
+
+    async def set_speed(self, _: int) -> None:
+        if self.supports_set_speed:
+            raise NotImplementedError
+        raise AqualinkOperationNotSupportedException
+
+    async def set_preset(self, _: str) -> None:
+        if self.supports_presets:
+            raise NotImplementedError
+        raise AqualinkOperationNotSupportedException

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -4,10 +4,7 @@ import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from iaqualink.exception import (
-    AqualinkInvalidParameterException,
-    AqualinkOperationNotSupportedException,
-)
+from iaqualink.exception import AqualinkOperationNotSupportedException
 
 if TYPE_CHECKING:
     from iaqualink.typing import DeviceData
@@ -187,17 +184,17 @@ class AqualinkNumber(AqualinkDevice):
 
 
 class AqualinkPump(AqualinkSwitch, AqualinkDevice):
-    # Some pump models are always-on; supports_turn_off=False signals this.
-    # Unlike AqualinkSwitch (which raises NotImplementedError unconditionally),
-    # AqualinkPump gates turn_on/turn_off behind capability flags so subclasses
-    # can advertise non-switchable pumps without overriding both methods.
+    # Pumps default to non-switchable; subclasses opt in by returning True.
+    # Unlike AqualinkSwitch (raises NotImplementedError unconditionally),
+    # AqualinkPump gates turn_on/turn_off so callers can check capability
+    # before attempting control.
     @property
     def supports_turn_on(self) -> bool:
-        return True
+        return False
 
     @property
     def supports_turn_off(self) -> bool:
-        return True
+        return False
 
     async def turn_on(self) -> None:
         if self.supports_turn_on:
@@ -232,8 +229,6 @@ class AqualinkPump(AqualinkSwitch, AqualinkDevice):
     async def set_speed_percentage(self, percentage: int) -> None:
         """Set speed as a percentage (0-100)."""
         if self.supports_set_speed_percentage:
-            if not 0 <= percentage <= 100:
-                raise AqualinkInvalidParameterException(percentage)
             raise NotImplementedError
         raise AqualinkOperationNotSupportedException
 

--- a/tests/base_test_device.py
+++ b/tests/base_test_device.py
@@ -363,7 +363,7 @@ class TestBaseNumber(TestBaseDevice):
         assert len(respx_mock.calls) == 0
 
 
-class TestBasePump(TestBaseSwitch):
+class TestBasePump(TestBaseBinarySensor):
     def test_inheritance(self) -> None:
         assert isinstance(self.sut, AqualinkPump)
 

--- a/tests/base_test_device.py
+++ b/tests/base_test_device.py
@@ -373,6 +373,13 @@ class TestBasePump(TestBaseDevice):
     def test_property_supports_turn_off(self) -> None:
         assert isinstance(self.sut.supports_turn_off, bool)
 
+    def test_property_is_on(self) -> None:
+        if not (self.sut.supports_turn_on or self.sut.supports_turn_off):
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                _ = self.sut.is_on
+        else:
+            assert isinstance(self.sut.is_on, bool)
+
     @respx.mock
     async def test_turn_on(self, respx_mock: respx.router.MockRouter) -> None:
         if not self.sut.supports_turn_on:

--- a/tests/base_test_device.py
+++ b/tests/base_test_device.py
@@ -8,6 +8,7 @@ import respx
 import respx.router
 
 from iaqualink.device import (
+    AqualinkPump,
     AqualinkBinarySensor,
     AqualinkLight,
     AqualinkNumber,
@@ -359,4 +360,131 @@ class TestBaseNumber(TestBaseDevice):
         respx_mock.route(dotstar).mock(resp_200)
         with pytest.raises(AqualinkInvalidParameterException):
             await self.sut.set_value(self.sut.max_value + 1.0)
+        assert len(respx_mock.calls) == 0
+
+
+class TestBasePump(TestBaseSwitch):
+    def test_inheritance(self) -> None:
+        assert isinstance(self.sut, AqualinkPump)
+
+    def test_property_supports_turn_on(self) -> None:
+        assert isinstance(self.sut.supports_turn_on, bool)
+
+    def test_property_supports_turn_off(self) -> None:
+        assert isinstance(self.sut.supports_turn_off, bool)
+
+    @respx.mock
+    async def test_turn_on(self, respx_mock: respx.router.MockRouter) -> None:
+        if not self.sut.supports_turn_on:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.turn_on()
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.turn_on()
+        assert len(respx_mock.calls) > 0
+        self.respx_calls = copy.copy(respx_mock.calls)
+
+    @respx.mock
+    async def test_turn_on_noop(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_turn_on:
+            pytest.skip("Device doesn't support turn_on")
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.turn_on()
+        assert len(respx_mock.calls) == 0
+
+    @respx.mock
+    async def test_turn_off(self, respx_mock: respx.router.MockRouter) -> None:
+        if not self.sut.supports_turn_off:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.turn_off()
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.turn_off()
+        assert len(respx_mock.calls) > 0
+        self.respx_calls = copy.copy(respx_mock.calls)
+
+    @respx.mock
+    async def test_turn_off_noop(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_turn_off:
+            pytest.skip("Device doesn't support turn_off")
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.turn_off()
+        assert len(respx_mock.calls) == 0
+
+    def test_property_supports_presets(self) -> None:
+        assert isinstance(self.sut.supports_presets, bool)
+
+    def test_property_supported_presets(self) -> None:
+        if self.sut.supports_presets:
+            assert isinstance(self.sut.supported_presets, list)
+            assert len(self.sut.supported_presets) > 0
+        else:
+            assert self.sut.supported_presets == []
+
+    def test_property_current_preset(self) -> None:
+        if self.sut.supports_presets:
+            assert self.sut.current_preset is None or isinstance(
+                self.sut.current_preset, str
+            )
+        else:
+            assert self.sut.current_preset is None
+
+    def test_property_supports_set_speed(self) -> None:
+        assert isinstance(self.sut.supports_set_speed, bool)
+
+    @respx.mock
+    async def test_set_speed_50(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_set_speed:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.set_speed(50)
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.set_speed(50)
+        assert len(respx_mock.calls) > 0
+        self.respx_calls = copy.copy(respx_mock.calls)
+
+    @respx.mock
+    async def test_set_speed_invalid_150(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_set_speed:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.set_speed(150)
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        with pytest.raises(AqualinkInvalidParameterException):
+            await self.sut.set_speed(150)
+        assert len(respx_mock.calls) == 0
+
+    @respx.mock
+    async def test_set_preset(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_presets:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.set_preset("any")
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        preset = self.sut.supported_presets[0]
+        await self.sut.set_preset(preset)
+        assert len(respx_mock.calls) > 0
+        self.respx_calls = copy.copy(respx_mock.calls)
+
+    @respx.mock
+    async def test_set_preset_invalid(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_presets:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.set_preset("nonexistent")
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        with pytest.raises(AqualinkInvalidParameterException):
+            await self.sut.set_preset("nonexistent_preset")
         assert len(respx_mock.calls) == 0

--- a/tests/base_test_device.py
+++ b/tests/base_test_device.py
@@ -486,6 +486,19 @@ class TestBasePump(TestBaseSwitch):
         self.respx_calls = copy.copy(respx_mock.calls)
 
     @respx.mock
+    async def test_set_speed_percentage_invalid_negative(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_set_speed_percentage:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.set_speed_percentage(-1)
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        with pytest.raises(AqualinkInvalidParameterException):
+            await self.sut.set_speed_percentage(-1)
+        assert len(respx_mock.calls) == 0
+
+    @respx.mock
     async def test_set_speed_percentage_invalid_150(
         self, respx_mock: respx.router.MockRouter
     ) -> None:

--- a/tests/base_test_device.py
+++ b/tests/base_test_device.py
@@ -363,7 +363,7 @@ class TestBaseNumber(TestBaseDevice):
         assert len(respx_mock.calls) == 0
 
 
-class TestBasePump(TestBaseBinarySensor):
+class TestBasePump(TestBaseDevice):
     def test_inheritance(self) -> None:
         assert isinstance(self.sut, AqualinkPump)
 
@@ -433,7 +433,8 @@ class TestBasePump(TestBaseBinarySensor):
             assert isinstance(self.sut.supported_presets, list)
             assert len(self.sut.supported_presets) > 0
         else:
-            assert self.sut.supported_presets == []
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                _ = self.sut.supported_presets
 
     def test_property_current_preset(self) -> None:
         if self.sut.supports_presets:
@@ -441,7 +442,8 @@ class TestBasePump(TestBaseBinarySensor):
                 self.sut.current_preset, str
             )
         else:
-            assert self.sut.current_preset is None
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                _ = self.sut.current_preset
 
     def test_property_supports_set_speed_percentage(self) -> None:
         assert isinstance(self.sut.supports_set_speed_percentage, bool)

--- a/tests/base_test_device.py
+++ b/tests/base_test_device.py
@@ -8,10 +8,10 @@ import respx
 import respx.router
 
 from iaqualink.device import (
-    AqualinkPump,
     AqualinkBinarySensor,
     AqualinkLight,
     AqualinkNumber,
+    AqualinkPump,
     AqualinkSensor,
     AqualinkSwitch,
     AqualinkThermostat,
@@ -390,9 +390,14 @@ class TestBasePump(TestBaseSwitch):
     ) -> None:
         if not self.sut.supports_turn_on:
             pytest.skip("Device doesn't support turn_on")
-        respx_mock.route(dotstar).mock(resp_200)
-        await self.sut.turn_on()
-        assert len(respx_mock.calls) == 0
+        with patch.object(
+            type(self.sut),
+            "is_on",
+            new_callable=PropertyMock(return_value=True),
+        ):
+            respx_mock.route(dotstar).mock(resp_200)
+            await self.sut.turn_on()
+            assert len(respx_mock.calls) == 0
 
     @respx.mock
     async def test_turn_off(self, respx_mock: respx.router.MockRouter) -> None:
@@ -411,9 +416,14 @@ class TestBasePump(TestBaseSwitch):
     ) -> None:
         if not self.sut.supports_turn_off:
             pytest.skip("Device doesn't support turn_off")
-        respx_mock.route(dotstar).mock(resp_200)
-        await self.sut.turn_off()
-        assert len(respx_mock.calls) == 0
+        with patch.object(
+            type(self.sut),
+            "is_on",
+            new_callable=PropertyMock(return_value=False),
+        ):
+            respx_mock.route(dotstar).mock(resp_200)
+            await self.sut.turn_off()
+            assert len(respx_mock.calls) == 0
 
     def test_property_supports_presets(self) -> None:
         assert isinstance(self.sut.supports_presets, bool)
@@ -449,17 +459,59 @@ class TestBasePump(TestBaseSwitch):
         assert len(respx_mock.calls) > 0
         self.respx_calls = copy.copy(respx_mock.calls)
 
+    def test_property_supports_set_speed_percentage(self) -> None:
+        assert isinstance(self.sut.supports_set_speed_percentage, bool)
+
     @respx.mock
-    async def test_set_speed_invalid_150(
+    async def test_set_speed_percentage_0(
         self, respx_mock: respx.router.MockRouter
     ) -> None:
-        if not self.sut.supports_set_speed:
+        if not self.sut.supports_set_speed_percentage:
             with pytest.raises(AqualinkOperationNotSupportedException):
-                await self.sut.set_speed(150)
+                await self.sut.set_speed_percentage(0)
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.set_speed_percentage(0)
+        assert len(respx_mock.calls) > 0
+        self.respx_calls = copy.copy(respx_mock.calls)
+
+    @respx.mock
+    async def test_set_speed_percentage_50(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_set_speed_percentage:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.set_speed_percentage(50)
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.set_speed_percentage(50)
+        assert len(respx_mock.calls) > 0
+        self.respx_calls = copy.copy(respx_mock.calls)
+
+    @respx.mock
+    async def test_set_speed_percentage_100(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_set_speed_percentage:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.set_speed_percentage(100)
+            return
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.set_speed_percentage(100)
+        assert len(respx_mock.calls) > 0
+        self.respx_calls = copy.copy(respx_mock.calls)
+
+    @respx.mock
+    async def test_set_speed_percentage_invalid_150(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        if not self.sut.supports_set_speed_percentage:
+            with pytest.raises(AqualinkOperationNotSupportedException):
+                await self.sut.set_speed_percentage(150)
             return
         respx_mock.route(dotstar).mock(resp_200)
         with pytest.raises(AqualinkInvalidParameterException):
-            await self.sut.set_speed(150)
+            await self.sut.set_speed_percentage(150)
         assert len(respx_mock.calls) == 0
 
     @respx.mock

--- a/tests/base_test_device.py
+++ b/tests/base_test_device.py
@@ -443,22 +443,6 @@ class TestBasePump(TestBaseSwitch):
         else:
             assert self.sut.current_preset is None
 
-    def test_property_supports_set_speed(self) -> None:
-        assert isinstance(self.sut.supports_set_speed, bool)
-
-    @respx.mock
-    async def test_set_speed_50(
-        self, respx_mock: respx.router.MockRouter
-    ) -> None:
-        if not self.sut.supports_set_speed:
-            with pytest.raises(AqualinkOperationNotSupportedException):
-                await self.sut.set_speed(50)
-            return
-        respx_mock.route(dotstar).mock(resp_200)
-        await self.sut.set_speed(50)
-        assert len(respx_mock.calls) > 0
-        self.respx_calls = copy.copy(respx_mock.calls)
-
     def test_property_supports_set_speed_percentage(self) -> None:
         assert isinstance(self.sut.supports_set_speed_percentage, bool)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -296,11 +296,3 @@ class TestAqualinkPump(TestBasePump, TestAqualinkDevice):
         system = MagicMock()
         data: dict[str, str] = {}
         self.sut = AqualinkPump(system, data)
-
-    def test_property_is_on_true(self) -> None:
-        with pytest.raises(NotImplementedError):
-            super().test_property_is_on_true()
-
-    def test_property_is_on_false(self) -> None:
-        with pytest.raises(NotImplementedError):
-            super().test_property_is_on_false()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -5,22 +5,22 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
 
 from iaqualink.device import (
-    AqualinkPump,
     AqualinkBinarySensor,
     AqualinkDevice,
     AqualinkLight,
     AqualinkNumber,
+    AqualinkPump,
     AqualinkSensor,
     AqualinkSwitch,
     AqualinkThermostat,
 )
 
 from .base_test_device import (
-    TestBasePump,
     TestBaseBinarySensor,
     TestBaseDevice,
     TestBaseLight,
     TestBaseNumber,
+    TestBasePump,
     TestBaseSensor,
     TestBaseSwitch,
     TestBaseThermostat,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
 
 from iaqualink.device import (
+    AqualinkPump,
     AqualinkBinarySensor,
     AqualinkDevice,
     AqualinkLight,
@@ -15,6 +16,7 @@ from iaqualink.device import (
 )
 
 from .base_test_device import (
+    TestBasePump,
     TestBaseBinarySensor,
     TestBaseDevice,
     TestBaseLight,
@@ -287,3 +289,34 @@ class TestAqualinkNumber(TestBaseNumber, TestAqualinkDevice):
     async def test_set_value_above_max(self) -> None:
         with pytest.raises(NotImplementedError):
             await super().test_set_value_above_max()
+
+
+class TestAqualinkPump(TestBasePump, TestAqualinkDevice):
+    def setUp(self) -> None:
+        system = MagicMock()
+        data: dict[str, str] = {}
+        self.sut = AqualinkPump(system, data)
+
+    def test_property_is_on_true(self) -> None:
+        with pytest.raises(NotImplementedError):
+            super().test_property_is_on_true()
+
+    def test_property_is_on_false(self) -> None:
+        with pytest.raises(NotImplementedError):
+            super().test_property_is_on_false()
+
+    async def test_turn_on(self) -> None:
+        with pytest.raises(NotImplementedError):
+            await super().test_turn_on()
+
+    async def test_turn_on_noop(self) -> None:
+        with pytest.raises(NotImplementedError):
+            await super().test_turn_on_noop()
+
+    async def test_turn_off(self) -> None:
+        with pytest.raises(NotImplementedError):
+            await super().test_turn_off()
+
+    async def test_turn_off_noop(self) -> None:
+        with pytest.raises(NotImplementedError):
+            await super().test_turn_off_noop()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -304,19 +304,3 @@ class TestAqualinkPump(TestBasePump, TestAqualinkDevice):
     def test_property_is_on_false(self) -> None:
         with pytest.raises(NotImplementedError):
             super().test_property_is_on_false()
-
-    async def test_turn_on(self) -> None:
-        with pytest.raises(NotImplementedError):
-            await super().test_turn_on()
-
-    async def test_turn_on_noop(self) -> None:
-        with pytest.raises(NotImplementedError):
-            await super().test_turn_on_noop()
-
-    async def test_turn_off(self) -> None:
-        with pytest.raises(NotImplementedError):
-            await super().test_turn_off()
-
-    async def test_turn_off_noop(self) -> None:
-        with pytest.raises(NotImplementedError):
-            await super().test_turn_off_noop()


### PR DESCRIPTION
## Summary

- Adds `AqualinkPump` base class extending `AqualinkDevice` in `src/iaqualink/device.py`
- Designed to map to HA `FanEntity`; exposes capabilities as opt-in bool flags (all default `False`):
  - `supports_turn_on` / `supports_turn_off` / `is_on` — switchable pump control
  - `supports_presets` / `supported_presets` / `current_preset` / `set_preset(preset)` — named mode control
  - `supports_set_speed_percentage` / `set_speed_percentage(percentage)` — 0-100% speed control
- Capabilities raise `NotImplementedError` when `supports_*=True` and not overridden; raise `AqualinkOperationNotSupportedException` when `supports_*=False`
- Base class validates `set_speed_percentage` range (0-100) and `set_preset` membership against `supported_presets`
- Adds `TestBasePump` abstract test class in `tests/base_test_device.py`
- Adds `TestAqualinkPump` concrete test class in `tests/test_device.py`

## Test plan

- [x] `uv run pytest` — all tests pass
- [x] `uv run pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)