### PR TITLE
feat(cli): add Pumps and Numbers groups to device tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,21 @@ To add a new system type:
 6. Register the new system module import in `src/iaqualink/client.py` so `AqualinkSystem.from_data()` can discover the subclass at runtime
 7. Add tests following existing patterns in `tests/systems/newsystem/`
 
+## Adding New Base Device Types
+
+When adding a new direct subclass of `AqualinkDevice` to `device.py`, you **must** also add a corresponding entry to `_DEVICE_GROUPS` in `src/iaqualink/cli/app.py`. Devices without a matching group silently fall through to the "Other" bucket in the CLI output. The current base types and their CLI group order are:
+
+| Class | CLI Group |
+|---|---|
+| `AqualinkThermostat` | Thermostats |
+| `AqualinkLight` | Lights |
+| `AqualinkSwitch` | Switches |
+| `AqualinkPump` | Pumps |
+| `AqualinkNumber` | Numbers |
+| `AqualinkSensor` | Sensors |
+
+Subclasses must appear before their superclass in `_DEVICE_GROUPS` (e.g. `AqualinkLight` before `AqualinkSwitch`).
+
 ## Quality Gates
 
 Before finalizing any change, validate it against the API spec files in `spec/` if they exist and are relevant to the change:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,16 +174,16 @@ To add a new system type:
 
 When adding a new direct subclass of `AqualinkDevice` to `device.py`, you **must** also add a corresponding entry to `_DEVICE_GROUPS` in `src/iaqualink/cli/app.py`. Devices without a matching group silently fall through to the "Other" bucket in the CLI output. The current base types and their CLI group order are:
 
-| Class | CLI Group |
-|---|---|
-| `AqualinkThermostat` | Thermostats |
-| `AqualinkLight` | Lights |
-| `AqualinkSwitch` | Switches |
-| `AqualinkPump` | Pumps |
-| `AqualinkNumber` | Numbers |
-| `AqualinkSensor` | Sensors |
+| Class | CLI Group | Notes |
+|---|---|---|
+| `AqualinkThermostat` | Thermostats | |
+| `AqualinkLight` | Lights | |
+| `AqualinkSwitch` | Switches | |
+| `AqualinkPump` | Pumps | |
+| `AqualinkNumber` | Numbers | |
+| `AqualinkSensor` | Sensors | `AqualinkBinarySensor` extends `AqualinkSensor` and is covered by this entry |
 
