### PR TITLE
feat(tooling): local review loop, protocol reference docs, and worktree bootstrap

### DIFF
--- a/.claude/agents/architecture-auditor.md
+++ b/.claude/agents/architecture-auditor.md
@@ -1,5 +1,5 @@
 ---
-description: Given a diff, verify protocol behavior against docs/reference/<system>.md and flag divergences. No access to decompiled sources.
+description: Given a diff, verify protocol behavior against docs/reference/<system>.md and flag divergences. Uses only repo-tracked files.
 ---
 
 # Architecture Auditor
@@ -15,7 +15,6 @@ You are a protocol correctness reviewer for the iaqualink-py library. Your job i
 
 ## What you do NOT have access to and must not reference
 
-- Any decompiled source directory
 - Any path outside this repository
 
 ## Review procedure

--- a/.claude/agents/architecture-auditor.md
+++ b/.claude/agents/architecture-auditor.md
@@ -1,0 +1,47 @@
+---
+description: Given a diff, verify protocol behavior against docs/reference/<system>.md and flag divergences. No access to decompiled sources.
+---
+
+# Architecture Auditor
+
+You are a protocol correctness reviewer for the iaqualink-py library. Your job is to check that a code diff does not introduce undocumented divergences from the wire-level protocol defined in `docs/reference/`.
+
+## What you have access to
+
+- The diff under review (provided in the prompt)
+- `docs/reference/client.md` — shared auth, device list, HTTP config
+- `docs/reference/iaqua.md` — iQ20 pool controller protocol
+- `docs/reference/exo.md` — EXO/SWC chlorinator protocol
+
+## What you do NOT have access to and must not reference
+
+- Any decompiled source directory
+- Any path outside this repository
+
+## Review procedure
+
+1. **Identify affected systems** from the diff's changed file paths:
+   - `src/iaqualink/client.py` or `src/iaqualink/reauth.py` → `docs/reference/client.md`
+   - `src/iaqualink/systems/iaqua/` → `docs/reference/iaqua.md`
+   - `src/iaqualink/systems/exo/` → `docs/reference/exo.md`
+
+2. **Read the reference doc(s)** for each affected system.
+
+3. **For each changed URL, header, query param, JSON field name, or auth flow** in the diff:
+   - Find the corresponding entry in the reference doc.
+   - Check: does the implementation match?
+   - If the item is already listed in the reference doc's "Deltas vs current implementation" table: it is a known accepted divergence — do not flag it.
+   - If the item diverges from the reference AND is not in the deltas table: flag it.
+
+4. **Output format** — one line per issue:
+   ```
+   DIVERGENCE <file>:<line> — <what the code does> | reference says: <what the doc specifies>
+   ```
+   If nothing to flag: output `Protocol: LGTM`
+
+## Rules
+
+- Report divergences only. Do not comment on code style, types, or test coverage — those are handled by other rubric sections.
+- Do not invent behavior. If you cannot find the item in the reference doc, say "not in reference doc" rather than guessing.
+- Do not suggest fixes. Inventory only.
+- If `docs/reference/<system>.md` does not exist for an affected system, output: `No reference doc for <system> — cannot audit protocol correctness.`

--- a/.claude/agents/ha-reviewer.md
+++ b/.claude/agents/ha-reviewer.md
@@ -1,0 +1,98 @@
+---
+description: Review library changes and device types against Home Assistant integration patterns. Fetches HA source from GitHub. Suggests improvements and flags compatibility issues.
+---
+
+# HA Reviewer
+
+You are a Home Assistant integration specialist reviewing the iaqualink-py library. This library is a standalone async Python library; its primary consumer is an HA integration that maps pool devices to HA entities.
+
+## What you do
+
+Given a diff, a device class, or a general improvement request, you:
+
+1. Fetch the relevant HA source from GitHub
+2. Read the library's device hierarchy
+3. Report compatibility issues and improvement suggestions
+
+## HA source locations
+
+Fetch files as needed from:
+
+```
+BASE = https://raw.githubusercontent.com/home-assistant/core/dev
+```
+
+Key files:
+
+| What | Path |
+|---|---|
+| Entity base | `homeassistant/helpers/entity.py` |
+| RestoreEntity | `homeassistant/helpers/restore_state.py` |
+| Switch base | `homeassistant/components/switch/__init__.py` |
+| Sensor base | `homeassistant/components/sensor/__init__.py` |
+| Light base | `homeassistant/components/light/__init__.py` |
+| Climate base | `homeassistant/components/climate/__init__.py` |
+| Number base | `homeassistant/components/number/__init__.py` |
+| Binary sensor base | `homeassistant/components/binary_sensor/__init__.py` |
+| Existing iaqualink integration | `homeassistant/components/iaqualink/__init__.py` |
+| Existing iaqualink entities | `homeassistant/components/iaqualink/climate.py` (and switch.py, sensor.py, light.py) |
+
+Fetch only what is relevant to the question. Do not fetch everything upfront.
+
+## Library device hierarchy
+
+Read from `src/iaqualink/device.py` (base classes) and the system-specific device files:
+- `src/iaqualink/systems/iaqua/device.py`
+- `src/iaqualink/systems/exo/device.py`
+
+## Review procedure
+
+### Compatibility check
+
+For each device class in the diff or under review:
+
+1. Identify the corresponding HA entity type (switch → `SwitchEntity`, sensor → `SensorEntity`, etc.)
+2. Fetch the HA base class for that entity type
+3. Check:
+   - Does the library class expose the properties HA expects? (`is_on`, `state`, `native_value`, `native_unit_of_measurement`, `device_class`, `extra_state_attributes`, etc.)
+   - Are property return types compatible with HA's type hints?
+   - Are any required abstract properties missing?
+   - Does async behavior match HA expectations (no blocking I/O, correct coroutine signatures)?
+
+### Improvement suggestions
+
+After the compatibility check, look at the existing HA iaqualink integration (if it exists on GitHub) and identify:
+
+- Where the integration has to work around library limitations
+- Properties or methods the integration has to re-derive that the library could provide directly
+- HA entity features the library's device model makes difficult (e.g., missing `target_temperature`, `hvac_modes`, `supported_features` bitmask)
+- Naming or casing inconsistencies between library property names and HA conventions
+
+### Output format
+
+```
+## Compatibility
+
+| Device class | HA entity type | Status | Notes |
+|---|---|---|---|
+| IaquaThermostat | ClimateEntity | ⚠ partial | missing hvac_modes, supported_features |
+| IaquaLightSwitch | LightEntity | ✓ | |
+...
+
+## Issues
+
+- IaquaThermostat:42 — `target_temperature` returns str; ClimateEntity expects float | None
+- ...
+
+## Suggestions
+
+- Add `device_class` property to sensor subclasses (HA uses it for unit auto-detection and icons)
+- ...
+```
+
+## Rules
+
+- Only suggest changes that make the library more useful to HA integrations without adding HA as a dependency.
+- Do not propose adding `homeassistant` as a library dependency — the library must remain standalone.
+- Flag HA deprecations (e.g., removed properties in recent HA versions) if you notice them in the existing integration.
+- If the iaqualink integration doesn't exist in HA core, note that and check community integrations or skip that step.

