### PR TITLE
feat(cli): list-devices shows all systems by default

### DIFF
--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -77,7 +77,7 @@ SystemOption = Annotated[
     str | None,
     typer.Option(
         "--system",
-        help="System serial number. Required when multiple systems exist.",
+        help="System serial number or name. Filters output to a single system.",
     ),
 ]
 DeviceArgument = Annotated[
@@ -481,12 +481,20 @@ async def _list_devices(
     cookie_jar: Path,
 ) -> Tree:
     systems = await _fetch_systems(credentials, cookie_jar)
-    system = _resolve_system(systems, system_selector)
-    devices = await _load_devices_for_system(system)
-    _save_session_jar(cookie_jar, system.aqualink.auth_state)
-    return _render_device_tree(
-        [(system.serial, system)], {system.serial: devices}
-    )
+    if system_selector is not None:
+        system = _resolve_system(systems, system_selector)
+        selected_systems = [(system.serial, system)]
+    else:
+        selected_systems = _sorted_systems(systems)
+
+    devices_by_system: dict[str, dict[str, AqualinkDevice]] = {}
+    for serial, system in selected_systems:
+        devices_by_system[serial] = await _load_devices_for_system(system)
+
+    if selected_systems:
+        _, any_system = selected_systems[0]
+        _save_session_jar(cookie_jar, any_system.aqualink.auth_state)
+    return _render_device_tree(selected_systems, devices_by_system)
 
 
 async def _status(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -495,6 +495,40 @@ def test_list_devices_saves_jar_after_device_load(tmp_path: Path) -> None:
     assert data["client_id"] == "post-device-session"
 
 
+def test_list_devices_all_systems_when_no_selector(tmp_path: Path) -> None:
+    switch = _make_device(AqualinkSwitch, "Pump", "1")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink(
+                "SN001", "Backyard", {"pump": switch}
+            ),
+            "SN002": FakeSystemWithAqualink("SN002", "Spa", {"pump": switch}),
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "list-devices")
+    assert result.exit_code == 0
+    assert "Backyard" in result.stdout
+    assert "Spa" in result.stdout
+
+
+def test_list_devices_filters_to_single_system_when_selector_given(
+    tmp_path: Path,
+) -> None:
+    switch = _make_device(AqualinkSwitch, "Pump", "1")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink(
+                "SN001", "Backyard", {"pump": switch}
+            ),
+            "SN002": FakeSystemWithAqualink("SN002", "Spa", {"pump": switch}),
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "list-devices", "--system", "SN001")
+    assert result.exit_code == 0
+    assert "Backyard" in result.stdout
+    assert "Spa" not in result.stdout
+
+
 def test_status_saves_jar_after_device_load(tmp_path: Path) -> None:
     FakeClient.systems_factory = staticmethod(
         lambda: {"SN001": FakeSystemWithAqualink("SN001", "Pool")}


### PR DESCRIPTION
## Summary

- `list-devices` previously errored with _"Multiple systems found. Use --system with one of: ..."_ when no `--system` flag was given and the account had more than one system
- Now iterates all systems and renders the full device tree, matching the existing `status` command behavior
- `--system` still works to filter output to a single system
- Updated `--system` help text to reflect it's now optional for all commands

## Test plan

- [ ] `test_list_devices_all_systems_when_no_selector` — multi-system, no selector → both systems shown
- [ ] `test_list_devices_filters_to_single_system_when_selector_given` — multi-system, `--system SN001` → only SN001 shown
- [ ] All existing CLI tests still pass (23 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)