### PR TITLE
feat(logging): per-system loggers, sensitive-data redaction, structured summaries

### DIFF
--- a/.claude/review-criteria.md
+++ b/.claude/review-criteria.md
@@ -60,7 +60,7 @@ This is an `asyncio`-based library. Flag any of the following:
 ## 5. Code Quality and Best Practices
 
 - No commented-out code.
-- No `print()` — use `LOGGER = logging.getLogger("iaqualink")`.
+- No `print()` — use a module-level `LOGGER = logging.getLogger("iaqualink.<module>")`. See `docs/development/contributing.md` § Logging for the full name table.
 - No f-string logging: `LOGGER.debug("x=%s", x)` not `LOGGER.debug(f"x={x}")`.
 - Constants in module scope, not inline magic strings or numbers (exception: trivial `""` / `0` / `1` states).
 - New device/system subclasses must register via the `NAME` + `__init_subclass__` pattern — no manual dict edits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,17 @@ Subclasses must appear before their superclass in `_DEVICE_GROUPS` (e.g. `Aquali
 
 **Divergences from reference behavior** are documented in the "Deltas vs current implementation" section of each architecture doc. Before adding new divergences, confirm they are intentional and add them to the appropriate doc.
 
+## Logging Guidelines
+
+See [`docs/development/contributing.md` — Logging section](docs/development/contributing.md#logging) for the full reference.
+
+Quick rules:
+- New module logger: `logging.getLogger("iaqualink.systems.<name>")` for system modules; `"iaqualink.<module>"` otherwise.
+- Request logging: always wrap with `_redact_url(url)` and `_redact_kwargs(kwargs)` from `client.py`.
+- Parse methods: `LOGGER.debug("<Name> body: %s", data)` must be the first line after `data = response.json()`.
+- **Never** log auth response bodies (login/refresh) — they contain raw tokens.
+- Auth events (`login`, token refresh, reauth fallback) log at INFO; everything else at DEBUG or WARNING.
+
 ## Review Checklist
 
 Before declaring any diff done, self-apply `.claude/review-criteria.md`. That file contains the full rubric used by the GitHub PR reviewer. Running it locally closes the gap between local iteration and PR feedback.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -152,6 +152,82 @@ def example_function(param: str) -> int:
     return len(param)
 ```
 
+### Logging
+
+#### Logger names
+
+Each module uses a named child logger under the `iaqualink` root so callers can filter
+output per subsystem. The root logger (`iaqualink`) is configured by the CLI's
+`--debug` flag; all children inherit it automatically.
+
+| Module | Logger name |
+|--------|-------------|
+| `client.py` | `iaqualink.client` |
+| `system.py` | `iaqualink.system` |
+| `device.py` | `iaqualink.device` |
+| `systems/iaqua/system.py`, `systems/iaqua/device.py` | `iaqualink.systems.iaqua` |
+| `systems/exo/system.py`, `systems/exo/device.py` | `iaqualink.systems.exo` |
+| `systems/i2d/system.py`, `systems/i2d/device.py` | `iaqualink.systems.i2d` |
+| `cli/app.py` | `iaqualink.cli` |
+
+When adding a new system, use `logging.getLogger("iaqualink.systems.<name>")` in both
+`system.py` and `device.py`.
+
+#### Sensitive data
+
+**Never** log the following values directly:
+
+- Credentials: `password`, `_password`
+- Auth tokens: `authentication_token`, `id_token`, `refresh_token`, `client_id`
+- Request secrets: HMAC `signature`, `sessionID`
+
+When logging request parameters, use the helpers in `client.py`:
+
+```python
+LOGGER.debug("-> %s %s %s", method, _redact_url(url), _redact_kwargs(kwargs))
+```
+
+`AqualinkAuthState.__repr__` already masks token fields — logging an auth state object is safe.
+
+Auth **response** bodies (login, refresh) contain raw tokens — never log them on success.
+
+#### Response body visibility
+
+Parse methods log the full raw response body at `DEBUG` **before** any parsing logic, so even a
+mid-parse crash shows exactly what the API returned:
+
+```python
+def _parse_foo_response(self, response: httpx.Response) -> None:
+    data = response.json()
+    LOGGER.debug("Foo body: %s", data)      # must be first — visible even if parse raises
+    ...
+    LOGGER.debug("Foo parsed: serial=%s status=%s", self.serial, self.status.name)
+```
+
+Device-state response bodies (home, devices, shadow, alldata) contain no auth tokens and are
+safe to log in full. The body line provides API visibility for issue reports; the structured
+summary at the end provides grep-friendly output.
+
+#### Log levels
+
+| Level | Use for |
+|-------|---------|
+| `INFO` | Auth lifecycle events: login, token refresh, reauth fallback |
+| `DEBUG` | Normal flow: request/response details, parse results, device counts |
+| `WARNING` | Unexpected but handled: unknown enum value, offline device, skipped update |
+| `ERROR` / exception | Not used — raise exceptions instead |
+
+Auth lifecycle events that warrant `INFO`:
+
+```python
+LOGGER.info("Authenticated: user=%s", self.username)
+LOGGER.info("Auth token refreshed: user=%s", self.username)
+LOGGER.info("Refresh token expired, re-authenticating: user=%s", self.username)
+```
+
+System status changes stay at `DEBUG` (noisy on frequent polling); unexpected status values
+stay at `WARNING`.
+
 ## Testing
 
 ### Test Structure

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -177,7 +177,7 @@ When adding a new system, use `logging.getLogger("iaqualink.systems.<name>")` in
 
 **Never** log the following values directly:
 
-- Credentials: `password`, `_password`
+- Credentials: `password`, `_password`, `api_key`
 - Auth tokens: `authentication_token`, `id_token`, `refresh_token`, `client_id`
 - Request secrets: HMAC `signature`, `sessionID`
 

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -5,7 +5,7 @@ import importlib
 import logging
 import re
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields as dataclass_fields
 from typing import TYPE_CHECKING, Any, Self
 
 import httpx
@@ -49,6 +49,8 @@ _REDACT_KEYS = frozenset(
     {
         "api_key",
         "authentication_token",
+        "client_id",
+        "id_token",
         "password",
         "refresh_token",
         "sessionID",
@@ -66,7 +68,7 @@ def _redact_url(url: str) -> str:
 
 def _redact_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     out = dict(kwargs)
-    for key in ("json", "params"):
+    for key in ("json", "params", "data"):
         if key in out and isinstance(out[key], dict):
             out[key] = {
                 k: "***" if k in _REDACT_KEYS else v
@@ -109,11 +111,13 @@ class AqualinkAuthState:
         return cls(**values)
 
     def __repr__(self) -> str:
-        return (
-            f"AqualinkAuthState(username={self.username!r}, "
-            f"client_id=***, authentication_token=***, "
-            f"user_id={self.user_id!r}, id_token=***, refresh_token=***)"
+        parts = ", ".join(
+            f"{f.name}=***"
+            if f.name in _REDACT_KEYS
+            else f"{f.name}={getattr(self, f.name)!r}"
+            for f in dataclass_fields(self)
         )
+        return f"AqualinkAuthState({parts})"
 
 
 class AqualinkClient:

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import re
 import time
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Self
@@ -42,7 +43,36 @@ AQUALINK_HTTP_HEADERS = {
     "content-type": "application/json",
 }
 
-LOGGER = logging.getLogger("iaqualink")
+LOGGER = logging.getLogger("iaqualink.client")
+
+_REDACT_KEYS = frozenset(
+    {
+        "api_key",
+        "authentication_token",
+        "password",
+        "refresh_token",
+        "sessionID",
+        "signature",
+    }
+)
+_REDACT_URL_RE = re.compile(
+    r"(?<=[?&])(" + "|".join(sorted(_REDACT_KEYS)) + r")=[^&]*"
+)
+
+
+def _redact_url(url: str) -> str:
+    return _REDACT_URL_RE.sub(r"\1=***", url)
+
+
+def _redact_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    out = dict(kwargs)
+    for key in ("json", "params"):
+        if key in out and isinstance(out[key], dict):
+            out[key] = {
+                k: "***" if k in _REDACT_KEYS else v
+                for k, v in out[key].items()
+            }
+    return out
 
 
 @dataclass(frozen=True)
@@ -77,6 +107,13 @@ class AqualinkAuthState:
             values[field_name] = value
 
         return cls(**values)
+
+    def __repr__(self) -> str:
+        return (
+            f"AqualinkAuthState(username={self.username!r}, "
+            f"client_id=***, authentication_token=***, "
+            f"user_id={self.user_id!r}, id_token=***, refresh_token=***)"
+        )
 
 
 class AqualinkClient:
@@ -187,7 +224,12 @@ class AqualinkClient:
         headers.update(kwargs.pop("headers", {}))
         kwargs.setdefault("timeout", DEFAULT_REQUEST_TIMEOUT)
 
-        LOGGER.debug("-> %s %s %s", method.upper(), url, kwargs)
+        LOGGER.debug(
+            "-> %s %s %s",
+            method.upper(),
+            _redact_url(url),
+            _redact_kwargs(kwargs),
+        )
         try:
             r = await client.request(method, url, headers=headers, **kwargs)
         except (httpx.TransportError, OSError) as e:
@@ -267,6 +309,10 @@ class AqualinkClient:
                 r = await self._send_refresh_request()
             except AqualinkServiceUnauthorizedException:
                 # Refresh token is expired or invalid — fall back to full login.
+                LOGGER.info(
+                    "Refresh token expired, re-authenticating: user=%s",
+                    self.username,
+                )
                 await self.login()
                 return
 
@@ -274,10 +320,12 @@ class AqualinkClient:
                 r.json(),
                 refresh_token_fallback=self.refresh_token,
             )
+            LOGGER.info("Auth token refreshed: user=%s", self.username)
 
     async def login(self) -> None:
         r = await self._send_login_request()
         self._apply_login_data(r.json(), refresh_token_fallback="")
+        LOGGER.info("Authenticated: user=%s", self.username)
 
     def _clear_auth_state(self) -> None:
         self.client_id = ""
@@ -338,7 +386,8 @@ class AqualinkClient:
             raise
 
         data = r.json()
-        LOGGER.debug("Systems response: %s", data)
+        LOGGER.debug("Systems body: %s", data)
+        LOGGER.debug("get_systems: %d system(s) discovered", len(data))
 
         systems = [AqualinkSystem.from_data(self, x) for x in data]
         return {x.serial: x for x in systems}

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -12,7 +12,7 @@ from iaqualink.exception import (
 if TYPE_CHECKING:
     from iaqualink.typing import DeviceData
 
-LOGGER = logging.getLogger("iaqualink")
+LOGGER = logging.getLogger("iaqualink.device")
 
 
 class AqualinkDevice:

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from iaqualink.typing import Payload
 
 
-LOGGER = logging.getLogger("iaqualink")
+LOGGER = logging.getLogger("iaqualink.system")
 
 
 class SystemStatus(enum.Enum):

--- a/src/iaqualink/systems/exo/device.py
+++ b/src/iaqualink/systems/exo/device.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 EXO_TEMP_CELSIUS_LOW = 1
 EXO_TEMP_CELSIUS_HIGH = 40
 
-LOGGER = logging.getLogger("iaqualink")
+LOGGER = logging.getLogger("iaqualink.systems.exo")
 
 
 @unique

--- a/src/iaqualink/systems/exo/system.py
+++ b/src/iaqualink/systems/exo/system.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 EXO_DEVICES_URL = "https://prod.zodiac-io.com/devices/v1"
 
-LOGGER = logging.getLogger("iaqualink")
+LOGGER = logging.getLogger("iaqualink.systems.exo")
 
 
 class ExoSystem(AqualinkSystem):
@@ -67,8 +67,7 @@ class ExoSystem(AqualinkSystem):
 
     def _parse_shadow_response(self, response: httpx.Response) -> None:
         data = response.json()
-
-        LOGGER.debug("Shadow response: %s", data)
+        LOGGER.debug("Shadow body: %s", data)
 
         raw_aws_status = (
             data.get("state", {})
@@ -89,6 +88,9 @@ class ExoSystem(AqualinkSystem):
                 self.status = SystemStatus.UNKNOWN
             else:
                 self.status = mapped
+        LOGGER.debug(
+            "Shadow parsed: serial=%s status=%s", self.serial, self.status.name
+        )
 
         devices = {}
 
@@ -124,7 +126,9 @@ class ExoSystem(AqualinkSystem):
             attrs.update({"state": reported["heating"]["state"]})
             devices.update({name: attrs})
 
-        LOGGER.debug("devices: %s", devices)
+        LOGGER.debug(
+            "EXO devices parsed: serial=%s count=%d", self.serial, len(devices)
+        )
 
         for k, v in devices.items():
             if k in self.devices:

--- a/src/iaqualink/systems/i2d/device.py
+++ b/src/iaqualink/systems/i2d/device.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from iaqualink.systems.i2d.system import I2dSystem
     from iaqualink.typing import DeviceData
 
-LOGGER = logging.getLogger("iaqualink")
+LOGGER = logging.getLogger("iaqualink.systems.i2d")
 
 
 @unique

--- a/src/iaqualink/systems/i2d/system.py
+++ b/src/iaqualink/systems/i2d/system.py
@@ -249,12 +249,6 @@ class I2dSystem(AqualinkSystem):
                 "command": command,
                 "params": params,
             }
-            LOGGER.debug(
-                "i2d request: POST %s command=%s params=%s",
-                url,
-                command,
-                params,
-            )
             return await self.aqualink.send_request(
                 url, method="post", headers=headers, json=body, **kwargs
             )

--- a/src/iaqualink/systems/i2d/system.py
+++ b/src/iaqualink/systems/i2d/system.py
@@ -24,7 +24,7 @@ I2D_CONTROL_URL = "https://r-api.iaqualink.net/v2/devices"
 
 _SVRS_PRODUCT_IDS: frozenset[str] = frozenset({"0F", "18"})
 
-LOGGER = logging.getLogger("iaqualink")
+LOGGER = logging.getLogger("iaqualink.systems.i2d")
 
 
 class NumberSpec(NamedTuple):
@@ -297,7 +297,7 @@ class I2dSystem(AqualinkSystem):
 
     def _parse_alldata_response(self, response: httpx.Response) -> None:
         data = response.json()
-        LOGGER.debug("Alldata response: %s", data)
+        LOGGER.debug("Alldata body: %s", data)
 
         # API returns HTTP 200 even when device is unreachable; body carries status=500.
         if data.get("status") == "500":
@@ -382,3 +382,10 @@ class I2dSystem(AqualinkSystem):
                 self.devices[key] = I2dBinarySensor(
                     self, shared_data, key=key, label=label
                 )
+
+        LOGGER.debug(
+            "Alldata parsed: serial=%s status=%s devices=%d",
+            self.serial,
+            self.status.name,
+            len(self.devices),
+        )

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -27,7 +27,7 @@ IAQUA_TEMP_CELSIUS_HIGH = 40
 IAQUA_TEMP_FAHRENHEIT_LOW = 34
 IAQUA_TEMP_FAHRENHEIT_HIGH = 104
 
-LOGGER = logging.getLogger("iaqualink")
+LOGGER = logging.getLogger("iaqualink.systems.iaqua")
 
 
 @unique

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -286,6 +286,7 @@ class IaquaSystem(AqualinkSystem):
             )
             return
 
+        onetouch_count = 0
         for name, val in onetouch.items():
             if not isinstance(val, list) or not name.startswith("onetouch_"):
                 continue
@@ -295,6 +296,7 @@ class IaquaSystem(AqualinkSystem):
             if attrs.get("status") == IaquaBinaryState.OFF:
                 self.devices.pop(name, None)
                 continue
+            onetouch_count += 1
             if name in self.devices:
                 for dk, dv in attrs.items():
                     self.devices[name].data[dk] = dv
@@ -304,7 +306,7 @@ class IaquaSystem(AqualinkSystem):
         LOGGER.debug(
             "OneTouch parsed: serial=%s count=%d",
             self.serial,
-            sum(1 for k in self.devices if k.startswith("onetouch_")),
+            onetouch_count,
         )
 
     async def set_onetouch(self, name: str) -> None:

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -46,7 +46,7 @@ IAQUA_COMMAND_SET_SPA_HEATER = "set_spa_heater"
 IAQUA_COMMAND_SET_SPA_PUMP = "set_spa_pump"
 IAQUA_COMMAND_SET_TEMPS = "set_temps"
 
-LOGGER = logging.getLogger("iaqualink")
+LOGGER = logging.getLogger("iaqualink.systems.iaqua")
 
 
 _IAQUA_STATUS_MAP: dict[str, SystemStatus] = {
@@ -95,14 +95,13 @@ class IaquaSystem(AqualinkSystem):
                 **params,
                 "sessionID": self.aqualink.client_id,
             }
-            params_str = "&".join(f"{k}={v}" for k, v in request_params.items())
-            url = f"{IAQUA_SESSION_URL}?{params_str}"
             headers = {
                 "Authorization": f"Bearer {self.aqualink.id_token}",
                 "api_key": AQUALINK_API_KEY,
             }
             return await self.aqualink.send_request(
-                url,
+                IAQUA_SESSION_URL,
+                params=request_params,
                 headers=headers,
             )
 
@@ -137,8 +136,7 @@ class IaquaSystem(AqualinkSystem):
 
     def _parse_home_response(self, response: httpx.Response) -> None:
         data = response.json()
-
-        LOGGER.debug("Home response: %s", data)
+        LOGGER.debug("Home body: %s", data)
 
         home: dict = {}
         for x in data["home_screen"]:
@@ -147,6 +145,9 @@ class IaquaSystem(AqualinkSystem):
         raw_status = home.get("status")
         self.status = _IAQUA_STATUS_MAP.get(
             raw_status or "", SystemStatus.UNKNOWN
+        )
+        LOGGER.debug(
+            "Home parsed: serial=%s status=%s", self.serial, self.status.name
         )
         if self.status is not SystemStatus.ONLINE:
             LOGGER.warning(
@@ -191,8 +192,7 @@ class IaquaSystem(AqualinkSystem):
 
     def _parse_devices_response(self, response: httpx.Response) -> None:
         data = response.json()
-
-        LOGGER.debug("Devices response: %s", data)
+        LOGGER.debug("Devices body: %s", data)
 
         status = data["devices_screen"][0]["status"]
         if status in (IaquaSystemStatus.OFFLINE, IaquaSystemStatus.SERVICE, ""):
@@ -233,6 +233,10 @@ class IaquaSystem(AqualinkSystem):
                     device_class = IaquaAuxSwitch
                 self.devices[aux] = device_class(self, attrs)
 
+        LOGGER.debug(
+            "Devices parsed: serial=%s count=%d", self.serial, len(self.devices)
+        )
+
     async def set_switch(self, command: str) -> None:
         r = await self._send_session_request(command)
         self._parse_home_response(r)
@@ -263,8 +267,7 @@ class IaquaSystem(AqualinkSystem):
 
     def _parse_onetouch_response(self, response: httpx.Response) -> None:
         data = response.json()
-
-        LOGGER.debug("OneTouch response: %s", data)
+        LOGGER.debug("OneTouch body: %s", data)
 
         onetouch: dict = {}
         for x in data["onetouch_screen"]:
@@ -297,6 +300,12 @@ class IaquaSystem(AqualinkSystem):
                     self.devices[name].data[dk] = dv
             else:
                 self.devices[name] = IaquaOneTouchSwitch(self, attrs)
+
+        LOGGER.debug(
+            "OneTouch parsed: serial=%s count=%d",
+            self.serial,
+            sum(1 for k in self.devices if k.startswith("onetouch_")),
+        )
 
     async def set_onetouch(self, name: str) -> None:
         cmd = IAQUA_COMMAND_SET_ONETOUCH + "_" + name.removeprefix("onetouch_")

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import urllib.parse
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -557,8 +556,8 @@ class TestIaquaSystem(TestBaseSystem):
         with patch.object(self.sut, "_parse_onetouch_response") as mock_parse:
             await self.sut.set_onetouch("onetouch_1")
 
-            called_url = mock_request.call_args[0][1]
-            assert f"{IAQUA_COMMAND_SET_ONETOUCH}_1" in called_url
+            called_params = mock_request.call_args[1]["params"]
+            assert called_params["command"] == f"{IAQUA_COMMAND_SET_ONETOUCH}_1"
             mock_parse.assert_called_once_with(mock_request.return_value)
 
     async def test_refresh_onetouch_failure_raises(self) -> None:
@@ -710,14 +709,12 @@ class TestIaquaSystem(TestBaseSystem):
         ) as mock_refresh:
             await self.sut._send_home_screen_request()
 
-        retry_url = mock_request.call_args_list[1][0][1]
-        retry_headers = mock_request.call_args_list[1][1]["headers"]
-        retry_params = urllib.parse.parse_qs(
-            urllib.parse.urlparse(retry_url).query
-        )
+        retry_kwargs = mock_request.call_args_list[1][1]
+        retry_headers = retry_kwargs["headers"]
+        retry_params = retry_kwargs["params"]
 
         mock_refresh.assert_awaited_once()
-        assert retry_params["sessionID"] == ["new-session-id"]
+        assert retry_params["sessionID"] == "new-session-id"
         assert retry_headers["Authorization"] == "Bearer new-id-token"
 
     @patch("httpx.AsyncClient.request")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -701,6 +701,12 @@ class TestRedactKwargs(TestBase):
         assert result["json"] == {"command": "get_home", "serial": "ABC"}
         assert result["timeout"] == 10
 
+    def test_redacts_sensitive_keys_in_data(self) -> None:
+        kwargs = {"data": {"password": "secret", "user_id": "1"}}
+        result = _redact_kwargs(kwargs)
+        assert result["data"]["password"] == "***"
+        assert result["data"]["user_id"] == "1"
+
     def test_ignores_non_dict_json(self) -> None:
         kwargs = {"json": "not-a-dict"}
         result = _redact_kwargs(kwargs)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,8 @@ import respx
 from iaqualink.client import (
     AqualinkAuthState,
     AqualinkClient,
+    _redact_kwargs,
+    _redact_url,
 )
 from iaqualink.const import (
     AQUALINK_API_KEY,
@@ -616,3 +618,110 @@ class TestAqualinkClient(TestBase):
         await self.client._send_systems_request()
 
         assert self.client.refresh_token == original_refresh_token
+
+
+class TestRedactUrl(TestBase):
+    def test_redacts_password_in_query(self) -> None:
+        url = "https://example.com/login?email=user&password=s3cr3t"
+        assert (
+            _redact_url(url)
+            == "https://example.com/login?email=user&password=***"
+        )
+
+    def test_redacts_signature_in_query(self) -> None:
+        url = "https://r-api.iaqualink.net/v2/devices.json?user_id=1&signature=abc123&timestamp=1"
+        assert "signature=***" in _redact_url(url)
+        assert "user_id=1" in _redact_url(url)
+
+    def test_redacts_sessionID_in_query(self) -> None:
+        url = "https://p-api.iaqualink.net/v2/mobile/session.json?sessionID=tok&command=get_home"
+        result = _redact_url(url)
+        assert "sessionID=***" in result
+        assert "command=get_home" in result
+
+    def test_redacts_authentication_token_in_query(self) -> None:
+        url = "https://example.com/api?authentication_token=secret&other=ok"
+        result = _redact_url(url)
+        assert "authentication_token=***" in result
+        assert "other=ok" in result
+
+    def test_no_change_when_no_sensitive_params(self) -> None:
+        url = "https://example.com/api?user_id=42&timestamp=1234"
+        assert _redact_url(url) == url
+
+    def test_redacts_api_key_in_query(self) -> None:
+        url = "https://example.com/api?api_key=deadbeef&user_id=1"
+        result = _redact_url(url)
+        assert "api_key=***" in result
+        assert "user_id=1" in result
+
+
+class TestRedactKwargs(TestBase):
+    def test_redacts_password_in_json(self) -> None:
+        kwargs = {"json": {"email": "user@example.com", "password": "s3cr3t"}}
+        result = _redact_kwargs(kwargs)
+        assert result["json"]["password"] == "***"
+        assert result["json"]["email"] == "user@example.com"
+
+    def test_redacts_refresh_token_in_json(self) -> None:
+        kwargs = {"json": {"email": "u", "refresh_token": "tok"}}
+        result = _redact_kwargs(kwargs)
+        assert result["json"]["refresh_token"] == "***"
+
+    def test_redacts_authentication_token_in_json(self) -> None:
+        kwargs = {"json": {"authentication_token": "tok", "user_id": "1"}}
+        result = _redact_kwargs(kwargs)
+        assert result["json"]["authentication_token"] == "***"
+        assert result["json"]["user_id"] == "1"
+
+    def test_redacts_api_key_in_json(self) -> None:
+        kwargs = {"json": {"api_key": "deadbeef", "command": "/opmode/write"}}
+        result = _redact_kwargs(kwargs)
+        assert result["json"]["api_key"] == "***"
+        assert result["json"]["command"] == "/opmode/write"
+
+    def test_redacts_sessionID_in_params(self) -> None:
+        kwargs = {"params": {"sessionID": "tok", "command": "get_home"}}
+        result = _redact_kwargs(kwargs)
+        assert result["params"]["sessionID"] == "***"
+        assert result["params"]["command"] == "get_home"
+
+    def test_does_not_mutate_original(self) -> None:
+        original_json = {"password": "secret", "email": "u"}
+        kwargs = {"json": original_json}
+        _redact_kwargs(kwargs)
+        assert original_json["password"] == "secret"
+
+    def test_passthrough_when_no_sensitive_keys(self) -> None:
+        kwargs = {
+            "json": {"command": "get_home", "serial": "ABC"},
+            "timeout": 10,
+        }
+        result = _redact_kwargs(kwargs)
+        assert result["json"] == {"command": "get_home", "serial": "ABC"}
+        assert result["timeout"] == 10
+
+    def test_ignores_non_dict_json(self) -> None:
+        kwargs = {"json": "not-a-dict"}
+        result = _redact_kwargs(kwargs)
+        assert result["json"] == "not-a-dict"
+
+
+class TestAqualinkAuthStateRepr(TestBase):
+    def test_repr_masks_tokens(self) -> None:
+        state = AqualinkAuthState(
+            username="user@example.com",
+            client_id="session-id",
+            authentication_token="auth-tok",
+            user_id="42",
+            id_token="jwt",
+            refresh_token="refresh-tok",
+        )
+        r = repr(state)
+        assert "user@example.com" in r
+        assert "42" in r
+        assert "session-id" not in r
+        assert "auth-tok" not in r
+        assert "jwt" not in r
+        assert "refresh-tok" not in r
+        assert "***" in r


### PR DESCRIPTION
## Summary

- **Per-module logger hierarchy** — all modules now use `iaqualink.<module>` child loggers (e.g. `iaqualink.systems.iaqua`, `iaqualink.client`) so callers can filter by subsystem without enabling all debug output
- **Sensitive-data redaction** — `_redact_url()` and `_redact_kwargs()` strip `password`, `refresh_token`, `authentication_token`, `api_key`, `sessionID`, and `signature` from every request log; `AqualinkAuthState.__repr__` masks all token fields
- **Response body visibility** — raw response body logged at DEBUG *before* each parse method, preserving full API visibility for issue reports even when parsing raises mid-way; structured summary (status, device count) follows for grep-friendly output
- **iaqua session URL refactor** — `_send_session_request` now passes `params=` kwarg to httpx instead of manually baking the query string, enabling consistent redaction via `_redact_kwargs`
- **INFO-level auth events** — `login()`, token refresh success, and refresh-expired fallback now emit INFO so library consumers see auth lifecycle without enabling DEBUG
- **Logging guidelines** added to `docs/development/contributing.md` (logger name table, sensitive field list, body-first parse pattern, log level guide) with a terse pointer in `CLAUDE.md`

## Test plan

- [ ] `uv run prek run --all-files` passes
- [ ] `uv run pytest` passes (848 tests, 12 skipped)
- [ ] 15 new unit tests cover `_redact_url`, `_redact_kwargs`, and `AqualinkAuthState.__repr__`
- [ ] Enable `--debug` and verify no token values appear in log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)