-Subclasses must appear before their superclass in `_DEVICE_GROUPS` (e.g. `AqualinkLight` before `AqualinkSwitch`).
+Subclasses must appear before their superclass in `_DEVICE_GROUPS` (e.g. `AqualinkLight` before `AqualinkSwitch`). Only add a new row for direct subclasses of `AqualinkDevice`; intermediate classes like `AqualinkBinarySensor` are automatically covered by their parent's entry.
 
 ## Quality Gates
 

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -18,6 +18,8 @@ from iaqualink.client import AqualinkAuthState, AqualinkClient
 from iaqualink.device import (
     AqualinkDevice,
     AqualinkLight,
+    AqualinkNumber,
+    AqualinkPump,
     AqualinkSensor,
     AqualinkSwitch,
     AqualinkThermostat,
@@ -244,10 +246,15 @@ def _sorted_devices(
 
 
 # Subclasses must appear before their superclass (Light/Thermostat extend Switch).
+# IMPORTANT: Every concrete AqualinkDevice subclass in device.py must have a
+# matching entry here so devices never silently fall through to "Other".
+# When adding a new base device type, add its entry to this list.
 _DEVICE_GROUPS: list[tuple[type[AqualinkDevice], str, str]] = [
     (AqualinkThermostat, "🌡️", "Thermostats"),
     (AqualinkLight, "💡", "Lights"),
     (AqualinkSwitch, "⚡", "Switches"),
+    (AqualinkPump, "⚙️", "Pumps"),
+    (AqualinkNumber, "🔢", "Numbers"),
     (AqualinkSensor, "📊", "Sensors"),
 ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,8 @@ from iaqualink.client import AqualinkAuthState
 from iaqualink.device import (
     AqualinkDevice,
     AqualinkLight,
+    AqualinkNumber,
+    AqualinkPump,
     AqualinkSensor,
     AqualinkSwitch,
     AqualinkThermostat,
@@ -342,7 +344,9 @@ def test_group_devices_all_types() -> None:
     devices = [
         ("t1", _make_device(AqualinkThermostat, "Heater")),
         ("l1", _make_device(AqualinkLight, "Light")),
-        ("s1", _make_device(AqualinkSwitch, "Pump")),
+        ("s1", _make_device(AqualinkSwitch, "Switch")),
+        ("p1", _make_device(AqualinkPump, "Pump")),
+        ("nb1", _make_device(AqualinkNumber, "RPM")),
         ("n1", _make_device(AqualinkSensor, "Temp")),
     ]
     groups = cli_module._group_devices(devices)
@@ -350,6 +354,8 @@ def test_group_devices_all_types() -> None:
         "Thermostats",
         "Lights",
         "Switches",
+        "Pumps",
+        "Numbers",
         "Sensors",
     ]
     for _, _, members in groups:
@@ -368,6 +374,20 @@ def test_group_devices_light_not_swallowed_by_switch() -> None:
     groups = cli_module._group_devices([("l", light)])
     assert len(groups) == 1
     assert groups[0][1] == "Lights"
+
+
+def test_group_devices_pump_grouped_as_pump() -> None:
+    pump = _make_device(AqualinkPump, "Filter Pump")
+    groups = cli_module._group_devices([("p", pump)])
+    assert len(groups) == 1
+    assert groups[0][1] == "Pumps"
+
+
+def test_group_devices_number_grouped_as_number() -> None:
+    number = _make_device(AqualinkNumber, "RPM")
+    groups = cli_module._group_devices([("nb", number)])
+    assert len(groups) == 1
+    assert groups[0][1] == "Numbers"
 
 
 def test_group_devices_unknown_type_goes_to_other() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 
 from iaqualink.client import AqualinkAuthState
 from iaqualink.device import (
+    AqualinkBinarySensor,
     AqualinkDevice,
     AqualinkLight,
     AqualinkNumber,
@@ -388,6 +389,22 @@ def test_group_devices_number_grouped_as_number() -> None:
     groups = cli_module._group_devices([("nb", number)])
     assert len(groups) == 1
     assert groups[0][1] == "Numbers"
+
+
+def test_group_devices_binary_sensor_covered_by_sensor_group() -> None:
+    # AqualinkBinarySensor extends AqualinkSensor; no separate _DEVICE_GROUPS
+    # entry is needed — it is matched by the AqualinkSensor entry.
+    binary = _make_device(AqualinkBinarySensor, "Freeze")
+    groups = cli_module._group_devices([("b", binary)])
+    assert len(groups) == 1
+    assert groups[0][1] == "Sensors"
+
+
+# AqualinkPump and AqualinkNumber extend AqualinkDevice directly and share no
+# IS-A relationship with AqualinkSensor or AqualinkSwitch, so there is no risk
+# of them being swallowed by another group. No "not swallowed" tests are needed
+# for those types (unlike AqualinkThermostat/AqualinkLight which extend
+# AqualinkSwitch and do require such guards).
 
 
 def test_group_devices_unknown_type_goes_to_other() -> None:


### PR DESCRIPTION
## Summary

- `AqualinkPump` and `AqualinkNumber` were silently falling to the "Other" bucket in CLI status/list-devices output because `_DEVICE_GROUPS` had no entries for them
- Add ⚙️ **Pumps** and 🔢 **Numbers** groups in the correct position (after Switches, before Sensors)
- Add two focused tests: `test_group_devices_pump_grouped_as_pump` and `test_group_devices_number_grouped_as_number`
- Update `test_group_devices_all_types` to cover all six base types
- Add mandatory checklist to `CLAUDE.md` listing every base device type and its CLI group, so new types can't be missed

## Test plan

- [x] All 630 existing tests pass (12 skipped, no regressions)
- [x] Two new grouping tests pass
- [x] `pre-commit run --all-files` clean (ruff, ruff-format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)