--- a/.claude/commands/ha-review.md
+++ b/.claude/commands/ha-review.md
@@ -1,0 +1,52 @@
+---
+description: Review library changes or device types against Home Assistant patterns. Flags compatibility issues and suggests improvements. Usage: /ha-review [diff|devices|<class_name>]
+---
+
+# /ha-review
+
+Review the library against Home Assistant integration requirements.
+
+## Modes
+
+Run with no argument or one of:
+
+| Argument | What it does |
+|---|---|
+| *(none)* | Reviews the current diff vs master for HA compatibility |
+| `devices` | Reviews the full device hierarchy for HA compatibility and improvement opportunities |
+| `<ClassName>` | Reviews a specific device class (e.g., `/ha-review IaquaThermostat`) |
+
+## Steps
+
+### 1. Gather context
+
+**No argument / diff mode:**
+```bash
+git fetch origin master 2>/dev/null || true
+BASE=$(git merge-base HEAD origin/master 2>/dev/null || git rev-list --max-parents=0 HEAD)
+git diff "$BASE"...HEAD -- src/
+```
+Pass the diff to the `ha-reviewer` agent.
+
+**`devices` mode:**
+Read `src/iaqualink/device.py`, `src/iaqualink/systems/iaqua/device.py`, `src/iaqualink/systems/exo/device.py`. Pass all three to the agent.
+
+**Class name mode:**
+Grep for the class across `src/iaqualink/` and read the file. Pass to the agent.
+
+### 2. Invoke ha-reviewer
+
+Pass the gathered context to the `ha-reviewer` subagent with the instruction:
+- For diff mode: "Review this diff for HA entity compatibility issues."
+- For devices mode: "Review the full device hierarchy for HA compatibility and suggest improvements."
+- For class mode: "Review `<ClassName>` for HA entity compatibility and suggest improvements."
+
+### 3. Output
+
+Print the agent's report. Highlight any issues that would break existing HA integrations in red (prefix with `BREAKING:`).
+
+## Notes
+
+- Does not modify any files. Review only.
+- To action a suggestion from this review, open a follow-up with the specific change in mind and implement it.
+- HA entity base classes are fetched from `github.com/home-assistant/core` at review time — no local HA install required.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,56 @@
+---
+description: Run the full .claude/review-criteria.md rubric against the current diff vs master. Use before opening a PR.
+---
+
+# /review
+
+Run the review rubric against the current branch.
+
+## Steps
+
+### 1. Get the diff
+
+```bash
+git fetch origin master 2>/dev/null || true
+BASE=$(git merge-base HEAD origin/master 2>/dev/null \
+    || git rev-list --max-parents=0 HEAD)
+git diff "$BASE"...HEAD
+```
+
+If the diff is empty, report "No changes vs master" and stop.
+
+### 2. §0 — Confidentiality (hard blocker — check first)
+
+Grep the diff for the patterns listed in `.claude/review-criteria.md` §0:
+
+```bash
+git diff "$BASE"...HEAD | grep -nP \
+    '\.java\b|com\.zodiac\.|com\.amazonaws\.|networkmodule/|iaqualinkandroid/|RetrofitClient\b|NetworkClient\b|SecurityUtils\b|ApiHelper\b|UserAuthenticationManager\b'
+```
+
+Any hit is a hard blocker. Report each match as `§0 <file>:<line> — <match>`. Do not proceed with the rest of the review if §0 fails.
+
+### 3. §1 — Protocol Correctness
+
+Invoke the `architecture-auditor` subagent with the diff. Pass the full diff text as context. Report its output verbatim under `§1`.
+
+### 4. §2–§10 — Remaining rubric sections
+
+Work through each remaining section of `.claude/review-criteria.md` in order (§2 Async Correctness through §10 Spec Validation). For each section:
+
+- Read the diff against the criteria.
+- Report issues as: `§<N> <file>:<line> — <one-line description>`
+- If the section is clean: `§<N> LGTM`
+
+### 5. Summary
+
+After all sections: print a one-line summary.
+- If any blocker: `BLOCKED — fix §<N> before opening PR`
+- If issues but no blockers: `ISSUES — address before merging`
+- If all clean: `LGTM — ready for PR`
+
+## Notes
+
+- This command mirrors what the GitHub `claude-code-review.yml` bot runs on every PR. Running it locally closes the feedback loop before push.
+- Use `git push --no-verify` to skip the automated pre-push hook if you need to push work-in-progress.
+- To review a specific commit range: run `/review` then manually adjust the `BASE` ref if needed.

--- a/.claude/review-criteria.md
+++ b/.claude/review-criteria.md
@@ -1,0 +1,116 @@
+# Review Criteria
+
+Use this rubric when reviewing any diff against `master`. Each item is independently checkable. Stop and flag before declaring the review done.
+
+---
+
+## 0. Confidentiality (check first — hard blocker)
+
+Repo-tracked files must never contain identifiers derived from decompiled source.
+
+**ALLOWED** in repo: hostnames, URLs, HTTP header names, JSON wire field names, numeric constants, named protocol constants whose names are observable at the wire level.
+
+**NOT ALLOWED**: decompiled Java/Kotlin file paths, package names (`com.zodiac.*`, `com.amazonaws.*`, etc.), class names, method names, variable names, or any identifier that only exists inside the decompiled APK.
+
+Action: grep the diff for `.java`, `com.zodiac`, `com.amazonaws`, `infinity/`, `networkmodule/`, `iaqualinkandroid/`, `RetrofitClient`, `NetworkClient`, `SecurityUtils`, `ApiHelper`. Flag any hit that is not inside a comment quoting a source reference. If a concept from the decompiled source was used, ensure only its wire-level manifestation (field name, URL path, header value) appears in the repo.
+
+---
+
+## 1. Protocol Correctness
+
+- Every URL path, HTTP method, query parameter, and JSON field name must match `docs/getting-started/<system>.md` for the system being changed.
+- If the diff diverges from the architecture doc, a comment in the code must explain why.
+- Check auth header format per system: iQ20 session uses bare `IdToken`; shadow endpoints vary — verify against the architecture doc.
+- New constants (URLs, paths, header names) must trace to the architecture doc, not be invented.
+
+---
+
+## 2. Async Correctness
+
+This is an `asyncio`-based library. Flag any of the following:
+
+- Blocking I/O in a coroutine: `open()`, `time.sleep()`, `requests.*`, `subprocess.*`, synchronous `socket.*`, or any call that blocks the event loop.
+- Missing `await` on a coroutine call.
+- `asyncio.get_event_loop()` — use `asyncio.get_running_loop()` instead.
+- `asyncio.run()` called inside a coroutine.
+- Shared mutable state accessed from multiple coroutines without a lock (see `_refresh_lock` pattern in `client.py`).
+- Fire-and-forget tasks created without storing a reference (task GC).
+
+---
+
+## 3. Error Handling
+
+- `AqualinkServiceThrottledException` must be re-raised before the broader `AqualinkServiceException` handler in any `update()` method. Swallowing throttle errors sets `online = None` incorrectly.
+- `AqualinkServiceUnauthorizedException` triggers the reauth retry path in `reauth.py` — do not catch it silently in request code.
+- All new request code that can receive a 401 must go through `_send_with_reauth_retry()` (system-level) or `send_with_reauth_retry()` (client-level).
+- Exception messages must not include raw HTTP response bodies (may contain credentials).
+
+---
+
+## 4. Type Annotations
+
+- All new public and private functions/methods must have complete annotations (parameters + return type).
+- Use `Self` (from `typing`) for `__aenter__` / factory methods that return the same class.
+- `TYPE_CHECKING` guard for imports used only in annotations.
+- No `Any` in public API surface unless genuinely unavoidable, and commented.
+- `mypy` must pass cleanly: `uv run mypy src/` with no new errors.
+
+---
+
+## 5. Code Quality and Best Practices
+
+- No commented-out code.
+- No `print()` — use `LOGGER = logging.getLogger("iaqualink")`.
+- No f-string logging: `LOGGER.debug("x=%s", x)` not `LOGGER.debug(f"x={x}")`.
+- Constants in module scope, not inline magic strings or numbers (exception: trivial `""` / `0` / `1` states).
+- New device/system subclasses must register via the `NAME` + `__init_subclass__` pattern — no manual dict edits.
+- `from_data()` dispatch must use the subclass registry; do not add `if device_type == "..."` branches to base classes.
+- No `import *`.
+
+---
+
+## 6. Test Coverage
+
+- Every new public method that mutates state or makes a network call must have at least one test.
+- Tests use `respx` for HTTP mocking and `unittest.IsolatedAsyncioTestCase`.
+- New system types must have tests under `tests/systems/<system>/test_system.py` and `test_device.py` following the abstract base pattern in `tests/base_test_system.py` and `tests/base_test_device.py`.
+- Fixtures (mock responses) belong in `tests/` alongside the test file that uses them.
+- Tests must not import from `src/iaqualink` using private names (ruff SLF001 is suppressed in tests, but avoid it anyway).
+- `uv run pytest` must pass with no new failures or warnings promoted to errors.
+
+---
+
+## 7. Performance
+
+- No redundant HTTP calls: `update()` must not make more requests than the architecture doc specifies for that system.
+- No polling loops inside library code — the library is called by the consumer; it must not start background tasks.
+- Connection reuse: new code must not create `httpx.AsyncClient` instances per-request; use the shared client from `AqualinkClient._get_httpx_client()`.
+
+---
+
+## 8. Security
+
+- No credentials, tokens, or API keys hardcoded in source or tests (use fixtures/constants).
+- No logging of token values, passwords, or raw request bodies at any log level.
+- URL construction must not allow injection: use `httpx` params dict, not f-string concatenation for user-controlled values.
+- Cookie jar writes use atomic temp-file pattern (see CLI session persistence).
+
+---
+
+## 9. Pre-commit Compliance
+
+Run before declaring done:
+
+```bash
+uv run pre-commit run --show-diff-on-failure --color=always --all-files
+uv run pytest
+uv run mypy src/
+```
+
+All three must be clean. Trailing whitespace, missing newlines, and lock-file drift are caught by pre-commit — fix them, do not suppress hooks.
+
+---
+
+## 10. Spec Validation
+
+If the diff touches or adds any endpoint, field, or auth flow: read the relevant section of `docs/getting-started/<system>.md` and verify the implementation matches. If the doc does not yet cover the change, update the doc as part of the same commit. Do not ship protocol changes without doc coverage.

