### PR TITLE
feat(device): add AqualinkNumber base class

### DIFF
--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -176,7 +176,10 @@ class AqualinkNumber(AqualinkDevice):
 
     async def set_value(self, value: float) -> None:
         if not self.min_value <= value <= self.max_value:
-            raise AqualinkInvalidParameterException(value)
+            msg = (
+                f"{value} is out of range ({self.min_value}-{self.max_value})."
+            )
+            raise AqualinkInvalidParameterException(msg)
         await self._set_value(value)
 
     async def _set_value(self, value: float) -> None:

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -4,7 +4,10 @@ import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from iaqualink.exception import AqualinkOperationNotSupportedException
+from iaqualink.exception import (
+    AqualinkInvalidParameterException,
+    AqualinkOperationNotSupportedException,
+)
 
 if TYPE_CHECKING:
     from iaqualink.typing import DeviceData
@@ -147,4 +150,31 @@ class AqualinkThermostat(AqualinkSwitch, AqualinkDevice):
         raise NotImplementedError
 
     async def set_temperature(self, _: int) -> None:
+        raise NotImplementedError
+
+
+class AqualinkNumber(AqualinkDevice):
+    @property
+    def current_value(self) -> float | None:
+        raise NotImplementedError
+
+    @property
+    def min_value(self) -> float:
+        raise NotImplementedError
+
+    @property
+    def max_value(self) -> float:
+        raise NotImplementedError
+
+    @property
+    def step(self) -> float:
+        return 1.0
+
+    @property
+    def unit(self) -> str | None:
+        return None
+
+    async def set_value(self, value: float) -> None:
+        if not self.min_value <= value <= self.max_value:
+            raise AqualinkInvalidParameterException(value)
         raise NotImplementedError

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -177,4 +177,7 @@ class AqualinkNumber(AqualinkDevice):
     async def set_value(self, value: float) -> None:
         if not self.min_value <= value <= self.max_value:
             raise AqualinkInvalidParameterException(value)
+        await self._set_value(value)
+
+    async def _set_value(self, value: float) -> None:
         raise NotImplementedError

