### PR TITLE
feat(cli): pump and number control commands

### DIFF
--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -659,7 +659,7 @@ async def _set_number_value(
     t.append(device.label, style="bold")
     t.append(f" [{device_name}]", style="dim")
     unit = device.unit
-    value_str = f" to {value}{unit}" if unit else f" to {value}"
+    value_str = f" to {value} {unit}" if unit else f" to {value}"
     t.append(f"{value_str} on ")
     t.append_text(_format_system_line(system))
     return t

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -536,15 +536,28 @@ async def _run_switch_command(
     devices = await _load_devices_for_system(system)
     device_name, device = _resolve_device(devices, device_selector)
 
-    if not isinstance(device, AqualinkSwitch):
+    if isinstance(device, AqualinkSwitch):
+        if target_state == "on":
+            await device.turn_on()
+        else:
+            await device.turn_off()
+    elif isinstance(device, AqualinkPump):
+        if target_state == "on" and not device.supports_turn_on:
+            _exit_with_error(
+                f"Pump {device_name!r} does not support turn on.",
+            )
+        if target_state == "off" and not device.supports_turn_off:
+            _exit_with_error(
+                f"Pump {device_name!r} does not support turn off.",
+            )
+        if target_state == "on":
+            await device.turn_on()
+        else:
+            await device.turn_off()
+    else:
         _exit_with_error(
             f"Device {device_name!r} does not support power controls.",
         )
-
-    if target_state == "on":
-        await device.turn_on()
-    else:
-        await device.turn_off()
 
     _save_session_jar(cookie_jar, system.aqualink.auth_state)
     t = Text()
@@ -553,6 +566,101 @@ async def _run_switch_command(
     t.append(device.label, style="bold")
     t.append(f" [{device_name}]", style="dim")
     t.append(" on ")
+    t.append_text(_format_system_line(system))
+    return t
+
+
+async def _set_pump_speed(
+    credentials: Credentials,
+    system_selector: str | None,
+    device_selector: str,
+    percentage: int,
+    cookie_jar: Path,
+) -> Text:
+    systems = await _fetch_systems(credentials, cookie_jar)
+    system = _resolve_system(systems, system_selector)
+    devices = await _load_devices_for_system(system)
+    device_name, device = _resolve_device(devices, device_selector)
+
+    if not isinstance(device, AqualinkPump):
+        _exit_with_error(f"Device {device_name!r} is not a pump.")
+
+    if not device.supports_set_speed_percentage:
+        _exit_with_error(
+            f"Pump {device_name!r} does not support speed control.",
+        )
+
+    await device.set_speed_percentage(percentage)
+    _save_session_jar(cookie_jar, system.aqualink.auth_state)
+    t = Text()
+    t.append("✓ ", style="bold green")
+    t.append("Set speed of ")
+    t.append(device.label, style="bold")
+    t.append(f" [{device_name}]", style="dim")
+    t.append(f" to {percentage}% on ")
+    t.append_text(_format_system_line(system))
+    return t
+
+
+async def _set_pump_preset(
+    credentials: Credentials,
+    system_selector: str | None,
+    device_selector: str,
+    preset: str,
+    cookie_jar: Path,
+) -> Text:
+    systems = await _fetch_systems(credentials, cookie_jar)
+    system = _resolve_system(systems, system_selector)
+    devices = await _load_devices_for_system(system)
+    device_name, device = _resolve_device(devices, device_selector)
+
+    if not isinstance(device, AqualinkPump):
+        _exit_with_error(f"Device {device_name!r} is not a pump.")
+
+    if not device.supports_presets:
+        _exit_with_error(
+            f"Pump {device_name!r} does not support presets.",
+        )
+
+    await device.set_preset(preset)
+    _save_session_jar(cookie_jar, system.aqualink.auth_state)
+    t = Text()
+    t.append("✓ ", style="bold green")
+    t.append("Set preset of ")
+    t.append(device.label, style="bold")
+    t.append(f" [{device_name}]", style="dim")
+    t.append(f" to {preset!r} on ")
+    t.append_text(_format_system_line(system))
+    return t
+
+
+async def _set_number_value(
+    credentials: Credentials,
+    system_selector: str | None,
+    device_selector: str,
+    value: float,
+    cookie_jar: Path,
+) -> Text:
+    systems = await _fetch_systems(credentials, cookie_jar)
+    system = _resolve_system(systems, system_selector)
+    devices = await _load_devices_for_system(system)
+    device_name, device = _resolve_device(devices, device_selector)
+
+    if not isinstance(device, AqualinkNumber):
+        _exit_with_error(
+            f"Device {device_name!r} does not support numeric values.",
+        )
+
+    await device.set_value(value)
+    _save_session_jar(cookie_jar, system.aqualink.auth_state)
+    t = Text()
+    t.append("✓ ", style="bold green")
+    t.append("Set ")
+    t.append(device.label, style="bold")
+    t.append(f" [{device_name}]", style="dim")
+    unit = device.unit
+    value_str = f" to {value}{unit}" if unit else f" to {value}"
+    t.append(f"{value_str} on ")
     t.append_text(_format_system_line(system))
     return t
 
@@ -805,4 +913,60 @@ def set_effect(
     credentials = _resolve_credentials(username, password, config)
     _console.print(
         _run_async(_set_effect(credentials, system, device, effect, cookie_jar))
+    )
+
+
+@app.command("set-speed")
+def set_speed(
+    device: DeviceArgument,
+    percentage: Annotated[
+        int, typer.Argument(help="Pump speed percentage (0-100).")
+    ],
+    username: UsernameOption = None,
+    password: PasswordOption = None,
+    config: ConfigOption = DEFAULT_CONFIG_PATH,
+    system: SystemOption = None,
+    cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
+) -> None:
+    credentials = _resolve_credentials(username, password, config)
+    _console.print(
+        _run_async(
+            _set_pump_speed(credentials, system, device, percentage, cookie_jar)
+        )
+    )
+
+
+@app.command("set-preset")
+def set_preset(
+    device: DeviceArgument,
+    preset: Annotated[str, typer.Argument(help="Pump preset name.")],
+    username: UsernameOption = None,
+    password: PasswordOption = None,
+    config: ConfigOption = DEFAULT_CONFIG_PATH,
+    system: SystemOption = None,
+    cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
+) -> None:
+    credentials = _resolve_credentials(username, password, config)
+    _console.print(
+        _run_async(
+            _set_pump_preset(credentials, system, device, preset, cookie_jar)
+        )
+    )
+
+
+@app.command("set-value")
+def set_value(
+    device: DeviceArgument,
+    value: Annotated[float, typer.Argument(help="Numeric value to set.")],
+    username: UsernameOption = None,
+    password: PasswordOption = None,
+    config: ConfigOption = DEFAULT_CONFIG_PATH,
+    system: SystemOption = None,
+    cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
+) -> None:
+    credentials = _resolve_credentials(username, password, config)
+    _console.print(
+        _run_async(
+            _set_number_value(credentials, system, device, value, cookie_jar)
+        )
     )

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -542,17 +542,17 @@ async def _run_switch_command(
         else:
             await device.turn_off()
     elif isinstance(device, AqualinkPump):
-        if target_state == "on" and not device.supports_turn_on:
-            _exit_with_error(
-                f"Pump {device_name!r} does not support turn on.",
-            )
-        if target_state == "off" and not device.supports_turn_off:
-            _exit_with_error(
-                f"Pump {device_name!r} does not support turn off.",
-            )
         if target_state == "on":
+            if not device.supports_turn_on:
+                _exit_with_error(
+                    f"Pump {device_name!r} does not support turn on.",
+                )
             await device.turn_on()
         else:
+            if not device.supports_turn_off:
+                _exit_with_error(
+                    f"Pump {device_name!r} does not support turn off.",
+                )
             await device.turn_off()
     else:
         _exit_with_error(

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -659,7 +659,7 @@ async def _set_number_value(
     t.append(device.label, style="bold")
     t.append(f" [{device_name}]", style="dim")
     unit = device.unit
-    value_str = f" to {value} {unit}" if unit else f" to {value}"
+    value_str = f" to {value:g} {unit}" if unit else f" to {value:g}"
     t.append(f"{value_str} on ")
     t.append_text(_format_system_line(system))
     return t
@@ -920,7 +920,8 @@ def set_effect(
 def set_speed(
     device: DeviceArgument,
     percentage: Annotated[
-        int, typer.Argument(help="Pump speed percentage (0-100).")
+        int,
+        typer.Argument(help="Pump speed percentage (0-100).", min=0, max=100),
     ],
     username: UsernameOption = None,
     password: PasswordOption = None,

--- a/src/iaqualink/systems/i2d/system.py
+++ b/src/iaqualink/systems/i2d/system.py
@@ -263,7 +263,7 @@ class I2dSystem(AqualinkSystem):
                         raise _AqualinkOfflineSignal(
                             msg, response=exc.response
                         ) from exc
-                except ValueError, KeyError:
+                except (ValueError, KeyError):
                     pass
             raise
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -766,12 +766,6 @@ def _make_pump(
     supports_presets: bool = False,
     presets: list[str] | None = None,
 ) -> AqualinkPump:
-    _s_on = supports_turn_on
-    _s_off = supports_turn_off
-    _s_speed = supports_set_speed_percentage
-    _s_presets = supports_presets
-    _presets = presets or []
-
     class _Impl(AqualinkPump):
         @property
         def label(self) -> str:
@@ -795,11 +789,11 @@ def _make_pump(
 
         @property
         def supports_turn_on(self) -> bool:
-            return _s_on
+            return supports_turn_on
 
         @property
         def supports_turn_off(self) -> bool:
-            return _s_off
+            return supports_turn_off
 
         @property
         def is_on(self) -> bool:
@@ -813,25 +807,27 @@ def _make_pump(
 
         @property
         def supports_set_speed_percentage(self) -> bool:
-            return _s_speed
+            return supports_set_speed_percentage
 
         async def set_speed_percentage(self, percentage: int) -> None:
-            pass
+            if not 0 <= percentage <= 100:
+                raise AqualinkInvalidParameterException(percentage)
 
         @property
         def supports_presets(self) -> bool:
-            return _s_presets
+            return supports_presets
 
         @property
         def supported_presets(self) -> list[str]:
-            return _presets
+            return presets or []
 
         @property
         def current_preset(self) -> str | None:
             return None
 
         async def set_preset(self, preset: str) -> None:
-            pass
+            if preset not in (presets or []):
+                raise AqualinkInvalidParameterException(preset)
 
     return object.__new__(_Impl)
 
@@ -1011,6 +1007,18 @@ def test_set_speed_saves_jar(tmp_path: Path) -> None:
     assert data["client_id"] == "post-device-session"
 
 
+def test_set_speed_out_of_range_exits(tmp_path: Path) -> None:
+    pump = _make_pump("VSP", "1", supports_set_speed_percentage=True)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-speed", "vsp", "150")
+    assert result.exit_code == 1
+    assert "150" in result.stderr
+
+
 # ---------------------------------------------------------------------------
 # set-effect
 # ---------------------------------------------------------------------------
@@ -1149,6 +1157,20 @@ def test_set_preset_saves_jar(tmp_path: Path) -> None:
     assert result.exit_code == 0
     data = json.loads(cookie_jar.read_text())
     assert data["client_id"] == "post-device-session"
+
+
+def test_set_preset_invalid_preset_exits(tmp_path: Path) -> None:
+    pump = _make_pump(
+        "VSP", "1", supports_presets=True, presets=["Low", "High"]
+    )
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-preset", "vsp", "Bogus")
+    assert result.exit_code == 1
+    assert "Bogus" in result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -952,6 +952,18 @@ def test_turn_on_sensor_exits(tmp_path: Path) -> None:
     assert "does not support power controls" in result.stderr
 
 
+def test_turn_off_sensor_exits(tmp_path: Path) -> None:
+    sensor = _make_device(AqualinkSensor, "Temp", "72")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"temp": sensor})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "turn-off", "temp")
+    assert result.exit_code == 1
+    assert "does not support power controls" in result.stderr
+
+
 # ---------------------------------------------------------------------------
 # set-speed
 # ---------------------------------------------------------------------------
@@ -1187,8 +1199,7 @@ def test_set_value_number_device(tmp_path: Path) -> None:
     )
     result, _ = _invoke_with_jar(tmp_path, "set-value", "rpm", "2000")
     assert result.exit_code == 0
-    assert "RPM" in result.output
-    assert "2000" in result.output
+    assert "2000.0 RPM" in result.output
 
 
 def test_set_value_number_device_without_unit(tmp_path: Path) -> None:
@@ -1238,3 +1249,12 @@ def test_set_value_saves_jar(tmp_path: Path) -> None:
     assert result.exit_code == 0
     data = json.loads(cookie_jar.read_text())
     assert data["client_id"] == "post-device-session"
+
+
+# ---------------------------------------------------------------------------
+# Smoke imports
+# ---------------------------------------------------------------------------
+
+
+def test_i2d_system_module_importable() -> None:
+    importlib.import_module("iaqualink.systems.i2d.system")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -752,6 +752,266 @@ def test_set_brightness_saves_jar_after_command(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Pump helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pump(
+    label: str = "VSP",
+    state: str | None = "1",
+    *,
+    supports_turn_on: bool = False,
+    supports_turn_off: bool = False,
+    supports_set_speed_percentage: bool = False,
+    supports_presets: bool = False,
+    presets: list[str] | None = None,
+) -> AqualinkPump:
+    _s_on = supports_turn_on
+    _s_off = supports_turn_off
+    _s_speed = supports_set_speed_percentage
+    _s_presets = supports_presets
+    _presets = presets or []
+
+    class _Impl(AqualinkPump):
+        @property
+        def label(self) -> str:
+            return label
+
+        @property
+        def state(self) -> str | None:
+            return state
+
+        @property
+        def name(self) -> str:
+            return label
+
+        @property
+        def manufacturer(self) -> str:
+            return ""
+
+        @property
+        def model(self) -> str:
+            return ""
+
+        @property
+        def supports_turn_on(self) -> bool:
+            return _s_on
+
+        @property
+        def supports_turn_off(self) -> bool:
+            return _s_off
+
+        @property
+        def is_on(self) -> bool:
+            return bool(state)
+
+        async def turn_on(self) -> None:
+            pass
+
+        async def turn_off(self) -> None:
+            pass
+
+        @property
+        def supports_set_speed_percentage(self) -> bool:
+            return _s_speed
+
+        async def set_speed_percentage(self, percentage: int) -> None:
+            pass
+
+        @property
+        def supports_presets(self) -> bool:
+            return _s_presets
+
+        @property
+        def supported_presets(self) -> list[str]:
+            return _presets
+
+        @property
+        def current_preset(self) -> str | None:
+            return None
+
+        async def set_preset(self, preset: str) -> None:
+            pass
+
+    return object.__new__(_Impl)
+
+
+def _make_number(
+    label: str = "RPM",
+    state: str | None = "1500",
+    *,
+    min_value: float = 0.0,
+    max_value: float = 3450.0,
+    unit: str | None = "RPM",
+) -> AqualinkNumber:
+    _min = min_value
+    _max = max_value
+    _unit = unit
+
+    class _Impl(AqualinkNumber):
+        @property
+        def label(self) -> str:
+            return label
+
+        @property
+        def state(self) -> str | None:
+            return state
+
+        @property
+        def name(self) -> str:
+            return label
+
+        @property
+        def manufacturer(self) -> str:
+            return ""
+
+        @property
+        def model(self) -> str:
+            return ""
+
+        @property
+        def current_value(self) -> float | None:
+            return float(state) if state else None
+
+        @property
+        def min_value(self) -> float:
+            return _min
+
+        @property
+        def max_value(self) -> float:
+            return _max
+
+        @property
+        def unit(self) -> str | None:
+            return _unit
+
+        async def _set_value(self, value: float) -> None:
+            pass
+
+    return object.__new__(_Impl)
+
+
+# ---------------------------------------------------------------------------
+# turn-on / turn-off with AqualinkPump
+# ---------------------------------------------------------------------------
+
+
+def test_turn_on_pump_with_support(tmp_path: Path) -> None:
+    pump = _make_pump("VSP", "0", supports_turn_on=True)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "turn-on", "vsp")
+    assert result.exit_code == 0
+    assert "VSP" in result.output
+
+
+def test_turn_on_pump_without_support_exits(tmp_path: Path) -> None:
+    pump = _make_pump("VSP", "0", supports_turn_on=False)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "turn-on", "vsp")
+    assert result.exit_code == 1
+    assert "does not support turn on" in result.stderr
+
+
+def test_turn_off_pump_with_support(tmp_path: Path) -> None:
+    pump = _make_pump("VSP", "1", supports_turn_off=True)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "turn-off", "vsp")
+    assert result.exit_code == 0
+    assert "VSP" in result.output
+
+
+def test_turn_off_pump_without_support_exits(tmp_path: Path) -> None:
+    pump = _make_pump("VSP", "1", supports_turn_off=False)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "turn-off", "vsp")
+    assert result.exit_code == 1
+    assert "does not support turn off" in result.stderr
+
+
+def test_turn_on_sensor_exits(tmp_path: Path) -> None:
+    sensor = _make_device(AqualinkSensor, "Temp", "72")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"temp": sensor})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "turn-on", "temp")
+    assert result.exit_code == 1
+    assert "does not support power controls" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# set-speed
+# ---------------------------------------------------------------------------
+
+
+def test_set_speed_pump_with_support(tmp_path: Path) -> None:
+    pump = _make_pump("VSP", "1", supports_set_speed_percentage=True)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-speed", "vsp", "75")
+    assert result.exit_code == 0
+    assert "75%" in result.output
+    assert "VSP" in result.output
+
+
+def test_set_speed_pump_without_support_exits(tmp_path: Path) -> None:
+    pump = _make_pump("VSP", "1", supports_set_speed_percentage=False)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-speed", "vsp", "75")
+    assert result.exit_code == 1
+    assert "does not support speed control" in result.stderr
+
+
+def test_set_speed_non_pump_exits(tmp_path: Path) -> None:
+    switch = _make_device(AqualinkSwitch, "Filter", "1")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"filter": switch})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-speed", "filter", "50")
+    assert result.exit_code == 1
+    assert "is not a pump" in result.stderr
+
+
+def test_set_speed_saves_jar(tmp_path: Path) -> None:
+    pump = _make_pump("VSP", "1", supports_set_speed_percentage=True)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, cookie_jar = _invoke_with_jar(tmp_path, "set-speed", "vsp", "50")
+    assert result.exit_code == 0
+    data = json.loads(cookie_jar.read_text())
+    assert data["client_id"] == "post-device-session"
+
+
+# ---------------------------------------------------------------------------
 # set-effect
 # ---------------------------------------------------------------------------
 