--- a/.claude/review-criteria.md
+++ b/.claude/review-criteria.md
@@ -6,13 +6,13 @@ Use this rubric when reviewing any diff against `master`. Each item is independe
 
 ## 0. Confidentiality (check first — hard blocker)
 
-Repo-tracked files must never contain identifiers derived from decompiled source.
+Repo-tracked files must contain only wire-observable identifiers.
 
 **ALLOWED** in repo: hostnames, URLs, HTTP header names, JSON wire field names, numeric constants, named protocol constants whose names are observable at the wire level.
 
-**NOT ALLOWED**: decompiled Java/Kotlin file paths, package names (`com.zodiac.*`, `com.amazonaws.*`, etc.), class names, method names, variable names, or any identifier that only exists inside the decompiled APK.
+**NOT ALLOWED**: Java/Kotlin file paths, package names (`com.zodiac.*`, `com.amazonaws.*`, etc.), class names, method names, variable names from any external reference source.
 
-Action: grep the diff for `.java`, `com.zodiac`, `com.amazonaws`, `infinity/`, `networkmodule/`, `iaqualinkandroid/`, `RetrofitClient`, `NetworkClient`, `SecurityUtils`, `ApiHelper`. Flag any hit that is not inside a comment quoting a source reference. If a concept from the decompiled source was used, ensure only its wire-level manifestation (field name, URL path, header value) appears in the repo.
+Action: grep the diff for `.java`, `com.zodiac`, `com.amazonaws`, `infinity/`, `networkmodule/`, `iaqualinkandroid/`, `RetrofitClient`, `NetworkClient`, `SecurityUtils`, `ApiHelper`. Flag any hit that is not inside a meta-rule statement. Ensure only the wire-level manifestation of any concept (field name, URL path, header value) appears in the repo.
 
 ---
 

--- a/.claude/review-criteria.md
+++ b/.claude/review-criteria.md
@@ -18,7 +18,7 @@ Action: grep the diff for `.java`, `com.zodiac`, `com.amazonaws`, `infinity/`, `
 
 ## 1. Protocol Correctness
 
-- Every URL path, HTTP method, query parameter, and JSON field name must match `docs/getting-started/<system>.md` for the system being changed.
+- Every URL path, HTTP method, query parameter, and JSON field name must match `docs/reference/<system>.md` for the system being changed.
 - If the diff diverges from the architecture doc, a comment in the code must explain why.
 - Check auth header format per system: iQ20 session uses bare `IdToken`; shadow endpoints vary — verify against the architecture doc.
 - New constants (URLs, paths, header names) must trace to the architecture doc, not be invented.
@@ -113,4 +113,4 @@ All three must be clean. Trailing whitespace, missing newlines, and lock-file dr
 
 ## 10. Spec Validation
 
-If the diff touches or adds any endpoint, field, or auth flow: read the relevant section of `docs/getting-started/<system>.md` and verify the implementation matches. If the doc does not yet cover the change, update the doc as part of the same commit. Do not ship protocol changes without doc coverage.
+If the diff touches or adds any endpoint, field, or auth flow: read the relevant section of `docs/reference/<system>.md` and verify the implementation matches. If the doc does not yet cover the change, update the doc as part of the same commit. Do not ship protocol changes without doc coverage.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,26 @@ repos:
     rev: 0.6.5
     hooks:
       - id: uv-lock
+
+  - repo: local
+    hooks:
+      - id: check-identifiers
+        name: check for decompiler artifact identifiers
+        entry: scripts/precommit.sh
+        language: script
+        stages: [pre-commit]
+        types: [text]
+        exclude: |
+          (?x)^(
+            CLAUDE\.md|
+            \.claude/review-criteria\.md|
+            scripts/precommit\.sh
+          )$
+
+      - id: claude-review
+        name: claude AI review
+        entry: scripts/claude-review-hook.sh
+        language: script
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,21 +33,22 @@ repos:
     hooks:
       - id: check-identifiers
         name: check for decompiler artifact identifiers
-        entry: scripts/precommit.sh
-        language: script
+        entry: bash scripts/precommit.sh
+        language: system
         stages: [pre-commit]
         types: [text]
         exclude: |
           (?x)^(
             CLAUDE\.md|
             \.claude/review-criteria\.md|
+            \.claude/commands/review\.md|
             scripts/precommit\.sh
           )$
 
       - id: claude-review
         name: claude AI review
-        entry: scripts/claude-review-hook.sh
-        language: script
+        entry: bash scripts/claude-review-hook.sh
+        language: system
         stages: [pre-push]
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   - repo: local
     hooks:
       - id: check-identifiers
-        name: check for decompiler artifact identifiers
+        name: check for third-party protocol identifiers
         entry: bash scripts/precommit.sh
         language: system
         stages: [pre-commit]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,6 @@ bash scripts/setup-worktree.sh
 The script (idempotent):
 - Installs pre-commit hooks for both `pre-commit` and `pre-push` stages
 - Checks that `uv` and `claude` are on `PATH`
-- Checks that `uv` and `claude` are on `PATH`
 - Prints a checklist of what is wired
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Confidentiality
+
+Repo-tracked files must never contain identifiers derived from decompiled source.
+
+**ALLOWED:** hostnames, URLs, HTTP header names, JSON wire field names, numeric constants, protocol constants observable at the wire level.
+
+**NOT ALLOWED:** decompiled file paths, package names (`com.zodiac.*`, `com.amazonaws.*`), class names, method names, variable names lifted from decompiled APK source.
+
+The private tooling that researches protocol behavior and produces architecture docs lives outside this repo. Repo-side workflows must not reference `/tank/data/Code/iaqualink-decomp` or any path inside it.
+
+---
+
 ## General guidance (micro-caveman)
 
 For conversational replies, not generated docs/comments, respond like smart caveman.
@@ -77,6 +89,20 @@ uv run mkdocs build
 uv run mkdocs build --strict
 ```
 
+### Worktree Setup
+
+When starting work in a new git worktree, run the setup script to wire hooks and verify the environment:
+
+```bash
+bash scripts/setup-worktree.sh
+```
+
+The script (idempotent):
+- Installs pre-commit hooks for both `pre-commit` and `pre-push` stages
+- Checks that `uv` and `claude` are on `PATH`
+- Warns (non-fatal) if the decompiled source directory is absent — most worktrees do not need it
+- Prints a checklist of what is wired
+
 ## Architecture
 
 ### Core Class Hierarchy
@@ -149,10 +175,14 @@ The library follows a plugin-style architecture with base classes and system-spe
 ### Test Structure
 
 Tests use `unittest.IsolatedAsyncioTestCase` with a custom base class:
-- **TestBase** ([tests/base.py](tests/base.py)) - Base test class with AqualinkClient setup
-- Uses `respx` library for HTTP mocking
+- **TestBase** ([tests/base.py](tests/base.py)) — base test class with `AqualinkClient` and `respx` mock transport pre-wired
+- Uses `respx` for HTTP mocking — no live network calls; no real credentials needed
 - System-specific tests under `tests/systems/iaqua/` and `tests/systems/exo/`
-- Abstract base tests in `base_test_system.py` and `base_test_device.py`
+- Abstract base tests in `base_test_system.py` and `base_test_device.py` — new system types must subclass these
+- Mock HTTP response fixtures (JSON dicts / response bodies) live alongside the test file that uses them in the same `tests/systems/<system>/` directory
+- Run all tests: `uv run pytest`
+- Run one file: `uv run pytest tests/systems/iaqua/test_system.py`
+- Run one case: `uv run pytest tests/systems/iaqua/test_system.py::TestIaquaSystem::test_update`
 
 ### Key Constants
 
@@ -186,15 +216,29 @@ When adding a new direct subclass of `AqualinkDevice` to `device.py`, you **must
 
 Subclasses must appear before their superclass in `_DEVICE_GROUPS` (e.g. `AqualinkLight` before `AqualinkSwitch`). Only add a new row for direct subclasses of `AqualinkDevice`; intermediate classes like `AqualinkBinarySensor` are automatically covered by their parent's entry.
 
-## Quality Gates
+## Protocol Reference
 
-Before finalizing any change, validate it against the API spec files in `spec/` if they exist and are relevant to the change:
+`docs/reference/<system>.md` is the source of truth for protocol behavior in this repo:
 
-1. Read the relevant section(s) of any spec files found under `spec/` for any endpoint, field, or behavior being added or modified.
-2. Ensure URL paths, HTTP methods, request/response field names, and authentication flows match the spec exactly.
-3. If the implementation diverges from the spec, document the reason explicitly in the code with a comment.
+- `docs/reference/client.md` — auth flow, login/refresh request+response shapes, device list, HTTP client config
+- `docs/reference/iaqua.md` — iQ20 pool controller: session endpoint, all commands, response field shapes, enum wire values
+- `docs/reference/exo.md` — EXO/SWC chlorinator: shadow REST endpoints, full state field reference, write shapes
 
-This step is mandatory alongside linting, type checking, and tests.
+**Before changing any endpoint, field, or auth flow:** read the relevant section of the architecture doc and verify the change matches. If the doc does not cover the change, update the doc in the same commit.
+
+**Divergences from reference behavior** are documented in the "Deltas vs current implementation" section of each architecture doc. Before adding new divergences, confirm they are intentional and add them to the appropriate doc.
+
+## Review Checklist
+
+Before declaring any diff done, self-apply `.claude/review-criteria.md`. That file contains the full rubric used by the GitHub PR reviewer. Running it locally closes the gap between local iteration and PR feedback.
+
+The mandatory pre-declare commands:
+
+```bash
+uv run pre-commit run --show-diff-on-failure --color=always --all-files
+uv run pytest
+uv run mypy src/
+```
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Confidentiality
 
-Repo-tracked files must never contain identifiers derived from decompiled source.
+Repo-tracked files must contain only wire-observable identifiers: hostnames, URLs, HTTP header names, JSON field names, numeric constants, protocol constants visible on the wire.
 
 **ALLOWED:** hostnames, URLs, HTTP header names, JSON wire field names, numeric constants, protocol constants observable at the wire level.
 
-**NOT ALLOWED:** decompiled file paths, package names (`com.zodiac.*`, `com.amazonaws.*`), class names, method names, variable names lifted from decompiled APK source.
+**NOT ALLOWED:** Java/Kotlin file paths, package names (`com.zodiac.*`, `com.amazonaws.*`), class names, method names, variable names from any external reference source.
 
-The private tooling that researches protocol behavior and produces architecture docs lives outside this repo. Repo-side workflows must not reference `/tank/data/Code/iaqualink-decomp` or any path inside it.
+The private tooling that researches protocol behavior and produces architecture docs lives outside this repo.
 
 ---
 
@@ -100,7 +100,7 @@ bash scripts/setup-worktree.sh
 The script (idempotent):
 - Installs pre-commit hooks for both `pre-commit` and `pre-push` stages
 - Checks that `uv` and `claude` are on `PATH`