--- a/tests/base_test_device.py
+++ b/tests/base_test_device.py
@@ -10,6 +10,7 @@ import respx.router
 from iaqualink.device import (
     AqualinkBinarySensor,
     AqualinkLight,
+    AqualinkNumber,
     AqualinkSensor,
     AqualinkSwitch,
     AqualinkThermostat,
@@ -297,3 +298,65 @@ class TestBaseThermostat(TestBaseSwitch):
             with pytest.raises(AqualinkInvalidParameterException):
                 await self.sut.set_temperature(204)
             assert len(respx_mock.calls) == 0
+
+
+class TestBaseNumber(TestBaseDevice):
+    def test_inheritance(self) -> None:
+        assert isinstance(self.sut, AqualinkNumber)
+
+    def test_property_current_value(self) -> None:
+        assert self.sut.current_value is None or isinstance(
+            self.sut.current_value, float
+        )
+
+    def test_property_min_value(self) -> None:
+        assert isinstance(self.sut.min_value, float)
+
+    def test_property_max_value(self) -> None:
+        assert isinstance(self.sut.max_value, float)
+
+    def test_property_min_le_max(self) -> None:
+        assert self.sut.min_value <= self.sut.max_value
+
+    def test_property_step(self) -> None:
+        assert isinstance(self.sut.step, float)
+        assert self.sut.step > 0
+
+    def test_property_unit(self) -> None:
+        assert self.sut.unit is None or isinstance(self.sut.unit, str)
+
+    @respx.mock
+    async def test_set_value_at_min(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.set_value(self.sut.min_value)
+        assert len(respx_mock.calls) > 0
+        self.respx_calls = copy.copy(respx_mock.calls)
+
+    @respx.mock
+    async def test_set_value_at_max(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        respx_mock.route(dotstar).mock(resp_200)
+        await self.sut.set_value(self.sut.max_value)
+        assert len(respx_mock.calls) > 0
+        self.respx_calls = copy.copy(respx_mock.calls)
+
+    @respx.mock
+    async def test_set_value_below_min(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        respx_mock.route(dotstar).mock(resp_200)
+        with pytest.raises(AqualinkInvalidParameterException):
+            await self.sut.set_value(self.sut.min_value - 1.0)
+        assert len(respx_mock.calls) == 0
+
+    @respx.mock
+    async def test_set_value_above_max(
+        self, respx_mock: respx.router.MockRouter
+    ) -> None:
+        respx_mock.route(dotstar).mock(resp_200)
+        with pytest.raises(AqualinkInvalidParameterException):
+            await self.sut.set_value(self.sut.max_value + 1.0)
+        assert len(respx_mock.calls) == 0

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -8,6 +8,7 @@ from iaqualink.device import (
     AqualinkBinarySensor,
     AqualinkDevice,
     AqualinkLight,
+    AqualinkNumber,
     AqualinkSensor,
     AqualinkSwitch,
     AqualinkThermostat,
@@ -17,6 +18,7 @@ from .base_test_device import (
     TestBaseBinarySensor,
     TestBaseDevice,
     TestBaseLight,
+    TestBaseNumber,
     TestBaseSensor,
     TestBaseSwitch,
     TestBaseThermostat,
@@ -246,3 +248,42 @@ class TestAqualinkThermostat(TestBaseThermostat, TestAqualinkDevice):
     async def test_set_temperature_invalid_204c(self) -> None:
         with pytest.raises(NotImplementedError):
             await super().test_set_temperature_invalid_204c()
+
+
+class TestAqualinkNumber(TestBaseNumber, TestAqualinkDevice):
+    def setUp(self) -> None:
+        system = MagicMock()
+        data: dict[str, str] = {}
+        self.sut = AqualinkNumber(system, data)
+
+    def test_property_current_value(self) -> None:
+        with pytest.raises(NotImplementedError):
+            super().test_property_current_value()
+
+    def test_property_min_value(self) -> None:
+        with pytest.raises(NotImplementedError):
+            super().test_property_min_value()
+
+    def test_property_max_value(self) -> None:
+        with pytest.raises(NotImplementedError):
+            super().test_property_max_value()
+
+    def test_property_min_le_max(self) -> None:
+        with pytest.raises(NotImplementedError):
+            super().test_property_min_le_max()
+
+    async def test_set_value_at_min(self) -> None:
+        with pytest.raises(NotImplementedError):
+            await super().test_set_value_at_min()
+
+    async def test_set_value_at_max(self) -> None:
+        with pytest.raises(NotImplementedError):
+            await super().test_set_value_at_max()
+
+    async def test_set_value_below_min(self) -> None:
+        with pytest.raises(NotImplementedError):
+            await super().test_set_value_below_min()
+
+    async def test_set_value_above_max(self) -> None:
+        with pytest.raises(NotImplementedError):
+            await super().test_set_value_above_max()


### PR DESCRIPTION
## Summary

- Adds `AqualinkNumber` base class extending `AqualinkDevice` in `src/iaqualink/device.py`
- Exposes numeric entity capabilities mirroring the Home Assistant `NumberEntity` interface:
  - `current_value` (`float | None`) — current reading, subclass-provided
  - `min_value` / `max_value` (`float`) — allowed range, subclass-provided
  - `step` (`float`, default `1.0`) — increment hint for UI
  - `unit` (`str | None`, default `None`) — unit of measurement
  - `set_value(value: float)` — validates range (raises `AqualinkInvalidParameterException` on out-of-range), then delegates to subclass
- Adds `TestBaseNumber` abstract test class in `tests/base_test_device.py`
- Adds `TestAqualinkNumber` concrete test class in `tests/test_device.py`

## Test plan

- [x] `uv run pytest` — 598 passed, 10 skipped
- [x] `uv run pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)