@@ -830,3 +1090,129 @@ def test_set_effect_rejects_unknown_effect_name(tmp_path: Path) -> None:
     result, _ = _invoke_with_jar(tmp_path, "set-effect", "light", "Bogus")
     assert result.exit_code == 1
     assert "Bogus" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# set-preset
+# ---------------------------------------------------------------------------
+
+
+def test_set_preset_pump_with_support(tmp_path: Path) -> None:
+    pump = _make_pump(
+        "VSP", "1", supports_presets=True, presets=["Low", "High"]
+    )
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-preset", "vsp", "Low")
+    assert result.exit_code == 0
+    assert "Low" in result.output
+    assert "VSP" in result.output
+
+
+def test_set_preset_pump_without_support_exits(tmp_path: Path) -> None:
+    pump = _make_pump("VSP", "1", supports_presets=False)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-preset", "vsp", "Low")
+    assert result.exit_code == 1
+    assert "does not support presets" in result.stderr
+
+
+def test_set_preset_non_pump_exits(tmp_path: Path) -> None:
+    switch = _make_device(AqualinkSwitch, "Filter", "1")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"filter": switch})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-preset", "filter", "Low")
+    assert result.exit_code == 1
+    assert "is not a pump" in result.stderr
+
+
+def test_set_preset_saves_jar(tmp_path: Path) -> None:
+    pump = _make_pump(
+        "VSP", "1", supports_presets=True, presets=["Low", "High"]
+    )
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"vsp": pump})
+        }
+    )
+    result, cookie_jar = _invoke_with_jar(tmp_path, "set-preset", "vsp", "High")
+    assert result.exit_code == 0
+    data = json.loads(cookie_jar.read_text())
+    assert data["client_id"] == "post-device-session"
+
+
+# ---------------------------------------------------------------------------
+# set-value
+# ---------------------------------------------------------------------------
+
+
+def test_set_value_number_device(tmp_path: Path) -> None:
+    number = _make_number("RPM", "1500", max_value=3450.0, unit="RPM")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"rpm": number})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-value", "rpm", "2000")
+    assert result.exit_code == 0
+    assert "RPM" in result.output
+    assert "2000" in result.output
+
+
+def test_set_value_number_device_without_unit(tmp_path: Path) -> None:
+    number = _make_number("Level", "5", max_value=10.0, unit=None)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"level": number})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-value", "level", "7")
+    assert result.exit_code == 0
+    assert "7" in result.output
+
+
+def test_set_value_non_number_exits(tmp_path: Path) -> None:
+    switch = _make_device(AqualinkSwitch, "Filter", "1")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"filter": switch})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-value", "filter", "50")
+    assert result.exit_code == 1
+    assert "does not support numeric values" in result.stderr
+
+
+def test_set_value_out_of_range_exits(tmp_path: Path) -> None:
+    number = _make_number("RPM", "1500", max_value=3450.0, unit="RPM")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"rpm": number})
+        }
+    )
+    result, _ = _invoke_with_jar(tmp_path, "set-value", "rpm", "9999")
+    assert result.exit_code == 1
+    assert "out of range" in result.stderr
+
+
+def test_set_value_saves_jar(tmp_path: Path) -> None:
+    number = _make_number("RPM", "1500", max_value=3450.0, unit="RPM")
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"rpm": number})
+        }
+    )
+    result, cookie_jar = _invoke_with_jar(tmp_path, "set-value", "rpm", "2000")
+    assert result.exit_code == 0
+    data = json.loads(cookie_jar.read_text())
+    assert data["client_id"] == "post-device-session"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -810,8 +810,7 @@ def _make_pump(
             return supports_set_speed_percentage
 
         async def set_speed_percentage(self, percentage: int) -> None:
-            if not 0 <= percentage <= 100:
-                raise AqualinkInvalidParameterException(percentage)
+            pass
 
         @property
         def supports_presets(self) -> bool:
@@ -840,10 +839,6 @@ def _make_number(
     max_value: float = 3450.0,
     unit: str | None = "RPM",
 ) -> AqualinkNumber:
-    _min = min_value
-    _max = max_value
-    _unit = unit
-
     class _Impl(AqualinkNumber):
         @property
         def label(self) -> str:
@@ -871,15 +866,15 @@ def _make_number(
 
         @property
         def min_value(self) -> float:
-            return _min
+            return min_value
 
         @property
         def max_value(self) -> float:
-            return _max
+            return max_value
 
         @property
         def unit(self) -> str | None:
-            return _unit
+            return unit
 
         async def _set_value(self, value: float) -> None:
             pass
@@ -1027,8 +1022,8 @@ def test_set_speed_out_of_range_exits(tmp_path: Path) -> None:
         }
     )
     result, _ = _invoke_with_jar(tmp_path, "set-speed", "vsp", "150")