-- Warns (non-fatal) if the decompiled source directory is absent — most worktrees do not need it
+- Checks that `uv` and `claude` are on `PATH`
 - Prints a checklist of what is wired
 
 ## Architecture

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -1,0 +1,173 @@
+# Client — Authentication and Device Discovery
+
+This document describes the shared authentication flow, token lifecycle, device discovery endpoint, and HTTP client configuration that applies to all system types.
+
+---
+
+## API Families
+
+The iAquaLink platform exposes two distinct API families, each with its own base host:
+
+| Family | Host | Used for |
+|---|---|---|
+| **Legacy** | `p-api.iaqualink.net` | iQ20 pool controller session commands |
+| **Shadow / zodiac-io.com** | `prod.zodiac-io.com` | Authentication, token refresh, EXO/shadow devices |
+| **Device registry** | `r-api.iaqualink.net` | Device list, firmware |
+
+All endpoints use HTTPS. There is no HTTP fallback in production.
+
+---
+
+## Authentication
+
+### Login
+
+```
+POST https://prod.zodiac-io.com/users/v1/login
+Content-Type: application/json
+```
+
+**Request body:**
+
+| Field | Type | Description |
+|---|---|---|
+| `apiKey` | string | Production API key |
+| `email` | string | User email address |
+| `password` | string | User password |
+
+**Response body (relevant fields):**
+
+| Field | Type | Description |
+|---|---|---|
+| `authentication_token` | string | Legacy token — sent as query param to iQ20 session and device list |
+| `session_id` | string | Session identifier — sent as `sessionID` query param to iQ20 session |
+| `id` | integer | Numeric user ID — sent as `user_id` query param to device list |
+| `username` | string | |
+| `email` | string | |
+| `userPoolOAuth.IdToken` | string | Cognito JWT — sent as `Authorization` header to shadow and iQ20 session endpoints |
+| `userPoolOAuth.RefreshToken` | string | Opaque refresh token — absent on subsequent refreshes; reuse previous value |
+| `userPoolOAuth.AccessToken` | string | Cognito access token (not used by this library) |
+| `userPoolOAuth.ExpiresIn` | integer | IdToken TTL in seconds (typically 3600) |
+| `userPoolOAuth.TokenType` | string | Always `"Bearer"` |
+
+### Token Refresh
+
+```
+POST https://prod.zodiac-io.com/users/v1/refresh
+Content-Type: application/json
+```
+
+**Request body:**
+
+| Field | Type | Description |
+|---|---|---|
+| `refresh_token` | string | Value from `userPoolOAuth.RefreshToken` |
+| `email` | string | User email address |
+
+**Response body:** Same shape as login. `userPoolOAuth.RefreshToken` may be absent — if so, retain the previously stored refresh token.
+
+### Auth Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as prod.zodiac-io.com
+
+    C->>S: POST /users/v1/login {apiKey, email, password}
+    S-->>C: {authentication_token, session_id, id, userPoolOAuth: {IdToken, RefreshToken, ExpiresIn, ...}}
+
+    Note over C: Store all fields. IdToken expires in ExpiresIn seconds.
+
+    C->>S: POST /users/v1/refresh {refresh_token, email}
+    S-->>C: {IdToken (new), RefreshToken (may be absent), ...}
+
+    Note over C: If RefreshToken absent, keep previous value.
+    Note over C: If refresh returns 401, fall back to full login.
+```
+
+### Authorization Header Variants
+
+Different endpoints use different auth formats. Both are derived from the same login response:
+
+| Endpoint family | Header name | Value |
+|---|---|---|
+| iQ20 session (`p-api.iaqualink.net`) | `Authorization` | `{IdToken}` — bare, no `Bearer` prefix |
+| Shadow REST (`prod.zodiac-io.com`) | `Authorization` | `{IdToken}` — bare |
+| iQ20 session | `api_key` | Production API key |
+| Device list | — | Query params only (see below) |
+
+---
+
+## Device Discovery
+
+```
+GET https://r-api.iaqualink.net/devices.json
+```
+
+**Query parameters:**
+
+| Param | Value |
+|---|---|
+| `api_key` | Production API key |
+| `authentication_token` | From login response |
+| `user_id` | `id` field from login response (as string) |
+
+**Response:** JSON array. Each element represents one paired device:
+
+| Field | Type | Description |
+|---|---|---|
+| `serial_number` | string | Device serial — primary identifier used in all subsequent calls |
+| `device_type` | string | Determines which system class handles the device (e.g., `"iQ20"`, `"exo"`) |
+| `name` | string | User-assigned name |
+| `id` | integer | Numeric device ID |
+| `owner_id` | integer | Numeric owner user ID |
+| `firmware_version` | string | Current firmware |
+| `target_firmware_version` | string or null | Pending OTA target, if any |
+| `updating` | boolean | True during OTA in progress |
+| `created_at` | string | ISO 8601 timestamp |
+| `updated_at` | string | ISO 8601 timestamp |
+| `last_activity_at` | string or null | ISO 8601 timestamp of last device contact |
+
+---
+
+## HTTP Client Configuration
+
+Observed reference behavior:
+
+| Parameter | Value |
+|---|---|
+| Call timeout | 120 s |
+| Connect timeout | 30 s |
+| Read timeout | 20 s |
+| Write timeout | 20 s |
+| HTTP/2 | Not explicitly configured in reference (OkHttp negotiates automatically) |
+| Certificate pinning | Not observed in reference |
+| User-Agent | `okhttp/3.14.7` (set automatically by OkHttp) |
+| Retry on connection failure | Not observed in reference |
+
+---
+
+## Error Handling
+
+| HTTP status | Meaning | Observed handling |
+|---|---|---|
+| 200 | Success | — |
+| 400 | Bad request | Error propagated to caller |
+| 401 | Unauthorized / bad credentials | Triggers token refresh; if refresh also returns 401, falls back to full login |
+| 404 | Not found | Error propagated; client interprets as unauthorized for device list |
+| 409 | Conflict | Error propagated |
+| 429 | Rate limited | Not explicitly handled in reference; error propagated |
+| 500 | Device offline or server error | Error propagated |
+| 503 | Service unavailable / timeout | Error propagated |
+
+---
+
+## Deltas vs Current Implementation
+
+| # | Observed reference | Current Python client |
+|---|---|---|
+| 1 | Login request body field: `apiKey` (camelCase) | Sends `api_key` (snake_case) |
+| 2 | `userPoolOAuth.ExpiresIn` returned (token TTL in seconds) | Field is present in response but not used; no token-expiry-based proactive refresh |
+| 3 | No explicit HTTP/2 in reference | Python client enables HTTP/2 (`http2=True`) |
+| 4 | OkHttp sets `User-Agent: okhttp/3.14.7` implicitly | Python client sets `user-agent: okhttp/3.14.7` explicitly — effective result is the same |
+| 5 | No retry interceptor observed | Python client implements reauth retry via `send_with_reauth_retry()` — behaviour extends the reference |

--- a/docs/reference/exo.md
+++ b/docs/reference/exo.md
@@ -1,7 +1,7 @@
 # exo — EXO/SWC Chlorinator Protocol
 
-**Python system name:** `"exo"`  
-**Protocol family:** AWS IoT shadow (MQTT in reference; REST polling in current Python implementation)  
+**Python system name:** `"exo"`
+**Protocol family:** AWS IoT shadow (MQTT in reference; REST polling in current Python implementation)
 **Auth:** See [client.md](client.md)
 
 ---
@@ -237,12 +237,12 @@ For fields under `swc_0` that are scalars (not nested objects):
 
 The reference implementation does not poll via HTTP. It subscribes to AWS IoT MQTT topics using short-lived Cognito session credentials (accessKeyId, secretKey, sessionToken). This section documents the observed reference behavior for completeness.
 
-**MQTT broker:** `a1zi08qpbrtjyq-ats.iot.us-east-1.amazonaws.com`  
-**Transport:** TLS  
-**Client ID:** UUID, generated fresh per session  
-**Keepalive:** 60 seconds  
-**Auto-resubscribe:** Yes  
-**Max reconnect attempts:** 5  
+**MQTT broker:** `a1zi08qpbrtjyq-ats.iot.us-east-1.amazonaws.com`
+**Transport:** TLS
+**Client ID:** UUID, generated fresh per session
+**Keepalive:** 60 seconds
+**Auto-resubscribe:** Yes
+**Max reconnect attempts:** 5
 
 **Topic patterns:**
 

--- a/docs/reference/exo.md
+++ b/docs/reference/exo.md
@@ -1,0 +1,282 @@
+# exo — EXO/SWC Chlorinator Protocol
+
+**Python system name:** `"exo"`  
+**Protocol family:** AWS IoT shadow (MQTT in reference; REST polling in current Python implementation)  
+**Auth:** See [client.md](client.md)
+
+---
+
+## Overview
+
+EXO salt water chlorinator devices expose their state via an AWS IoT device shadow. The reference Android implementation uses MQTT exclusively to fetch and update shadow state. The current Python implementation uses HTTP REST to poll the same shadow data, which is also exposed as a REST endpoint.
+
+---
+
+## Shadow Endpoints (REST)
+
+Two URL versions exist in the production configuration:
+
+| Config key | Path | Notes |
+|---|---|---|
+| `tcx_filteration` | `/devices/v1/{serial}/shadow` | v1 — used by current Python implementation |
+| `device_details` | `/devices/v2/{serial}/shadow` | v2 — purpose unclear; may be for other device types |
+
+### Fetch shadow state
+
+```
+GET https://prod.zodiac-io.com/devices/v1/{serial}/shadow
+Authorization: {IdToken}
+```
+
+No request body.
+
+### Post desired state
+
+```
+POST https://prod.zodiac-io.com/devices/v1/{serial}/shadow
+Authorization: {IdToken}
+Content-Type: application/json
+
+{
+  "state": {
+    "desired": { ... }
+  }
+}
+```
+
+---
+
+## Shadow State Structure
+
+The full shadow response envelope:
+
+```json
+{
+  "state": {
+    "reported": { ... },
+    "desired":  { ... }
+  }
+}
+```
+
+The Python implementation reads only `state.reported`.
+
+### `state.reported` field reference
+
+#### `equipment.swc_0` — chlorinator core
+
+| Field | Type | Description |
+|---|---|---|
+| `swc` | integer | Chlorine production percentage (0–100) |
+| `swc_low` | integer | Low-salt warning flag (0/1) |
+| `production` | integer | Current production level |
+| `boost` | integer | Boost mode active (0/1) |
+| `boost_time` | string | Boost remaining time — stripped by current Python implementation |
+| `exo_state` | integer | Device operating state |
+| `error_code` | integer | Error code (0 = none) |
+| `error_state` | integer | Error state flag |
+| `temp` | string | Water temperature reading |
+| `amp` | string | Current draw |
+| `low` | integer | Low-production indicator |
+| `lang` | integer | Language setting |
+| `vsp` | string | Variable speed pump identifier — stripped |
+| `vr` | string | Firmware version — stripped |
+| `sn` | string | Serial number — stripped |
+| `ph_sp` | integer | pH set point |
+| `ph_only` | string | pH-only mode flag |
+| `orp_sp` | integer | ORP set point |
+| `aux230` | string | 230 V aux output state |
+| `dual_link` | string | Dual-link mode flag |
+| `filter_pump` | object | Filter pump state (see below) |
+| `vsp_speed` | object | Variable speed pump RPM bounds — stripped |
+| `sns_1` | object | Sensor 1 readings (see below) |
+| `sns_2` | object | Sensor 2 readings |
+| `sns_3` | object | Sensor 3 readings |
+| `aux_1` | object | Aux output 1 state (see below) |
+| `aux_2` | object | Aux output 2 state |
+
+**`filter_pump` object:**
+
+| Field | Type | Description |
+|---|---|---|
+| `state` | integer | 0 = off, 1 = on |
+| `type` | integer | Pump type code |
+
+**`sns_N` sensor object:**
+
+| Field | Type | Description |
+|---|---|---|
+| `sensor_type` | integer | Sensor type code |
+| `state` | integer | Sensor state |
+| `value` | number | Sensor reading |
+
+**`aux_N` aux output object:**
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | integer | Output type |
+| `mode` | integer | Operating mode |
+| `color` | integer | Color setting (for lights) |
+| `state` | integer | 0 = off, 1 = on |
+
+#### `heating` — heating control
+
+Present only if the device has a heating module.
+
+| Field | Type | Description |
+|---|---|---|
+| `state` | integer | Heater active (0/1) |
+| `enabled` | integer | Heating function enabled (0/1) |
+| `priority_enabled` | integer | Priority heating enabled (0/1) |
+| `sp` | integer | Temperature set point |
+| `sp_min` | integer | Minimum allowed set point |
+| `sp_max` | integer | Maximum allowed set point |
+| `vsp_rpm_index` | integer | Currently selected VSP speed index |
+| `vsp_rpm_list` | object | Map of speed-name → RPM integer (dynamic keys) |
+
+#### `schedules` — schedule entries
+
+Object whose keys are schedule identifiers (dynamic). Each schedule entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `timer.start` | string | Start time (HH:MM format) |
+| `timer.end` | string | End time (HH:MM format) |
+| `rpm` | integer | Target RPM for this schedule |
+| `name` | string | User-assigned schedule name |
+
+#### Top-level reported fields
+
+| Field | Type | Description |
+|---|---|---|
+| `hs.t1` | number | Water temperature (primary sensor) |
+| `tr` | number | Return temperature |
+| `vr` | string | Device firmware version |
+| `ty` | string | Device type string |
+| `aws.status` | string | AWS connectivity status |
+| `aws.session_id` | string | AWS session identifier |
+| `aws.timestamp` | string | Last AWS contact timestamp |
+
+---
+
+## Write Operations
+
+All writes use the desired-state POST (see Endpoints above). Only include the fields being changed — omit unchanged fields.
+
+### Set aux output state
+
+```json
+{
+  "state": {
+    "desired": {
+      "equipment": {
+        "swc_0": {
+          "{aux_name}": {
+            "state": 0
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Set toggle (scalar output)
+
+For fields under `swc_0` that are scalars (not nested objects):
+
+```json
+{
+  "state": {
+    "desired": {
+      "equipment": {
+        "swc_0": {
+          "{field_name}": {value}
+        }
+      }
+    }
+  }
+}
+```
+
+### Set heating state
+
+```json
+{
+  "state": {
+    "desired": {
+      "heating": {
+        "{field_name}": {value}
+      }
+    }
+  }
+}
+```
+
+### Set filter pump state
+
+```json
+{
+  "state": {
+    "desired": {
+      "equipment": {
+        "swc_0": {
+          "{pump_name}": {
+            "state": 0
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## MQTT Transport (Reference)
+
+The reference implementation does not poll via HTTP. It subscribes to AWS IoT MQTT topics using short-lived Cognito session credentials (accessKeyId, secretKey, sessionToken). This section documents the observed reference behavior for completeness.
+
+**MQTT broker:** `a1zi08qpbrtjyq-ats.iot.us-east-1.amazonaws.com`  
+**Transport:** TLS  
+**Client ID:** UUID, generated fresh per session  
+**Keepalive:** 60 seconds  
+**Auto-resubscribe:** Yes  
+**Max reconnect attempts:** 5  
+
+**Topic patterns:**
+
+| Operation | Topic |
+|---|---|
+| Request full shadow | `$aws/things/{serial}/shadow/get` (publish empty payload) |
+| Receive full shadow | `$aws/things/{serial}/shadow/get/accepted` (subscribe) |
+| Subscribe to delta updates | `$aws/things/{serial}/shadow/update/accepted` (subscribe) |
+| Post desired state | `$aws/things/{serial}/shadow/update` (publish) |
+| OTA events | `events/iaqualink/{serial}/{type}` (subscribe) |
+
+The EXO device is identified at the MQTT routing layer by a device-type ordinal. Shadow messages for EXO are dispatched based on the `device_type` field in the device list response.
+
+---
+
+## Error Handling
+
+| Condition | Detection | Action |
+|---|---|---|
+| HTTP 401 | Response code | Trigger token refresh, retry once |
+| HTTP 429 | Response code | Re-raise throttle exception before broader service exception |
+| Other HTTP error | Response code ≠ 200 | Raise service exception |
+| System offline | Not observed as a field in shadow state — not observed in reference | Not observed in reference |
+
+---
+
+## Deltas vs Current Implementation
+
+| # | Observed reference | Current Python (`ExoSystem`) |
+|---|---|---|
+| 1 | Uses MQTT exclusively for shadow get/update | Polls HTTP REST `GET /devices/v1/{serial}/shadow` |
+| 2 | Desired state sent via MQTT publish | POSTs desired state to same REST shadow URL |
+| 3 | Shadow URL version: not applicable (MQTT) | Uses `/devices/v1/` path (matches `tcx_filteration` config key, not `device_details` which is v2) |
+| 4 | `Authorization` format for REST shadow: not observed (MQTT path) | Sends bare `{id_token}` — consistent with other shadow endpoints |
+| 5 | `boost_time`, `vsp_speed`, `sn`, `vr`, `version` present in shadow | Python strips these fields — consistent with reference (reference also filters them in shadow processing) |
+| 6 | Temperature unit not present as a shadow field | Python hardcodes `temp_unit = "C"` — not contradicted by reference |
+| 7 | `heater` device derived from `heating.state` | Python creates a separate `"heater"` device entry with only `state` — not observed in reference as a distinct entity |

--- a/docs/reference/iaqua.md
+++ b/docs/reference/iaqua.md
@@ -1,8 +1,8 @@
 # iaqua — iQ20 Pool Controller Protocol
 
-**Python system name:** `"iaqua"`  
-**Wire device type:** `"iQ20"`  
-**Protocol family:** Legacy REST session (polling, no real-time push)  
+**Python system name:** `"iaqua"`
+**Wire device type:** `"iQ20"`
+**Protocol family:** Legacy REST session (polling, no real-time push)
 **Auth:** See [client.md](client.md)
 
 ---

--- a/docs/reference/iaqua.md
+++ b/docs/reference/iaqua.md
@@ -1,0 +1,233 @@
+# iaqua — iQ20 Pool Controller Protocol
+
+**Python system name:** `"iaqua"`  
+**Wire device type:** `"iQ20"`  
+**Protocol family:** Legacy REST session (polling, no real-time push)  
+**Auth:** See [client.md](client.md)
+
+---
+
+## Overview
+
+iQ20 pool controllers communicate through a single session endpoint on the `p-api.iaqualink.net` host. All operations — reads and writes — are `GET` requests to the same URL, differentiated by a `command` query parameter. There is no push or subscription mechanism; the client must poll.
+
+---
+
+## Session Endpoint
+
+```
+GET https://p-api.iaqualink.net/v2/mobile/session.json
+```
+
+**Headers (all requests):**
+
+| Header | Value |
+|---|---|
+| `Authorization` | `{IdToken}` — bare Cognito JWT, no `Bearer` prefix |
+| `api_key` | Production API key |
+| `Accept` | `application/json` |
+
+**Query parameters (all requests):**
+
+| Parameter | Value |
+|---|---|
+| `actionID` | `"command"` (literal) |
+| `command` | Command string (see below) |
+| `serial` | Device serial number |
+| `sessionID` | `session_id` from login response |
+
+---
+
+## Command Reference
+
+### Read commands
+
+Called on every `update()` cycle.
+
+#### `get_home`
+
+Returns system-level status and thermostat state. In addition to the common query params, the reference implementation sends:
+
+| Extra param | Value |
+|---|---|
+| `country` | User's country code (lowercase) |
+| `attached_test` | `"true"` |
+
+**Response structure:** JSON object containing a `home_screen` key whose value is an array of single-key dicts. Flatten all dicts in the array to obtain the following fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | string | System status — see Status enum below |
+| `system_type` | string | Pool configuration — see SystemType enum below |
+| `temp_scale` | string | `"F"` or `"C"` |
+| `pool_temp` | string | Current pool temperature |
+| `spa_temp` | string | Current spa temperature |
+| `air_temp` | string | Ambient air temperature |
+| `pool_set_point` | string | Pool target temperature |
+| `spa_set_point` | string | Spa target temperature |
+| `pool_chill_set_point` | string | Pool chill (cooling) set point |
+| `pool_pump` | string | Pool pump state (Toggle enum) |
+| `spa_pump` | string | Spa pump state (Toggle enum) |
+| `pool_heater` | string | Pool heater state (HeaterState enum) |
+| `spa_heater` | string | Spa heater state (HeaterState enum) |
+| `solar_heater` | string | Solar heater state (HeaterState enum) |
+| `cover_pool` | string | Pool cover state (Toggle enum) |
+| `freeze_protection` | string | Freeze protection state (Toggle enum) |
+| `swc_set_point` | string | Salt water chlorinator set point |
+| `swc_boost` | string | SWC boost mode active (Toggle enum) |
+| `swc_low` | string | SWC low-salt warning (Toggle enum) |
+| `is_icl_present` | string | ICL (Intellicenter Light) present flag |
+| `acl_value` | string | ACL sensor value |
+| `spa_salinity` | string | Spa salinity reading |
+| `pool_salinity` | string | Pool salinity reading |
+| `orp` | string | ORP sensor value |
+| `ph` | string | pH sensor value |
+| `heatpump_info` | object | Heat pump sub-status (nested) |
+| `swc_info` | object | SWC sub-status (nested) |
+
+If `status` is `"Offline"` or `"Service"`, no further fields should be trusted — raise an offline exception. If `system_type` is an empty string, skip processing the home screen update for this cycle.
+
+#### `get_devices`
+
+Returns the list of configurable aux outputs.
+
+**Response structure:** JSON object containing a `devices_screen` key whose value is an array.
+
+- Index 0: object with `status` field (same Status enum; repeat offline check).
+- Index 1–2: reserved/informational; not used for device state.
+- Index 3+: each element is a single-key dict whose key is the aux name (e.g., `"aux_1"`, `"aux_2"`). The value is an array of single-key dicts; flatten to get:
+
+| Field | Type | Description |
+|---|---|---|
+| `state` | string | Current state (Toggle enum) |
+| `label` | string | User-assigned label |
+| `icon` | string | Icon identifier |
+| `type` | string | Device type code — `"0"` generic, `"1"` dimmable light, `"2"` colour light |
+| `subtype` | string | Light subtype when `type` is `"2"` |
+
+If any state value is `"NaN"`, skip the devices-screen update for this cycle.
+
+---
+
+### Write commands
+
+All write commands share the same endpoint and common headers/params. Each returns the same response shape as the corresponding read command; parse it the same way to update local state.
+
+#### Pump and heater toggles
+
+| Command | What it toggles |
+|---|---|
+| `set_pool_pump` | Pool pump on/off |
+| `set_spa_pump` | Spa pump on/off |
+| `set_pool_heater` | Pool heater on/off |
+| `set_spa_heater` | Spa heater on/off |
+| `set_solar_heater` | Solar heater on/off |
+
+No extra parameters. Response: parse as `get_home`.
+
+#### `set_aux_{n}`
+
+Toggle aux output number `n`. Command string is `set_aux_{n}` where `n` is the numeric suffix of the aux key (e.g., aux key `aux_3` → command `set_aux_3`).
+
+No extra parameters. Response: parse as `get_devices`.
+
+#### `set_light`
+
+Control a colour light output.
+
+| Extra param | Value |
+|---|---|
+| `aux` | Aux slot identifier |
+| `subtype` | Light subtype string |
+| `light` | Target light mode/color |
+
+Response: parse as `get_devices`.
+
+#### `set_temps`
+
+Set pool and/or spa target temperatures. Both temperatures must always be sent together.
+
+| Extra param | Value |
+|---|---|
+| `temp1` | Spa target temperature (if spa present), then pool |
+| `temp2` | Pool target temperature (if spa present) |
+
+When only a pool is configured, send `temp1` = pool target only.
+
+Response: parse as `get_home`.
+
+---
+
+## Enum Wire Values
+
+All enum fields are serialized as strings in JSON.
+
+### SystemType
+
+| Wire value | Meaning |
+|---|---|
+| `"0"` | Spa and pool |
+| `"1"` | Pool only |
+| `"2"` | Dual (two pools) |
+| `"-1"` | Unknown |
+
+### Status
+
+| Wire value | Meaning |
+|---|---|
+| `"Online"` | System reachable |
+| `"Offline"` | System unreachable — raise offline exception |
+| `"Service"` | System in service mode — treat as offline |
+| `"Unknown"` | Unknown |
+
+### HeaterState
+
+| Wire value | Meaning |
+|---|---|
+| `"0"` | Off |
+| `"1"` | On (active heating) |
+| `"3"` | Enabled (setpoint maintained, not actively firing) |
+| `"-1"` | Unknown |
+
+### Toggle
+
+| Wire value | Meaning |
+|---|---|
+| `"0"` | Off |
+| `"1"` | On |
+| `"-1"` | Unknown |
+
+### TemperatureUnit
+
+| Wire value | Meaning |
+|---|---|
+| `"F"` | Fahrenheit |
+| `"C"` | Celsius |
+| `"Unknown"` | Unknown |
+
+---
+
+## Error Handling
+
+| Condition | Detection | Action |
+|---|---|---|
+| System offline or in service | `status` field = `"Offline"` or `"Service"` in any response | Raise offline exception |
+| Device state NaN | Any `state` value = `"NaN"` in `devices_screen` | Skip devices update; no exception |
+| HTTP 401 | Response code | Trigger token refresh, retry once |
+| HTTP 429 | Response code | Re-raise throttle exception before broader service exception |
+| Other HTTP error | Response code ≠ 200 | Raise service exception |
+
+---
+
+## Deltas vs Current Implementation
+
+| # | Observed reference | Current Python (`IaquaSystem`) |
+|---|---|---|
+| 1 | Session host: `p-api.iaqualink.net` | Uses `r-api.iaqualink.net` — different host |
+| 2 | `Authorization` header: bare `{IdToken}` (no prefix) | Sends `Bearer {id_token}` |
+| 3 | `get_home` sends `country` and `attached_test=true` params | Neither param is sent |
+| 4 | `sessionID` in query params | ✓ Matches reference (`client_id` = `session_id`) |
+| 5 | `api_key` header on session requests | ✓ Matches reference |
+| 6 | Response parsing: `home_screen` array flattened | ✓ Matches reference |
+| 7 | Offline detection from `status` field in both `get_home` and `get_devices` | ✓ Matches reference |
+| 8 | `devices_screen` aux entries start at index 3 | ✓ Matches reference (`[3:]`) |

--- a/scripts/claude-review-hook.sh
+++ b/scripts/claude-review-hook.sh
@@ -35,19 +35,21 @@ fi
 
 echo "Running Claude review (.claude/review-criteria.md)…"
 
-CRITERIA_TEXT=$(cat "$CRITERIA")
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
 
-RESULT=$(claude --print \
-"Apply every section of the following review rubric to the diff below.
-Report ONLY issues found. Format each issue as:
-  §<section_number> <file>:<line> — <one-line description>
-If all sections are clean, output exactly: LGTM
+{
+    printf 'Apply every section of the following review rubric to the diff below.\n'
+    printf 'Report ONLY issues found. Format each issue as:\n'
+    printf '  §<section_number> <file>:<line> — <one-line description>\n'
+    printf 'If all sections are clean, output exactly: LGTM\n\n'
+    printf '=== RUBRIC ===\n'
+    cat "$CRITERIA"
+    printf '\n=== DIFF ===\n'
+    printf '%s\n' "$DIFF"
+} > "$TMPFILE"
 
-=== RUBRIC ===
-$CRITERIA_TEXT
-
-=== DIFF ===
-$DIFF" 2>&1) || true
+RESULT=$(claude --print "$(cat "$TMPFILE")" 2>&1) || true
 
 echo "$RESULT"
 

--- a/scripts/claude-review-hook.sh
+++ b/scripts/claude-review-hook.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# pre-push hook: run Claude AI review against .claude/review-criteria.md.
+# Skippable with: git push --no-verify
+set -euo pipefail
+
+if ! command -v claude &>/dev/null; then
+    echo "⚠  claude not on PATH — skipping AI review."
+    echo "   Install Claude Code or use --no-verify to suppress this message."
+    exit 0
+fi
+
+ROOT=$(git rev-parse --show-toplevel)
+CRITERIA="$ROOT/.claude/review-criteria.md"
+
+if [ ! -f "$CRITERIA" ]; then
+    echo "⚠  .claude/review-criteria.md not found — skipping AI review."
+    exit 0
+fi
+
+BASE=$(git merge-base HEAD origin/master 2>/dev/null \
+    || git rev-list --max-parents=0 HEAD 2>/dev/null \
+    || true)
+
+if [ -z "$BASE" ]; then
+    echo "⚠  Could not determine merge base — skipping AI review."
+    exit 0
+fi
+
+DIFF=$(git diff "$BASE"...HEAD --diff-filter=ACMR 2>/dev/null | head -c 60000 || true)
+
+if [ -z "$DIFF" ]; then
+    echo "No source changes to review."
+    exit 0
+fi
+
+echo "Running Claude review (.claude/review-criteria.md)…"
+
+CRITERIA_TEXT=$(cat "$CRITERIA")
+
+RESULT=$(claude --print \
+"Apply every section of the following review rubric to the diff below.
+Report ONLY issues found. Format each issue as:
+  §<section_number> <file>:<line> — <one-line description>
+If all sections are clean, output exactly: LGTM
+
+=== RUBRIC ===
+$CRITERIA_TEXT
+
+=== DIFF ===
+$DIFF" 2>&1) || true
+
+echo "$RESULT"
+
+if echo "$RESULT" | grep -qE "^§0 "; then
+    echo ""
+    echo "BLOCKED: §0 Confidentiality issue detected. Fix before pushing."
+    exit 1
+fi
+
+exit 0

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# pre-commit hook: flag generic decompiler artifact identifiers.
-# Called with staged file paths as arguments.
-# Specific class/package name checking is handled by the Claude AI review
+# pre-commit hook: flag third-party protocol identifiers that must not
+# appear in repo-tracked files. Called with staged file paths as arguments.
+# Additional class/package name checking is handled by the Claude AI review
 # (see .claude/review-criteria.md §0).
 set -euo pipefail
 
@@ -26,7 +26,7 @@ done
 
 if [ "$FOUND" -ne 0 ]; then
     echo ""
-    echo "Decompiler artifact identifier(s) detected in staged files."
+    echo "Third-party protocol identifier(s) detected in staged files."
     echo "Remove them or add the file to the hook exclude list if intentional."
     exit 1
 fi

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -19,7 +19,7 @@ for file in "$@"; do
         while IFS= read -r match; do
             echo "FAIL [$pattern] $match"
             FOUND=1
-        done < <(grep -nP "$pattern" "$file" 2>/dev/null \
+        done < <(grep -nE "$pattern" "$file" 2>/dev/null \
                  | sed "s|^|$file:|" || true)
     done
 done

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# pre-commit hook: flag generic decompiler artifact identifiers.
+# Called with staged file paths as arguments.
+# Specific class/package name checking is handled by the Claude AI review
+# (see .claude/review-criteria.md §0).
+set -euo pipefail
+
+PATTERNS=(
+    '\.java\b'
+    '\.smali\b'
+    '[A-Za-z][A-Za-z0-9]*/[A-Za-z][A-Za-z0-9]*/[A-Za-z][A-Za-z0-9]*\.java'
+)
+
+FOUND=0
+
+for file in "$@"; do
+    [ -f "$file" ] || continue
+    for pattern in "${PATTERNS[@]}"; do
+        while IFS= read -r match; do
+            echo "FAIL [$pattern] $match"
+            FOUND=1
+        done < <(grep -nP "$pattern" "$file" 2>/dev/null \
+                 | sed "s|^|$file:|" || true)
+    done
+done
+
+if [ "$FOUND" -ne 0 ]; then
+    echo ""
+    echo "Decompiler artifact identifier(s) detected in staged files."
+    echo "Remove them or add the file to the hook exclude list if intentional."
+    exit 1
+fi

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Idempotent worktree bootstrap. Run once after creating or entering a new worktree.
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+echo "=== iAquaLink worktree setup ==="
+
+# Install prek (pre-commit) hooks for both stages
+uv run prek install --install-hooks --hook-type pre-commit --hook-type pre-push
+echo "✓ hooks installed (pre-commit + pre-push stages)"
+
+# Ensure hook scripts are executable
+chmod +x scripts/precommit.sh scripts/claude-review-hook.sh
+echo "✓ hook scripts marked executable"
+
+# Check for claude CLI (non-fatal)
+if command -v claude &>/dev/null; then
+    echo "✓ claude on PATH"
+else
+    echo "⚠  claude not on PATH — pre-push AI review will be skipped"
+    echo "   Install Claude Code to enable: https://claude.ai/code"
+fi
+
+echo ""
+echo "Wired:"
+echo "  pre-commit : trailing-ws  end-of-file  check-yaml  large-files"
+echo "               ruff  ruff-format  mypy  uv-lock  check-identifiers"
+echo "  pre-push   : claude-review (skip with --no-verify)"
+echo ""
+echo "Run tests: uv run pytest"
+echo "Run linters: uv run prek run --all-files"

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -7,6 +7,9 @@ cd "$ROOT"
 
 echo "=== iAquaLink worktree setup ==="
 
+# Check hard dependencies
+command -v uv &>/dev/null || { echo "✗ uv not found — install from https://docs.astral.sh/uv/"; exit 1; }
+
 # Install prek (pre-commit) hooks for both stages
 uv run prek install --install-hooks --hook-type pre-commit --hook-type pre-push
 echo "✓ hooks installed (pre-commit + pre-push stages)"


### PR DESCRIPTION
## Summary

- Add wire-level protocol reference docs at `docs/reference/`
- Add `.claude/review-criteria.md` — 10-section rubric mirroring the GitHub PR reviewer, for local use before pushing
- Update `CLAUDE.md` with confidentiality rules, protocol reference pointers, review checklist, and test/worktree conventions
- Add repo-level agents and commands: `/review`, `/ha-review`, `architecture-auditor`
- Add scripts: `setup-worktree.sh` (idempotent bootstrap), `precommit.sh` (identifier check), `claude-review-hook.sh` (pre-push AI review)
- Wire two new pre-commit hooks: `check-identifiers` (pre-commit stage) and `claude-review` (pre-push stage)

## What this closes

The GitHub PR reviewer (`claude-code-review.yml`) was the only place the full review rubric ran. This PR makes that rubric available locally via `/review` and as an automatic pre-push hook.

## Protocol reference docs

`docs/reference/` contains three wire-level protocol docs:

| File | Covers |
|---|---|
| `client.md` | Auth (login/refresh), device list, HTTP config, deltas vs Python |
| `iaqua.md` | iQ20 session endpoint, all commands, response shapes, enum wire values, deltas |
| `exo.md` | EXO/SWC shadow REST, full state field table, write shapes, deltas |

Deltas are inventoried only — no production code changes in this PR.

## Test plan

- [ ] Run `bash scripts/setup-worktree.sh` in a fresh worktree — verify all hooks install and checklist prints
- [ ] Stage a file containing `SomeClass.java` — verify `check-identifiers` hook blocks the commit
- [ ] Stage a clean file — verify hook passes
- [ ] Run `/review` — verify rubric output covers §0-§10
- [ ] Run `/ha-review devices` — verify HA entity compatibility report

Generated with [Claude Code](https://claude.ai/claude-code)