-    assert result.exit_code == 1
-    assert "150" in result.stderr
+    assert result.exit_code == 2
+    assert "150" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -1199,7 +1194,7 @@ def test_set_value_number_device(tmp_path: Path) -> None:
     )
     result, _ = _invoke_with_jar(tmp_path, "set-value", "rpm", "2000")
     assert result.exit_code == 0
-    assert "2000.0 RPM" in result.output
+    assert "2000 RPM" in result.output
 
 
 def test_set_value_number_device_without_unit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Extend `turn-on` / `turn-off` to support `AqualinkPump` devices, with per-pump capability checks (`supports_turn_on`, `supports_turn_off`)
- Add `set-speed <device> <percentage>` command for variable-speed pumps
- Add `set-preset <device> <preset>` command for pumps with named presets
- Add `set-value <device> <value>` command for `AqualinkNumber` devices (e.g. RPM setpoints, timers)

## Test plan

- [ ] `turn-on` / `turn-off` on a pump that supports it → success
- [ ] `turn-on` / `turn-off` on a pump that does not support it → error message
- [ ] `turn-on` / `turn-off` on a non-switch/pump device (sensor) → error message
- [ ] `set-speed` on a variable-speed pump → success
- [ ] `set-speed` on a pump without speed control → error message
- [ ] `set-speed` on a non-pump device → error message
- [ ] `set-preset` on a pump with presets → success
- [ ] `set-preset` on a pump without preset support → error message
- [ ] `set-value` on a number device (in-range value) → success
- [ ] `set-value` on a number device (out-of-range value) → raises `AqualinkInvalidParameterException` → CLI error
- [ ] `set-value` on a non-number device → error message
- [ ] Cookie jar saved after each successful command

🤖 Generated with [Claude Code](https://claude.com/claude-code)