### PR TITLE
feat(iaqua): VSP (variable speed pump) support

### DIFF
--- a/docs/api/systems/iaqua.md
+++ b/docs/api/systems/iaqua.md
@@ -124,7 +124,7 @@ Optional sub-system, only present when a heat pump is paired with the iQ20 contr
 
 Optional sub-system, only present when a variable-speed pump is paired with the iQ20 controller (`isVSP` flag in the master device list / appmodelserials fallback). Distinct from the standalone Jandy iQPump (`i2d` system type).
 
-- `vsp_pump_1` through `vsp_pump_N` - One entry per discovered slot. Class: `IaquaVSPump`. Maps to HA `AqualinkFan` contract: presets, on/off; no percentage (RPM) control.
+- `vsp_pump_<slot_id>` - One entry per discovered slot. Class: `IaquaVSPump`. Maps to HA `AqualinkFan` contract: presets, on/off; no percentage (RPM) control.
 
 ### Lights
 

--- a/docs/api/systems/iaqua.md
+++ b/docs/api/systems/iaqua.md
@@ -34,6 +34,10 @@ iAqua systems use the iaqualink.net API.
 
 ::: iaqualink.systems.iaqua.device.IaquaHeatPumpAlertSensor
 
+## IaquaVSPump
+
+::: iaqualink.systems.iaqua.device.IaquaVSPump
+
 ## Characteristics
 
 ### API Endpoint
@@ -115,6 +119,12 @@ Optional sub-system, only present when a heat pump is paired with the iQ20 contr
 - `heatpump_status` - Raw operational status (`off`/`enabled`/`on`). Class: `IaquaHeatPumpStatusSensor`.
 - `heatpump_alert` - Fault code, if any. Only present once an HPM command response has supplied one. Class: `IaquaHeatPumpAlertSensor`.
 - `pool_chill_set_point` - Pool chill (cooling) set point. Only present when chill mode is available. Uses the existing `IaquaSetPoint` class.
+
+### VSP Pumps
+
+Optional sub-system, only present when a variable-speed pump is paired with the iQ20 controller (`isVSP` flag in the master device list / appmodelserials fallback). Distinct from the standalone Jandy iQPump (`i2d` system type).
+
+- `vsp_pump_1` through `vsp_pump_N` - One entry per discovered slot. Class: `IaquaVSPump`. Maps to HA `AqualinkFan` contract: presets, on/off; no percentage (RPM) control.
 
 ### Lights
 

--- a/docs/implementation/systems/iaqua.md
+++ b/docs/implementation/systems/iaqua.md
@@ -265,9 +265,9 @@ Variable-speed pump support is an optional subsystem within `IaquaSystem`. It is
 
 ### Device class
 
-`IaquaPump(AqualinkFan, IaquaDevice)` — inherits device identity from `IaquaDevice` and exposes the `AqualinkFan` preset contract (suitable for a Home Assistant `fan` entity).
+`IaquaVSPump(AqualinkFan, IaquaDevice)` — inherits device identity from `IaquaDevice` and exposes the `AqualinkFan` preset contract (suitable for a Home Assistant `fan` entity).
 
-| `AqualinkFan` property | `IaquaPump` behaviour |
+| `AqualinkFan` property | `IaquaVSPump` behaviour |
 |---|---|
 | `supports_turn_on` | `True` — activates first speed preset (or `speed_id=1` if presets not yet loaded) via `enable_disable_pump_speedId` |
 | `supports_turn_off` | `True` — sends `enable_disable_pump_speedId` with `on_off_action=off` |
@@ -278,7 +278,7 @@ Variable-speed pump support is an optional subsystem within `IaquaSystem`. It is
 
 ### Slot ID
 
-Each VSP pump is identified by a `slot_id` (integer). This is stored in `device.data["slot_id"]` and read via `IaquaPump.slot_id`. It is set during discovery and passed to all speed commands.
+Each VSP pump is identified by a `slot_id` (integer). This is stored in `device.data["slot_id"]` and read via `IaquaVSPump.slot_id`. It is set during discovery and passed to all speed commands.
 
 ### Discovery flow
 
@@ -287,7 +287,7 @@ Each VSP pump is identified by a `slot_id` (integer). This is stored in `device.
 1. Check `system.data.get("isVSP") == "true"` (`is_vsp` property) — skip if false.
 2. Call `get_vsp_names()` → build `pumpId → pumpName` map.
 3. Call `get_master_device_list()` → filter to `isVSP == "true"` entries; if none found, fall back to `get_vsp_appmodelserials()`.
-4. For each slot ID not already in `self.devices`: create `IaquaPump`, call `fetch_speed()` to populate `_speed_presets`, then add to `self.devices`.
+4. For each slot ID not already in `self.devices`: create `IaquaVSPump`, call `fetch_speed()` to populate `_speed_presets`, then add to `self.devices`.
 
 Called from `_refresh()` after `_parse_devices_response`, only when `is_vsp and not _vsp_discovered`. The pump is never added to `self.devices` before `_speed_presets` is populated.
 
@@ -310,7 +310,7 @@ await pump.fetch_speed()          # explicit refresh from get_vsp_speedauxinfo i
 
 **No automatic preset refresh on `_refresh()`:** `get_vsp_speedauxinfo` is an extra HTTP call per pump. The current active preset can change externally (e.g. schedule), so callers needing up-to-date preset state should call `fetch_speed()` explicitly.
 
-**`slot_id` in `data`, not constructor:** Keeps the `IaquaDevice` constructor signature uniform (`system, data`). Discovery stores `slot_id` in the data dict; `IaquaPump.slot_id` reads it with a default of `1`.
+**`slot_id` in `data`, not constructor:** Keeps the `IaquaDevice` constructor signature uniform (`system, data`). Discovery stores `slot_id` in the data dict; `IaquaVSPump.slot_id` reads it with a default of `1`.
 
 **No `is_vsp` transition handling:** `is_vsp` reads `self.data["isVSP"]`, and `self.data` is set once at construction and never reassigned — a fresh `IaquaSystem` instance is created by `AqualinkSystem.from_data()` on every `get_systems()` call. So `is_vsp` is fixed for an instance's whole lifetime; there's no real "VSP support disappeared mid-session" transition to clean up after, only "this system was never VSP-capable."
 

--- a/docs/implementation/systems/iaqua.md
+++ b/docs/implementation/systems/iaqua.md
@@ -265,15 +265,15 @@ Variable-speed pump support is an optional subsystem within `IaquaSystem`. It is
 
 ### Device class
 
-`IaquaVSPump(AqualinkFan, IaquaDevice)` — inherits device identity from `IaquaDevice` and exposes the `AqualinkFan` preset contract (suitable for a Home Assistant `fan` entity).
+`IaquaVSPump(IaquaDevice, AqualinkFan)` — inherits device identity from `IaquaDevice` and exposes the `AqualinkFan` preset contract (suitable for a Home Assistant `fan` entity).
 
 | `AqualinkFan` property | `IaquaVSPump` behaviour |
 |---|---|
 | `supports_turn_on` | `True` — activates first speed preset (or `speed_id=1` if presets not yet loaded) via `enable_disable_pump_speedId` |
 | `supports_turn_off` | `True` — sends `enable_disable_pump_speedId` with `on_off_action=off` |
 | `supports_presets` | `True` after `fetch_speed()` populates a non-empty `_speed_presets`; `False` if the hardware reports an empty preset list |
-| `preset_modes` | Raises `AqualinkOperationNotSupportedException` if `_speed_presets` not yet populated |
-| `preset_mode` | Raises same exception if not loaded; returns `None` if no preset has `enabled == "true"` |
+| `preset_modes` | Raises `AqualinkOperationNotSupportedException` whenever `supports_presets` is `False` (not yet loaded, or hardware reports an empty preset list) |
+| `preset_mode` | Raises same exception under the same condition; otherwise returns `None` if no preset has `enabled == "true"` |
 | `supports_percentage` | `False` — arbitrary-RPM write not yet confirmed for iaqua VSP |
 
 ### Slot ID

--- a/docs/implementation/systems/iaqua.md
+++ b/docs/implementation/systems/iaqua.md
@@ -271,7 +271,7 @@ Variable-speed pump support is an optional subsystem within `IaquaSystem`. It is
 |---|---|
 | `supports_turn_on` | `True` — activates first speed preset (or `speed_id=1` if presets not yet loaded) via `enable_disable_pump_speedId` |
 | `supports_turn_off` | `True` — sends `enable_disable_pump_speedId` with `on_off_action=off` |
-| `supports_presets` | `True` after `fetch_speed()` is called; always `True` post-discovery since `fetch_speed()` runs before device enters `self.devices` |
+| `supports_presets` | `True` after `fetch_speed()` populates a non-empty `_speed_presets`; `False` if the hardware reports an empty preset list |
 | `preset_modes` | Raises `AqualinkOperationNotSupportedException` if `_speed_presets` not yet populated |
 | `preset_mode` | Raises same exception if not loaded; returns `None` if no preset has `enabled == "true"` |
 | `supports_percentage` | `False` — arbitrary-RPM write not yet confirmed for iaqua VSP |
@@ -306,11 +306,13 @@ await pump.fetch_speed()          # explicit refresh from get_vsp_speedauxinfo i
 
 ### Design decisions
 
-**`supports_presets` is `True` after `fetch_speed()`:** `IaquaPump` is always a VSP-capable device (that's why it was created). In practice `fetch_speed()` runs during discovery before the device enters `self.devices`, so by the time any external caller sees the pump `supports_presets` is already `True`. `False` is only observable if `IaquaPump` is constructed directly without calling `fetch_speed()`.
+**`supports_presets` reflects whether `_speed_presets` is a non-empty list:** `bool(self._speed_presets)` — `False` before `fetch_speed()` has run (`_speed_presets is None`) and also `False` if the hardware reports an empty `vsp_speedInfo` array (a discovered-but-unconfigured slot). This keeps the `AqualinkFan` contract intact: `supports_presets=True` only when `preset_modes` is non-empty.
 
 **No automatic preset refresh on `_refresh()`:** `get_vsp_speedauxinfo` is an extra HTTP call per pump. The current active preset can change externally (e.g. schedule), so callers needing up-to-date preset state should call `fetch_speed()` explicitly.
 
 **`slot_id` in `data`, not constructor:** Keeps the `IaquaDevice` constructor signature uniform (`system, data`). Discovery stores `slot_id` in the data dict; `IaquaPump.slot_id` reads it with a default of `1`.
+
+**No `is_vsp` transition handling:** `is_vsp` reads `self.data["isVSP"]`, and `self.data` is set once at construction and never reassigned — a fresh `IaquaSystem` instance is created by `AqualinkSystem.from_data()` on every `get_systems()` call. So `is_vsp` is fixed for an instance's whole lifetime; there's no real "VSP support disappeared mid-session" transition to clean up after, only "this system was never VSP-capable."
 
 **Turn on/off via `enable_disable_pump_speedId`:** `turn_on` activates the first configured speed preset (or `speed_id=1` if presets unavailable). `turn_off` sends `on_off_action=off` via `stop_vsp_pump()`. Both update `_speed_presets` via `_apply_speed_update()` from the response.
 

--- a/docs/implementation/systems/iaqua.md
+++ b/docs/implementation/systems/iaqua.md
@@ -53,7 +53,7 @@ Devices that will be exposed when implemented: `swc_set_point` (sensor), `swc_po
 
 #### VSP via iQ20 Session
 
-The iQ20 session endpoint hosts 14 VSP management commands (`get_vsp_names`, `get_vsp_speedauxinfo`, `get_vsp_definition`, `get_vsp_appmodelserials`, `get_unassigned_serials`, `set_vsp_name`, `set_vsp_definition`, `assign_vsp_serial`, `unassign_vsp_serial`, `enable_disable_pump_speedId`, `set_aux_speed`, `set_speed_name`, `set_speedname_value`, `enable_pump_speed_value`). None are implemented.
+The iQ20 session endpoint hosts 14 VSP management commands. Of these, `get_vsp_names`, `get_vsp_speedauxinfo`, `enable_disable_pump_speedId`, `get_vsp_appmodelserials`, and `get_master_device_list` are implemented (see [VSP Pump Control](#vsp-pump-control) below). The remaining 9 management commands (`get_vsp_definition`, `get_unassigned_serials`, `set_vsp_name`, `set_vsp_definition`, `assign_vsp_serial`, `unassign_vsp_serial`, `set_aux_speed`, `set_speed_name`, `set_speedname_value`, `enable_pump_speed_value`) are not implemented.
 
 Note: these iQ20-session VSP commands are distinct from the iQPump protocol handled by the `i2d` system. They control pumps physically wired to the iQ20 controller via the same `p-api` session endpoint.
 
@@ -67,7 +67,7 @@ Note: these iQ20-session VSP commands are distinct from the iQPump protocol hand
 
 #### Peripheral Device List
 
-`get_master_device_list` is not implemented.
+`get_master_device_list` is implemented and used during VSP pump discovery (see [VSP Pump Control](#vsp-pump-control)).
 
 ## System Status Lifecycle
 
@@ -256,6 +256,73 @@ The HPM command echo (`poolheatSetPointTemp`/`spaheatSetPointTemp`) is used to r
 | 1 | `on_off_action` literal `"on"`/`"off"` for `enable_disable_hpm` | ✓ Matches |
 | 2 | `setpoint_hpm_temp` only sends the parameter(s) being changed | ✓ Matches — no seeding of unrelated set points, unlike `set_temps` |
 | 3 | No HPM-specific temperature bounds documented | Reuses relay-heater bounds (assumption, not observed in reference) |
+
+## VSP Pump Control
+
+### Overview
+
+Variable-speed pump support is an optional subsystem within `IaquaSystem`. It is entirely separate from the standalone Jandy iQPump (device type `i2d`). All VSP commands use the same session endpoint as the rest of the iQ20 protocol (`p-api.iaqualink.net/v2/mobile/session.json`).
+
+### Device class
+
+`IaquaPump(AqualinkFan, IaquaDevice)` — inherits device identity from `IaquaDevice` and exposes the `AqualinkFan` preset contract (suitable for a Home Assistant `fan` entity).
+
+| `AqualinkFan` property | `IaquaPump` behaviour |
+|---|---|
+| `supports_turn_on` | `True` — activates first speed preset (or `speed_id=1` if presets not yet loaded) via `enable_disable_pump_speedId` |
+| `supports_turn_off` | `True` — sends `enable_disable_pump_speedId` with `on_off_action=off` |
+| `supports_presets` | `True` after `fetch_speed()` is called; always `True` post-discovery since `fetch_speed()` runs before device enters `self.devices` |
+| `preset_modes` | Raises `AqualinkOperationNotSupportedException` if `_speed_presets` not yet populated |
+| `preset_mode` | Raises same exception if not loaded; returns `None` if no preset has `enabled == "true"` |
+| `supports_percentage` | `False` — arbitrary-RPM write not yet confirmed for iaqua VSP |
+
+### Slot ID
+
+Each VSP pump is identified by a `slot_id` (integer). This is stored in `device.data["slot_id"]` and read via `IaquaPump.slot_id`. It is set during discovery and passed to all speed commands.
+
+### Discovery flow
+
+`_refresh_vsp_pumps()` runs **once per system lifetime** (guarded by `_vsp_discovered`):
+
+1. Check `system.data.get("isVSP") == "true"` (`is_vsp` property) — skip if false.
+2. Call `get_vsp_names()` → build `pumpId → pumpName` map.
+3. Call `get_master_device_list()` → filter to `isVSP == "true"` entries; if none found, fall back to `get_vsp_appmodelserials()`.
+4. For each slot ID not already in `self.devices`: create `IaquaPump`, call `fetch_speed()` to populate `_speed_presets`, then add to `self.devices`.
+
+Called from `_refresh()` after `_parse_devices_response`, only when `is_vsp and not _vsp_discovered`. The pump is never added to `self.devices` before `_speed_presets` is populated.
+
+### Preset lifecycle
+
+```python
+# _speed_presets populated automatically during _refresh_vsp_pumps() discovery
+pump.preset_modes               # ["LO", "MED", "HI", ...]
+pump.preset_mode                # name of preset with enabled=="true", or None
+await pump.set_preset_mode("LO")  # calls enable_disable_pump_speedId; updates _speed_presets from response
+await pump.turn_off()             # calls enable_disable_pump_speedId with on_off_action=off
+await pump.fetch_speed()          # explicit refresh from get_vsp_speedauxinfo if needed
+```
+
+`_speed_presets` is populated by `fetch_speed()` during discovery. After each write (`set_preset_mode`, `turn_on`, `turn_off`), `_apply_speed_update()` merges the response `vsp_speedInfo` back into `_speed_presets` so `is_on` and `preset_mode` stay current without an extra round-trip. Callers needing a full refresh can call `fetch_speed()` explicitly.
+
+### Design decisions
+
+**`supports_presets` is `True` after `fetch_speed()`:** `IaquaPump` is always a VSP-capable device (that's why it was created). In practice `fetch_speed()` runs during discovery before the device enters `self.devices`, so by the time any external caller sees the pump `supports_presets` is already `True`. `False` is only observable if `IaquaPump` is constructed directly without calling `fetch_speed()`.
+
+**No automatic preset refresh on `_refresh()`:** `get_vsp_speedauxinfo` is an extra HTTP call per pump. The current active preset can change externally (e.g. schedule), so callers needing up-to-date preset state should call `fetch_speed()` explicitly.
+
+**`slot_id` in `data`, not constructor:** Keeps the `IaquaDevice` constructor signature uniform (`system, data`). Discovery stores `slot_id` in the data dict; `IaquaPump.slot_id` reads it with a default of `1`.
+
+**Turn on/off via `enable_disable_pump_speedId`:** `turn_on` activates the first configured speed preset (or `speed_id=1` if presets unavailable). `turn_off` sends `on_off_action=off` via `stop_vsp_pump()`. Both update `_speed_presets` via `_apply_speed_update()` from the response.
+
+### Deltas vs Protocol Reference
+
+| # | Reference spec | Current implementation |
+|---|---|---|
+| 1 | `get_master_device_list` used to enumerate VSP devices with `isVSP` flag | ✓ Called during discovery; per-device `isVSP` flag is the primary slot-ID source. Falls back to `get_vsp_appmodelserials` if master list returns no VSP devices. |
+| 2 | `get_vsp_speedauxinfo` response uses `slot` (not `slot_id`) | Parsed via `data.get("vsp_speedInfo", [])` — `slot` field not consumed |
+| 3 | `enable_disable_pump_speedId` response carries updated `vsp_speedInfo` with `status` values | ✓ Parsed by `_apply_speed_update()` after `turn_on`, `turn_off`, and `set_preset_mode` |
+| 4 | `get_vsp_names` / `get_vsp_appmodelserials` called once at discovery | ✓ Matches — guarded by `_vsp_discovered` flag |
+| 5 | Arbitrary-RPM write command exists (path observed, shape unconfirmed) | Not implemented — `supports_percentage` returns `False` |
 
 ## See Also
 

--- a/docs/implementation/systems/iaqua.md
+++ b/docs/implementation/systems/iaqua.md
@@ -286,10 +286,10 @@ Each VSP pump is identified by a `slot_id` (integer). This is stored in `device.
 
 1. Check `system.data.get("isVSP") == "true"` (`is_vsp` property) — skip if false.
 2. Call `get_vsp_names()` → build `pumpId → pumpName` map.
-3. Call `get_master_device_list()` → filter to `isVSP == "true"` entries; if none found, fall back to `get_vsp_appmodelserials()`.
+3. Call `get_master_device_list()` → filter to `isVSP == "true"` entries; if none found, fall back to `get_vsp_appmodelserials()`. If the response's `count` is less than `totalCount`, log a warning — the list is paginated and there's no documented param to request subsequent pages, so VSP pumps beyond page 1 may go undiscovered.
 4. For each slot ID not already in `self.devices`: create `IaquaVSPump`, call `fetch_speed()` to populate `_speed_presets`, then add to `self.devices`.
 
-Called from `_refresh()` after `_parse_devices_response`, only when `is_vsp and not _vsp_discovered`. The pump is never added to `self.devices` before `_speed_presets` is populated.
+Called from `_refresh()` after `_parse_devices_response`, whenever `is_vsp` is true: `_refresh_vsp_pumps()` runs discovery once; on every subsequent cycle, `_refresh_vsp_speeds()` calls `fetch_speed()` on each already-discovered `IaquaVSPump` instead (see Preset lifecycle below). The pump is never added to `self.devices` before `_speed_presets` is populated. Any `AqualinkServiceException` from either path is logged and swallowed rather than propagated — see "Best-effort VSP refresh" below.
 
 ### Preset lifecycle
 
@@ -302,13 +302,17 @@ await pump.turn_off()             # calls enable_disable_pump_speedId with on_of
 await pump.fetch_speed()          # explicit refresh from get_vsp_speedauxinfo if needed
 ```
 
-`_speed_presets` is populated by `fetch_speed()` during discovery. After each write (`set_preset_mode`, `turn_on`, `turn_off`), `_apply_speed_update()` merges the response `vsp_speedInfo` back into `_speed_presets` so `is_on` and `preset_mode` stay current without an extra round-trip. Callers needing a full refresh can call `fetch_speed()` explicitly.
+`_speed_presets` is populated by `fetch_speed()` during discovery, and refreshed wholesale by `fetch_speed()` again on every subsequent `refresh()` cycle via `_refresh_vsp_speeds()`. After each write (`set_preset_mode`, `turn_on`, `turn_off`), `_apply_speed_update()` additionally merges the response `vsp_speedInfo` back into `_speed_presets` so `is_on` and `preset_mode` stay current without waiting for the next refresh cycle.
 
 ### Design decisions
 
 **`supports_presets` reflects whether `_speed_presets` is a non-empty list:** `bool(self._speed_presets)` — `False` before `fetch_speed()` has run (`_speed_presets is None`) and also `False` if the hardware reports an empty `vsp_speedInfo` array (a discovered-but-unconfigured slot). This keeps the `AqualinkFan` contract intact: `supports_presets=True` only when `preset_modes` is non-empty.
 
-**No automatic preset refresh on `_refresh()`:** `get_vsp_speedauxinfo` is an extra HTTP call per pump. The current active preset can change externally (e.g. schedule), so callers needing up-to-date preset state should call `fetch_speed()` explicitly.
+**Automatic preset refresh on every `_refresh()` cycle:** `_apply_speed_update()` (used after writes) only patches presets named in the response; if the server ever echoed a partial `vsp_speedInfo` list, presets it omitted would keep a stale `enabled` flag indefinitely. `_refresh_vsp_speeds()` calls `fetch_speed()` — which always replaces `_speed_presets` wholesale — for every discovered pump on each `refresh()` cycle, so any staleness self-heals within one cycle at the cost of one extra HTTP call per pump per refresh.
+
+**Best-effort VSP refresh — failures don't disconnect the system:** `_refresh_vsp_pumps()`/`_refresh_vsp_speeds()` run after home/devices/onetouch have already succeeded and `status` is `ONLINE`. The base `refresh()` template normally turns any `AqualinkServiceException` from `_refresh()` into `status = DISCONNECTED`. Since VSP is an optional sub-system, `_refresh()` catches `AqualinkServiceException` around just the VSP block, logs a warning, and leaves `status`/`_vsp_discovered` untouched — a flaky VSP call is retried on the next `refresh()` cycle instead of marking an otherwise-healthy system as disconnected. This is a deliberate, narrow exception to the rule (elsewhere in this codebase) that `_refresh()` implementations should not catch `AqualinkServiceException` subclasses themselves.
+
+**Partial `get_master_device_list` pages are logged, not paginated through:** the response includes `count`/`totalCount`, implying pagination, but there's no documented parameter to request page 2+. Rather than guess at one, `_refresh_vsp_pumps()` logs a warning when `count < totalCount` so under-discovery is diagnosable from a bug report.
 
 **`slot_id` in `data`, not constructor:** Keeps the `IaquaDevice` constructor signature uniform (`system, data`). Discovery stores `slot_id` in the data dict; `IaquaVSPump.slot_id` reads it with a default of `1`.
 

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -127,6 +127,7 @@ GET https://r-api.iaqualink.net/devices.json
 | `created_at` | string | ISO 8601 timestamp |
 | `updated_at` | string | ISO 8601 timestamp |
 | `last_activity_at` | string or null | ISO 8601 timestamp of last device contact |
+| `isVSP` | string | `iaqua` (iQ20) devices only — `"true"` if at least one VSP-capable pump is paired; absent or `"false"` otherwise |
 
 ---
 

--- a/docs/reference/systems/iaqua.md
+++ b/docs/reference/systems/iaqua.md
@@ -555,7 +555,44 @@ The `zoneColorVal` strings in the response are human-readable display names; the
 
 The iQ20 session endpoint also provides VSP management commands for pumps assigned to aux slots. These are separate from the iQPump `/r-api.iaqualink.net` protocol and operate on pumps physically connected to the iQ20 controller.
 
-All VSP commands use the same session endpoint.
+All VSP commands use the same session endpoint (`https://p-api.iaqualink.net/v2/mobile/session.json`). Optional subsystem — only present when at least one VSP-capable pump is paired with the iQ20 controller.
+
+### Discovery
+
+**Step 1 — Check `isVSP` flag.** The iAquaLink system-level data (returned by `AqualinkClient.get_systems()`) may include an `isVSP` field. If `isVSP == "true"`, at least one VSP pump is paired and the discovery commands below should be called.
+
+**Step 2 — Enumerate pumps** using `get_master_device_list`:
+
+| Param | Value |
+|---|---|
+| `command` | `get_master_device_list` |
+| `actionID` | `"command"` |
+| `serial` | iAquaLink serial |
+| `sessionID` | `session_id` from login |
+
+**Response** — JSON object:
+
+| Field | Type | Description |
+|---|---|---|
+| `response` | string | `"success"` or error string |
+| `is_error` | boolean | Error flag |
+| `count` | integer | Devices in this page |
+| `totalCount` | integer | Total paired devices |
+| `listType` | integer | List type discriminator |
+| `pageNum` | integer | Page number |
+| `deviceList` | array | Per-device objects (see below) |
+
+**Device object fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | integer | Device identifier |
+| `name` | string | Display name |
+| `isVSP` | string | `"true"` if pump is variable-speed capable, `"false"` or absent otherwise |
+
+---
+
+### VSP Session Commands
 
 #### `get_vsp_names`
 
@@ -567,8 +604,8 @@ Get names of all VSPs assigned to iQ20 aux slots.
 
 | Field | Type | Description |
 |---|---|---|
-| `serial` | string | Device serial |
-| `device_status` | string | `"online"` / `"offline"` |
+| `serial` | string | Device serial (echoed) |
+| `device_status` | string | `"Online"` / `"Offline"` (capital O) |
 | `is_error` | string | Error flag |
 | `vsp_names` | array | List of VSP name objects |
 
@@ -576,8 +613,8 @@ Each `vsp_names` element:
 
 | Field | Type | Description |
 |---|---|---|
-| `pumpId` | integer | VSP slot identifier |
-| `pumpName` | string | VSP display name |
+| `pumpId` | integer | Slot ID — matches `slot_id` in speed commands |
+| `pumpName` | string | User-assigned display name |
 
 #### `get_vsp_speedauxinfo`
 
@@ -591,12 +628,12 @@ Get speed and aux assignment information for a specific VSP slot.
 
 | Field | Type | Description |
 |---|---|---|
-| `serial` | string | Device serial |
-| `slot_id` | string | VSP slot identifier |
-| `device_status` | string | `"online"` / `"offline"` |
-| `is_error` | string | Error flag |
-| `maxSpeed` | string | Maximum speed |
-| `minSpeed` | string | Minimum speed |
+| `serial` | string | Device serial (echoed) |
+| `slot` | integer | Pump slot (echoed — note: `slot`, not `slot_id`) |
+| `device_status` | string | `"Online"` / `"Offline"` (capital O) |
+| `is_error` | boolean | Error flag |
+| `minSpeed` | integer | Global minimum RPM (e.g. `600`) |
+| `maxSpeed` | integer | Global maximum RPM (e.g. `3450`) |
 | `aux_count` | integer | Number of aux assignments |
 | `aux_speed_assignments` | array | List of aux speed assignment strings |
 | `vsp_speedInfo` | array | List of speed preset objects |
@@ -606,10 +643,10 @@ Each `vsp_speedInfo` element:
 
 | Field | Type | Description |
 |---|---|---|
-| `speedid` | integer | Speed preset identifier |
-| `speedName` | string | Speed preset name |
-| `speedvalue` | integer | Speed value |
-| `enabled` | string | Whether this speed is enabled |
+| `speedid` | integer | Preset ID (1–8) |
+| `speedName` | string | Human-readable name (e.g. `"LO"`, `"HI"`) |
+| `speedvalue` | integer | RPM setting for this preset |
+| `enabled` | string | `"true"` if currently active, `"false"` otherwise |
 
 #### `get_vsp_definition`
 
@@ -649,22 +686,22 @@ Get available VSP application model serial numbers for assignment.
 
 | Field | Type | Description |
 |---|---|---|
-| `serial` | string | iQ20 serial |
-| `device_status` | string | `"online"` / `"offline"` |
+| `serial` | string | Device serial (echoed) |
+| `device_status` | string | `"Online"` / `"Offline"` (capital O) |
 | `is_error` | string | Error flag |
-| `vsp_app_model_serials` | array | List of available VSP application/model records |
-| `response` | string | `"success"` or error string |
+| `response` | string | `"success"` or error |
+| `vsp_app_model_serials` | array | Per-slot hardware entries (see below) |
 
 Each `vsp_app_model_serials` element:
 
 | Field | Type | Description |
 |---|---|---|
+| `pumpId` | integer | Slot ID — primary join key with `get_vsp_names` |
+| `pumpSerial` | string | VSP device serial number |
+| `modelName` | string | Hardware model name |
+| `modelType` | integer | Model type discriminator |
 | `appId` | integer | Application identifier |
 | `appName` | string | Application name |
-| `modelName` | string | Model name |
-| `modelType` | integer | Model type identifier |
-| `pumpId` | integer | Pump slot identifier |
-| `pumpSerial` | string | Pump serial number |
 
 #### `get_unassigned_serials`
 
@@ -747,34 +784,34 @@ Remove a VSP serial assignment from an iQ20 aux slot.
 
 #### `enable_disable_pump_speedId`
 
-Enable or disable a specific speed preset for a VSP.
+Activate a speed preset or stop the pump.
 
 | Extra param | Value |
 |---|---|
 | `slot_id` | VSP slot identifier (integer) |
-| `speed_id` | Speed preset identifier (integer) |
-| `on_off_action` | `"on"` or `"off"` |
+| `speed_id` | Preset ID integer (1–8) |
+| `on_off_action` | `"on"` to activate at preset speed; `"off"` to stop pump |
 
 **Response fields:**
 
 | Field | Type | Description |
 |---|---|---|
-| `serial` | string | iQ20 serial |
-| `slot_id` | integer | VSP slot identifier |
-| `unit` | string | Speed unit |
-| `vsp_speedInfo` | array | Updated speed preset list |
-| `device_status` | string | `"online"` / `"offline"` |
-| `is_error` | string | Error flag |
-| `response` | string | `"success"` or error string |
+| `serial` | string | Device serial (echoed) |
+| `slot_id` | integer | Pump slot (echoed — note: `slot_id`, not `slot`) |
+| `unit` | string | `"rpm"` |
+| `vsp_speedInfo` | array | Updated preset states (see below) |
+| `device_status` | string | `"Online"` / `"Offline"` (capital O) |
+| `is_error` | boolean | Error flag |
+| `status` | string | `"success"` or error string |
 | `alert_message` | string | Alert message if any |
 
-Each `vsp_speedInfo` element:
+Each `vsp_speedInfo` element (in response):
 
 | Field | Type | Description |
 |---|---|---|
-| `speedId` | integer | Speed preset identifier |
-| `speedvalue` | integer | Speed value |
-| `status` | string | Enabled status string |
+| `speedId` | integer | Preset ID (1–8) — note capital `I`, unlike get response `speedid` |
+| `speedvalue` | integer | RPM for this preset |
+| `status` | string | `"Enabled"` if active, `"Disabled"` otherwise |
 
 #### `set_aux_speed`
 

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -448,6 +448,8 @@ class AqualinkFan(AqualinkDevice):
     @property
     def percentage(self) -> int | None:
         """Current speed as a percentage (0–100), or None if unknown."""
+        if not self.supports_percentage:
+            raise AqualinkOperationNotSupportedException
         return None
 
     async def _set_percentage(self, percentage: int) -> None:

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -145,7 +145,7 @@ class IaquaOneTouchSwitch(IaquaSwitch):
         await self.system.set_onetouch(self.data["name"])
 
 
-class IaquaPump(AqualinkFan, IaquaDevice):
+class IaquaVSPump(AqualinkFan, IaquaDevice):
     def __init__(self, system: IaquaSystem, data: DeviceData) -> None:
         super().__init__(system, data)
         self._speed_presets: list[dict[str, Any]] | None = None

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -164,7 +164,7 @@ class IaquaPump(AqualinkFan, IaquaDevice):
 
     @property
     def supports_presets(self) -> bool:
-        return self._speed_presets is not None
+        return bool(self._speed_presets)
 
     @property
     def supports_percentage(self) -> bool:

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import logging
 from enum import Enum, StrEnum, unique
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from iaqualink.device import (
     AqualinkBinarySensor,
     AqualinkClimate,
     AqualinkDevice,
+    AqualinkFan,
     AqualinkLight,
     AqualinkNumber,
     AqualinkSelect,
@@ -142,6 +143,93 @@ class IaquaOneTouchSwitch(IaquaSwitch):
     # state, so the inherited turn_on/turn_off guards are correct as-is.
     async def _toggle(self) -> None:
         await self.system.set_onetouch(self.data["name"])
+
+
+class IaquaPump(AqualinkFan, IaquaDevice):
+    def __init__(self, system: IaquaSystem, data: DeviceData) -> None:
+        super().__init__(system, data)
+        self._speed_presets: list[dict[str, Any]] | None = None
+
+    @property
+    def slot_id(self) -> int:
+        return int(self.data.get("slot_id", 1))
+
+    @property
+    def supports_turn_on(self) -> bool:
+        return True
+
+    @property
+    def supports_turn_off(self) -> bool:
+        return True
+
+    @property
+    def supports_presets(self) -> bool:
+        return self._speed_presets is not None
+
+    @property
+    def supports_percentage(self) -> bool:
+        return False
+
+    @property
+    def is_on(self) -> bool:
+        if self._speed_presets is None:
+            return self.state == IaquaBinaryState.ON
+        return any(p.get("enabled") == "true" for p in self._speed_presets)
+
+    @property
+    def preset_modes(self) -> list[str]:
+        if self._speed_presets is None:
+            raise AqualinkOperationNotSupportedException
+        return [str(p["speedName"]) for p in self._speed_presets]
+
+    @property
+    def preset_mode(self) -> str | None:
+        if self._speed_presets is None:
+            raise AqualinkOperationNotSupportedException
+        for p in self._speed_presets:
+            if p.get("enabled") == "true":
+                return str(p["speedName"])
+        return None
+
+    async def _set_preset_mode(self, preset_mode: str) -> None:
+        if self._speed_presets is None:
+            raise AqualinkOperationNotSupportedException
+        for p in self._speed_presets:
+            if p["speedName"] == preset_mode:
+                result = await self.system.set_vsp_speed(
+                    int(p["speedid"]), slot_id=self.slot_id
+                )
+                self._apply_speed_update(result.get("vsp_speedInfo", []))
+                return
+        raise AqualinkOperationNotSupportedException
+
+    async def turn_on(self) -> None:
+        if self.is_on:
+            return
+        speed_id = 1
+        if self._speed_presets:
+            speed_id = int(self._speed_presets[0]["speedid"])
+        result = await self.system.set_vsp_speed(speed_id, slot_id=self.slot_id)
+        self._apply_speed_update(result.get("vsp_speedInfo", []))
+
+    async def turn_off(self) -> None:
+        if not self.is_on:
+            return
+        result = await self.system.stop_vsp_pump(self.slot_id)
+        self._apply_speed_update(result.get("vsp_speedInfo", []))
+
+    def _apply_speed_update(self, speed_info: list[dict[str, Any]]) -> None:
+        if self._speed_presets is None or not speed_info:
+            return
+        by_id = {int(p["speedId"]): p["status"] for p in speed_info}
+        for preset in self._speed_presets:
+            status = by_id.get(int(preset["speedid"]))
+            if status is not None:
+                preset["enabled"] = "true" if status == "Enabled" else "false"
+
+    async def fetch_speed(self) -> None:
+        data = await self.system.get_vsp_speed(self.slot_id)
+        self._speed_presets = data.get("vsp_speedInfo", [])
 
 
 class IaquaHeater(IaquaSwitch):

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -145,7 +145,7 @@ class IaquaOneTouchSwitch(IaquaSwitch):
         await self.system.set_onetouch(self.data["name"])
 
 
-class IaquaVSPump(AqualinkFan, IaquaDevice):
+class IaquaVSPump(IaquaDevice, AqualinkFan):
     def __init__(self, system: IaquaSystem, data: DeviceData) -> None:
         super().__init__(system, data)
         self._speed_presets: list[dict[str, Any]] | None = None
@@ -178,13 +178,13 @@ class IaquaVSPump(AqualinkFan, IaquaDevice):
 
     @property
     def preset_modes(self) -> list[str]:
-        if self._speed_presets is None:
+        if not self._speed_presets:
             raise AqualinkOperationNotSupportedException
         return [str(p["speedName"]) for p in self._speed_presets]
 
     @property
     def preset_mode(self) -> str | None:
-        if self._speed_presets is None:
+        if not self._speed_presets:
             raise AqualinkOperationNotSupportedException
         for p in self._speed_presets:
             if p.get("enabled") == "true":
@@ -192,8 +192,8 @@ class IaquaVSPump(AqualinkFan, IaquaDevice):
         return None
 
     async def _set_preset_mode(self, preset_mode: str) -> None:
-        if self._speed_presets is None:
-            raise AqualinkOperationNotSupportedException
+        # supports_presets gates this in the base class's set_preset_mode().
+        assert self._speed_presets is not None
         for p in self._speed_presets:
             if p["speedName"] == preset_mode:
                 result = await self.system.set_vsp_speed(

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -165,11 +165,7 @@ class IaquaSystem(AqualinkSystem):
         # ICL info embedded in get_devices response as icl_info_list;
         # parsed by _parse_devices_response. get_icl_info times out on hardware.
 
-        if not self.is_vsp:
-            for key in [k for k in self.devices if k.startswith("vsp_pump_")]:
-                del self.devices[key]
-            self._vsp_discovered = False
-        elif not self._vsp_discovered:
+        if self.is_vsp and not self._vsp_discovered:
             await self._refresh_vsp_pumps()
 
     def _parse_home_response(self, response: httpx.Response) -> None:
@@ -597,7 +593,9 @@ class IaquaSystem(AqualinkSystem):
         r = await self._send_session_request(
             IAQUA_COMMAND_GET_VSP_SPEED, {"slot_id": str(slot_id)}
         )
-        return r.json()
+        data = r.json()
+        LOGGER.debug("VSP speed body: %s", redact_value(data))
+        return data
 
     async def set_vsp_speed(self, speed_id: int, slot_id: int = 1) -> Payload:
         r = await self._send_session_request(
@@ -608,7 +606,9 @@ class IaquaSystem(AqualinkSystem):
                 "on_off_action": "on",
             },
         )
-        return r.json()
+        data = r.json()
+        LOGGER.debug("VSP set speed body: %s", redact_value(data))
+        return data
 
     async def stop_vsp_pump(self, slot_id: int = 1) -> Payload:
         r = await self._send_session_request(
@@ -619,23 +619,31 @@ class IaquaSystem(AqualinkSystem):
                 "on_off_action": "off",
             },
         )
-        return r.json()
+        data = r.json()
+        LOGGER.debug("VSP stop pump body: %s", redact_value(data))
+        return data
 
     async def get_vsp_names(self) -> Payload:
         r = await self._send_session_request(IAQUA_COMMAND_GET_VSP_NAMES)
-        return r.json()
+        data = r.json()
+        LOGGER.debug("VSP names body: %s", redact_value(data))
+        return data
 
     async def get_vsp_appmodelserials(self) -> Payload:
         r = await self._send_session_request(
             IAQUA_COMMAND_GET_VSP_APPMODELSERIALS
         )
-        return r.json()
+        data = r.json()
+        LOGGER.debug("VSP appmodelserials body: %s", redact_value(data))
+        return data
 
     async def get_master_device_list(self) -> Payload:
         r = await self._send_session_request(
             IAQUA_COMMAND_GET_MASTER_DEVICE_LIST
         )
-        return r.json()
+        data = r.json()
+        LOGGER.debug("Master device list body: %s", redact_value(data))
+        return data
 
     async def _refresh_vsp_pumps(self) -> None:
         names_data = await self.get_vsp_names()
@@ -669,7 +677,7 @@ class IaquaSystem(AqualinkSystem):
                 "name": device_name,
                 "state": "0",
                 "label": label,
-                "slot_id": pump_id,
+                "slot_id": str(pump_id),
             }
             device = IaquaPump(self, data)
             await device.fetch_speed()

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -21,8 +21,8 @@ from iaqualink.systems.iaqua.device import (
     IaquaIclLight,
     IaquaLightSwitch,
     IaquaOneTouchSwitch,
-    IaquaPump,
     IaquaSetPoint,
+    IaquaVSPump,
     IaquaZoneStatus,
     light_subtype_to_class,
 )
@@ -679,7 +679,7 @@ class IaquaSystem(AqualinkSystem):
                 "label": label,
                 "slot_id": str(pump_id),
             }
-            device = IaquaPump(self, data)
+            device = IaquaVSPump(self, data)
             await device.fetch_speed()
             self.devices[device_name] = device
             LOGGER.debug(

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
     from iaqualink.client import AqualinkClient
     from iaqualink.typing import Payload
 
+# v2 session endpoint (p-api); used for all get_*/set_* commands.
+# r-api hosts v1 / swc endpoints — kept here for future reference.
 IAQUA_SESSION_URL = "https://p-api.iaqualink.net/v2/mobile/session.json"
 IAQUA_SESSION_V1_URL = "https://r-api.iaqualink.net/v1/mobile/session.json"
 
@@ -684,7 +686,7 @@ class IaquaSystem(AqualinkSystem):
             self.devices[device_name] = device
             LOGGER.debug(
                 "VSP pump discovered: serial=%s slot=%d name=%r",
-                self.serial,
+                mask_serial(self.serial),
                 pump_id,
                 label,
             )

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, ClassVar, cast
 
 from iaqualink.const import AQUALINK_API_KEY
+from iaqualink.exception import AqualinkServiceException
 from iaqualink.system import AqualinkSystem, SystemStatus
 from iaqualink.systems.iaqua.device import (
     _HOME_DEVICE_MAP,
@@ -167,8 +168,21 @@ class IaquaSystem(AqualinkSystem):
         # ICL info embedded in get_devices response as icl_info_list;
         # parsed by _parse_devices_response. get_icl_info times out on hardware.
 
-        if self.is_vsp and not self._vsp_discovered:
-            await self._refresh_vsp_pumps()
+        if self.is_vsp:
+            try:
+                if not self._vsp_discovered:
+                    await self._refresh_vsp_pumps()
+                else:
+                    await self._refresh_vsp_speeds()
+            except AqualinkServiceException:
+                # VSP is an optional sub-system; a flaky VSP call must not
+                # poison the otherwise-healthy refresh() above. Skip and
+                # retry on the next refresh() cycle instead.
+                LOGGER.warning(
+                    "VSP refresh failed for serial=%s; will retry next "
+                    "refresh()",
+                    mask_serial(self.serial),
+                )
 
     def _parse_home_response(self, response: httpx.Response) -> None:
         data = response.json()
@@ -656,6 +670,20 @@ class IaquaSystem(AqualinkSystem):
 
         # Primary: master device list — per-device isVSP flag identifies slots
         mdl_data = await self.get_master_device_list()
+        count, total_count = mdl_data.get("count"), mdl_data.get("totalCount")
+        if (
+            isinstance(count, int)
+            and isinstance(total_count, int)
+            and count < total_count
+        ):
+            LOGGER.warning(
+                "get_master_device_list returned a partial page (count=%d "
+                "totalCount=%d) for serial=%s; VSP pumps beyond page 1 may "
+                "be missed",
+                count,
+                total_count,
+                mask_serial(self.serial),
+            )
         vsp_slots: list[tuple[int, str]] = [
             (int(d["id"]), str(d.get("name", "")))
             for d in mdl_data.get("deviceList", [])
@@ -692,3 +720,8 @@ class IaquaSystem(AqualinkSystem):
             )
 
         self._vsp_discovered = True
+
+    async def _refresh_vsp_speeds(self) -> None:
+        for device in self.devices.values():
+            if isinstance(device, IaquaVSPump):
+                await device.fetch_speed()

--- a/src/iaqualink/systems/iaqua/system.py
+++ b/src/iaqualink/systems/iaqua/system.py
@@ -21,6 +21,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaIclLight,
     IaquaLightSwitch,
     IaquaOneTouchSwitch,
+    IaquaPump,
     IaquaSetPoint,
     IaquaZoneStatus,
     light_subtype_to_class,
@@ -38,8 +39,6 @@ if TYPE_CHECKING:
     from iaqualink.client import AqualinkClient
     from iaqualink.typing import Payload
 
-# v2 session endpoint (p-api); used for all get_*/set_* commands.
-# r-api hosts v1 / swc endpoints — kept here for future reference.
 IAQUA_SESSION_URL = "https://p-api.iaqualink.net/v2/mobile/session.json"
 IAQUA_SESSION_V1_URL = "https://r-api.iaqualink.net/v1/mobile/session.json"
 
@@ -67,6 +66,12 @@ IAQUA_COMMAND_ICL_ONOFF = "onoff_iclzone"
 IAQUA_COMMAND_ICL_SET_COLOR = "set_iclzone_color"
 IAQUA_COMMAND_ICL_SET_CUSTOM_COLOR = "define_iclzone_customcolor"
 
+IAQUA_COMMAND_GET_VSP_SPEED = "get_vsp_speedauxinfo"
+IAQUA_COMMAND_SET_VSP_SPEED = "enable_disable_pump_speedId"
+IAQUA_COMMAND_GET_VSP_NAMES = "get_vsp_names"
+IAQUA_COMMAND_GET_VSP_APPMODELSERIALS = "get_vsp_appmodelserials"
+IAQUA_COMMAND_GET_MASTER_DEVICE_LIST = "get_master_device_list"
+
 LOGGER = logging.getLogger("iaqualink.systems.iaqua")
 
 
@@ -89,6 +94,12 @@ class IaquaSystem(AqualinkSystem):
         # Re-evaluated from the home response on every update() call.
         # None = home response not yet parsed; True/False = last home response value.
         self._onetouch_supported: bool | None = None
+        # VSP pump discovery runs once; False = not yet run.
+        self._vsp_discovered: bool = False
+
+    @property
+    def is_vsp(self) -> bool:
+        return self.data.get("isVSP") == "true"
 
     def __repr__(self) -> str:
         attrs = ["name", "serial", "data"]
@@ -100,20 +111,16 @@ class IaquaSystem(AqualinkSystem):
         command: str,
         params: Payload | None = None,
     ) -> httpx.Response:
-        if not params:
-            params = {}
-
-        params.update(
-            {
-                "actionID": "command",
-                "command": command,
-                "serial": self.serial,
-            }
-        )
+        merged = {
+            **(params or {}),
+            "actionID": "command",
+            "command": command,
+            "serial": self.serial,
+        }
 
         async def do_request() -> httpx.Response:
             request_params = {
-                **params,
+                **merged,
                 "sessionID": self.aqualink.client_id,
             }
             headers = {
@@ -157,6 +164,13 @@ class IaquaSystem(AqualinkSystem):
 
         # ICL info embedded in get_devices response as icl_info_list;
         # parsed by _parse_devices_response. get_icl_info times out on hardware.
+
+        if not self.is_vsp:
+            for key in [k for k in self.devices if k.startswith("vsp_pump_")]:
+                del self.devices[key]
+            self._vsp_discovered = False
+        elif not self._vsp_discovered:
+            await self._refresh_vsp_pumps()
 
     def _parse_home_response(self, response: httpx.Response) -> None:
         data = response.json()
@@ -578,3 +592,93 @@ class IaquaSystem(AqualinkSystem):
             IAQUA_COMMAND_ICL_SET_CUSTOM_COLOR, params
         )
         self._parse_icl_custom_color_response(r)
+
+    async def get_vsp_speed(self, slot_id: int = 1) -> Payload:
+        r = await self._send_session_request(
+            IAQUA_COMMAND_GET_VSP_SPEED, {"slot_id": str(slot_id)}
+        )
+        return r.json()
+
+    async def set_vsp_speed(self, speed_id: int, slot_id: int = 1) -> Payload:
+        r = await self._send_session_request(
+            IAQUA_COMMAND_SET_VSP_SPEED,
+            {
+                "slot_id": str(slot_id),
+                "speed_id": str(speed_id),
+                "on_off_action": "on",
+            },
+        )
+        return r.json()
+
+    async def stop_vsp_pump(self, slot_id: int = 1) -> Payload:
+        r = await self._send_session_request(
+            IAQUA_COMMAND_SET_VSP_SPEED,
+            {
+                "slot_id": str(slot_id),
+                "speed_id": "1",  # ignored by server when on_off_action="off"
+                "on_off_action": "off",
+            },
+        )
+        return r.json()
+
+    async def get_vsp_names(self) -> Payload:
+        r = await self._send_session_request(IAQUA_COMMAND_GET_VSP_NAMES)
+        return r.json()
+
+    async def get_vsp_appmodelserials(self) -> Payload:
+        r = await self._send_session_request(
+            IAQUA_COMMAND_GET_VSP_APPMODELSERIALS
+        )
+        return r.json()
+
+    async def get_master_device_list(self) -> Payload:
+        r = await self._send_session_request(
+            IAQUA_COMMAND_GET_MASTER_DEVICE_LIST
+        )
+        return r.json()
+
+    async def _refresh_vsp_pumps(self) -> None:
+        names_data = await self.get_vsp_names()
+        name_map: dict[int, str] = {
+            int(p["pumpId"]): str(p["pumpName"])
+            for p in names_data.get("vsp_names", [])
+        }
+
+        # Primary: master device list — per-device isVSP flag identifies slots
+        mdl_data = await self.get_master_device_list()
+        vsp_slots: list[tuple[int, str]] = [
+            (int(d["id"]), str(d.get("name", "")))
+            for d in mdl_data.get("deviceList", [])
+            if d.get("isVSP") == "true"
+        ]
+
+        # Fallback: appmodelserials when master list yields no VSP devices
+        if not vsp_slots:
+            serials_data = await self.get_vsp_appmodelserials()
+            vsp_slots = [
+                (int(p["pumpId"]), "")
+                for p in serials_data.get("vsp_app_model_serials", [])
+            ]
+
+        for pump_id, mdl_name in vsp_slots:
+            device_name = f"vsp_pump_{pump_id}"
+            if device_name in self.devices:
+                continue
+            label = name_map.get(pump_id, mdl_name or f"VSP Pump {pump_id}")
+            data: Payload = {
+                "name": device_name,
+                "state": "0",
+                "label": label,
+                "slot_id": pump_id,
+            }
+            device = IaquaPump(self, data)
+            await device.fetch_speed()
+            self.devices[device_name] = device
+            LOGGER.debug(
+                "VSP pump discovered: serial=%s slot=%d name=%r",
+                self.serial,
+                pump_id,
+                label,
+            )
+
+        self._vsp_discovered = True

--- a/tests/systems/iaqua/factories.py
+++ b/tests/systems/iaqua/factories.py
@@ -27,10 +27,10 @@ from iaqualink.systems.iaqua.device import (
     IaquaIclLight,
     IaquaLightSwitch,
     IaquaOneTouchSwitch,
-    IaquaPump,
     IaquaSensor,
     IaquaSetPoint,
     IaquaSwitch,
+    IaquaVSPump,
 )
 from iaqualink.systems.iaqua.enums import IaquaTemperatureUnit
 from iaqualink.systems.iaqua.system import IaquaSystem
@@ -545,17 +545,17 @@ def _iaqua_fan() -> FanFixture:
 
     on_presets = [{**p} for p in _VSP_SPEED_INFO]
     on_presets[0]["enabled"] = "true"
-    device_on = IaquaPump(system, {**data})
+    device_on = IaquaVSPump(system, {**data})
     device_on._speed_presets = on_presets
 
     off_presets = [{**p} for p in _VSP_SPEED_INFO]
-    device_off = IaquaPump(system, {**data})
+    device_off = IaquaVSPump(system, {**data})
     device_off._speed_presets = off_presets
 
     return FanFixture(
         device_on=device_on,
         device_off=device_off,
-        expected_class=IaquaPump,
+        expected_class=IaquaVSPump,
     )
 
 

--- a/tests/systems/iaqua/factories.py
+++ b/tests/systems/iaqua/factories.py
@@ -27,6 +27,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaIclLight,
     IaquaLightSwitch,
     IaquaOneTouchSwitch,
+    IaquaPump,
     IaquaSensor,
     IaquaSetPoint,
     IaquaSwitch,
@@ -38,6 +39,7 @@ from ...conformance.fixtures import (
     BinarySensorFixture,
     ClimateFixture,
     DeviceFixture,
+    FanFixture,
     LightFixture,
     NumberFixture,
     SelectFixture,
@@ -521,5 +523,42 @@ iaqua_system_factories: list[tuple[str, Callable[[], Any]]] = [
     ("iaqua-system", _iaqua_system),
 ]
 
-# iaqua does not implement this device type.
-iaqua_fan_factories: list[tuple[str, Callable[[], Any]]] = []
+# ---------------------------------------------------------------------------
+# Fan fixtures
+# ---------------------------------------------------------------------------
+
+_VSP_SPEED_INFO: list[dict[str, Any]] = [
+    {"speedid": 1, "speedName": "LO", "speedvalue": 1800, "enabled": "false"},
+    {"speedid": 2, "speedName": "MED", "speedvalue": 3000, "enabled": "false"},
+    {"speedid": 3, "speedName": "HI", "speedvalue": 3450, "enabled": "false"},
+]
+
+
+def _iaqua_fan() -> FanFixture:
+    system = make_system()
+    data = {
+        "name": "vsp_pump_1",
+        "state": "0",
+        "label": "Main Pump",
+        "slot_id": "1",
+    }
+
+    on_presets = [{**p} for p in _VSP_SPEED_INFO]
+    on_presets[0]["enabled"] = "true"
+    device_on = IaquaPump(system, {**data})
+    device_on._speed_presets = on_presets
+
+    off_presets = [{**p} for p in _VSP_SPEED_INFO]
+    device_off = IaquaPump(system, {**data})
+    device_off._speed_presets = off_presets
+
+    return FanFixture(
+        device_on=device_on,
+        device_off=device_off,
+        expected_class=IaquaPump,
+    )
+
+
+iaqua_fan_factories: list[tuple[str, Callable[[], Any]]] = [
+    ("iaqua-pump", _iaqua_fan),
+]

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -27,6 +27,7 @@ from iaqualink.systems.iaqua.device import (
     IaquaLightSwitch,
     IaquaOneTouchSwitch,
     IaquaPresenceSensor,
+    IaquaPump,
     IaquaSensor,
     IaquaSetPoint,
     IaquaSwitch,
@@ -893,3 +894,195 @@ class TestIaquaIclLight:
         assert sut.rgbw == (200, 100, 50, 25)
         assert sut._color_id == ICL_CUSTOM_COLOR_ID
         assert sut.effect is None  # color_id=16 excluded from effect
+
+
+# ---------------------------------------------------------------------------
+# IaquaPump (VSP)
+# ---------------------------------------------------------------------------
+
+_VSP_SPEED_INFO = [
+    {"speedid": 1, "speedName": "MED", "speedvalue": 3000, "enabled": "false"},
+    {"speedid": 2, "speedName": "HI", "speedvalue": 3450, "enabled": "false"},
+    {
+        "speedid": 3,
+        "speedName": "POLARIS",
+        "speedvalue": 3450,
+        "enabled": "false",
+    },
+    {"speedid": 4, "speedName": "LO", "speedvalue": 1800, "enabled": "true"},
+    {"speedid": 5, "speedName": "TEMP", "speedvalue": 2000, "enabled": "false"},
+    {
+        "speedid": 6,
+        "speedName": "Temp2",
+        "speedvalue": 2250,
+        "enabled": "false",
+    },
+    {
+        "speedid": 7,
+        "speedName": "Heat Pump",
+        "speedvalue": 2750,
+        "enabled": "false",
+    },
+    {
+        "speedid": 8,
+        "speedName": "In Floor",
+        "speedvalue": 2750,
+        "enabled": "false",
+    },
+]
+
+
+def _make_pump():
+    system = make_system()
+    data = {
+        "name": "vsp_pump_1",
+        "state": "0",
+        "label": "Main Pump",
+        "slot_id": "1",
+    }
+    return system, IaquaPump(system, data)
+
+
+class TestIaquaPump:
+    def test_preset_modes_raises_before_fetch(self) -> None:
+        _, sut = _make_pump()
+        with pytest.raises(AqualinkOperationNotSupportedException):
+            _ = sut.preset_modes
+
+    def test_preset_mode_raises_before_fetch(self) -> None:
+        _, sut = _make_pump()
+        with pytest.raises(AqualinkOperationNotSupportedException):
+            _ = sut.preset_mode
+
+    def test_preset_modes_after_fetch(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = _VSP_SPEED_INFO  # type: ignore[assignment]
+        assert sut.preset_modes == [
+            "MED",
+            "HI",
+            "POLARIS",
+            "LO",
+            "TEMP",
+            "Temp2",
+            "Heat Pump",
+            "In Floor",
+        ]
+
+    def test_preset_mode_after_fetch(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = _VSP_SPEED_INFO  # type: ignore[assignment]
+        assert sut.preset_mode == "LO"
+
+    def test_preset_mode_none_when_all_disabled(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = [
+            {
+                "speedid": 1,
+                "speedName": "MED",
+                "speedvalue": 3000,
+                "enabled": "false",
+            },
+        ]
+        assert sut.preset_mode is None
+
+    async def test_set_preset_mode_raises_before_fetch(self) -> None:
+        _, sut = _make_pump()
+        with pytest.raises(AqualinkOperationNotSupportedException):
+            await sut.set_preset_mode("LO")
+
+    async def test_set_preset_mode_calls_system(self) -> None:
+        system, sut = _make_pump()
+        sut._speed_presets = _VSP_SPEED_INFO  # type: ignore[assignment]
+        with patch.object(system, "set_vsp_speed", return_value={}) as mock_set:
+            await sut.set_preset_mode("LO")
+        mock_set.assert_awaited_once_with(4, slot_id=1)
+
+    async def test_fetch_speed_populates_presets(self) -> None:
+        system, sut = _make_pump()
+        vsp_response = {"vsp_speedInfo": _VSP_SPEED_INFO}
+        with patch.object(system, "get_vsp_speed", return_value=vsp_response):
+            await sut.fetch_speed()
+        assert sut._speed_presets == _VSP_SPEED_INFO
+        assert sut.preset_mode == "LO"
+
+    async def test_fetch_speed_uses_slot_id_from_data(self) -> None:
+        system, sut = _make_pump()
+        sut.data["slot_id"] = 5
+        vsp_response = {"vsp_speedInfo": _VSP_SPEED_INFO}
+        with patch.object(
+            system, "get_vsp_speed", return_value=vsp_response
+        ) as mock_get:
+            await sut.fetch_speed()
+        mock_get.assert_awaited_once_with(5)
+
+    def test_apply_speed_update_noop_when_presets_none(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = None
+        sut._apply_speed_update([{"speedId": 1, "status": "Enabled"}])
+
+    def test_apply_speed_update_noop_when_speed_info_empty(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = _VSP_SPEED_INFO  # type: ignore[assignment]
+        original = [dict(p) for p in _VSP_SPEED_INFO]
+        sut._apply_speed_update([])
+        assert sut._speed_presets == original
+
+    def test_apply_speed_update_sets_enabled(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = [
+            {
+                "speedid": 1,
+                "speedName": "LO",
+                "speedvalue": 1800,
+                "enabled": "false",
+            },
+        ]
+        sut._apply_speed_update([{"speedId": 1, "status": "Enabled"}])
+        assert sut._speed_presets[0]["enabled"] == "true"
+
+    async def test_set_preset_mode_updates_speed_info(self) -> None:
+        system, sut = _make_pump()
+        sut._speed_presets = [
+            {
+                "speedid": 4,
+                "speedName": "LO",
+                "speedvalue": 1800,
+                "enabled": "false",
+            },
+        ]
+        speed_info = [{"speedId": 4, "status": "Enabled", "speedvalue": 1800}]
+        with patch.object(
+            system,
+            "set_vsp_speed",
+            return_value={"vsp_speedInfo": speed_info},
+        ):
+            await sut.set_preset_mode("LO")
+        assert sut._speed_presets[0]["enabled"] == "true"
+
+    async def test_set_preset_mode_uses_slot_id_from_data(self) -> None:
+        system, sut = _make_pump()
+        sut.data["slot_id"] = 5
+        sut._speed_presets = _VSP_SPEED_INFO  # type: ignore[assignment]
+        with patch.object(system, "set_vsp_speed", return_value={}) as mock_set:
+            await sut.set_preset_mode("LO")
+        mock_set.assert_awaited_once_with(4, slot_id=5)
+
+    def test_is_on_uses_preset_enabled_when_presets_loaded(self) -> None:
+        _, sut = _make_pump()
+        all_disabled = [{**p, "enabled": "false"} for p in _VSP_SPEED_INFO]
+        sut._speed_presets = all_disabled  # type: ignore[assignment]
+        assert sut.is_on is False
+        with_one_enabled = [
+            {**_VSP_SPEED_INFO[0], "enabled": "true"},
+            *_VSP_SPEED_INFO[1:],
+        ]
+        sut._speed_presets = with_one_enabled  # type: ignore[assignment]
+        assert sut.is_on is True
+
+    async def test_turn_on_with_presets_uses_first_preset_speed(self) -> None:
+        system, sut = _make_pump()
+        all_disabled = [{**p, "enabled": "false"} for p in _VSP_SPEED_INFO]
+        sut._speed_presets = all_disabled  # type: ignore[assignment]
+        with patch.object(system, "set_vsp_speed", return_value={}) as mock_set:
+            await sut.turn_on()
+        mock_set.assert_awaited_once_with(1, slot_id=sut.slot_id)

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -944,6 +944,20 @@ def _make_pump():
 
 
 class TestIaquaPump:
+    def test_supports_presets_false_before_fetch(self) -> None:
+        _, sut = _make_pump()
+        assert sut.supports_presets is False
+
+    def test_supports_presets_true_after_fetch_with_presets(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = _VSP_SPEED_INFO  # type: ignore[assignment]
+        assert sut.supports_presets is True
+
+    def test_supports_presets_false_when_speed_presets_empty(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = []
+        assert sut.supports_presets is False
+
     def test_preset_modes_raises_before_fetch(self) -> None:
         _, sut = _make_pump()
         with pytest.raises(AqualinkOperationNotSupportedException):

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -958,6 +958,18 @@ class TestIaquaVSPump:
         sut._speed_presets = []
         assert sut.supports_presets is False
 
+    def test_preset_modes_raises_when_speed_presets_empty(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = []
+        with pytest.raises(AqualinkOperationNotSupportedException):
+            _ = sut.preset_modes
+
+    def test_preset_mode_raises_when_speed_presets_empty(self) -> None:
+        _, sut = _make_pump()
+        sut._speed_presets = []
+        with pytest.raises(AqualinkOperationNotSupportedException):
+            _ = sut.preset_mode
+
     def test_preset_modes_raises_before_fetch(self) -> None:
         _, sut = _make_pump()
         with pytest.raises(AqualinkOperationNotSupportedException):

--- a/tests/systems/iaqua/test_device.py
+++ b/tests/systems/iaqua/test_device.py
@@ -27,10 +27,10 @@ from iaqualink.systems.iaqua.device import (
     IaquaLightSwitch,
     IaquaOneTouchSwitch,
     IaquaPresenceSensor,
-    IaquaPump,
     IaquaSensor,
     IaquaSetPoint,
     IaquaSwitch,
+    IaquaVSPump,
     IaquaZoneStatus,
 )
 from iaqualink.systems.iaqua.enums import IaquaTemperatureUnit
@@ -897,7 +897,7 @@ class TestIaquaIclLight:
 
 
 # ---------------------------------------------------------------------------
-# IaquaPump (VSP)
+# IaquaVSPump (VSP)
 # ---------------------------------------------------------------------------
 
 _VSP_SPEED_INFO = [
@@ -940,10 +940,10 @@ def _make_pump():
         "label": "Main Pump",
         "slot_id": "1",
     }
-    return system, IaquaPump(system, data)
+    return system, IaquaVSPump(system, data)
 
 
-class TestIaquaPump:
+class TestIaquaVSPump:
     def test_supports_presets_false_before_fetch(self) -> None:
         _, sut = _make_pump()
         assert sut.supports_presets is False

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -21,8 +21,8 @@ from iaqualink.systems.iaqua.device import (
     IaquaHeatPumpAlertSensor,
     IaquaHeatPumpMode,
     IaquaOneTouchSwitch,
-    IaquaPump,
     IaquaSetPoint,
+    IaquaVSPump,
 )
 from iaqualink.systems.iaqua.enums import IaquaSystemType, IaquaTemperatureUnit
 from iaqualink.systems.iaqua.system import (
@@ -1274,7 +1274,7 @@ class TestIaquaSystem:
         assert "vsp_pump_6" in sut.devices
         assert "vsp_pump_7" not in sut.devices
         pump5 = sut.devices["vsp_pump_5"]
-        assert isinstance(pump5, IaquaPump)
+        assert isinstance(pump5, IaquaVSPump)
         assert pump5.slot_id == 5
         assert pump5.data["slot_id"] == "5"  # DeviceData convention: str values
         assert pump5.label == "Main Pump"  # from get_vsp_names, not master list
@@ -1318,7 +1318,7 @@ class TestIaquaSystem:
 
     async def test_refresh_vsp_pumps_skips_existing(self) -> None:
         _, sut = _make_iaqua_system()
-        existing = IaquaPump(
+        existing = IaquaVSPump(
             sut, {"name": "vsp_pump_5", "state": "1", "slot_id": "5"}
         )
         sut.devices["vsp_pump_5"] = existing
@@ -1369,7 +1369,7 @@ class TestIaquaSystem:
             await sut.refresh()
 
         assert "vsp_pump_5" in sut.devices
-        assert isinstance(sut.devices["vsp_pump_5"], IaquaPump)
+        assert isinstance(sut.devices["vsp_pump_5"], IaquaVSPump)
         assert sut._vsp_discovered is True
 
     async def test_refresh_vsp_pumps_empty_discovery(self) -> None:

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -1276,6 +1276,7 @@ class TestIaquaSystem:
         pump5 = sut.devices["vsp_pump_5"]
         assert isinstance(pump5, IaquaPump)
         assert pump5.slot_id == 5
+        assert pump5.data["slot_id"] == "5"  # DeviceData convention: str values
         assert pump5.label == "Main Pump"  # from get_vsp_names, not master list
         assert pump5._speed_presets is not None
         assert sut._vsp_discovered is True
@@ -1370,35 +1371,6 @@ class TestIaquaSystem:
         assert "vsp_pump_5" in sut.devices
         assert isinstance(sut.devices["vsp_pump_5"], IaquaPump)
         assert sut._vsp_discovered is True
-
-    async def test_vsp_devices_cleared_when_is_vsp_false(self) -> None:
-        _, sut = _make_iaqua_system()
-        sut.devices["vsp_pump_1"] = MagicMock()
-        sut._vsp_discovered = True
-        with (
-            patch.object(
-                sut, "_send_home_screen_request", return_value=MagicMock()
-            ),
-            patch.object(
-                sut, "_parse_home_response", side_effect=_set_online_for(sut)
-            ),
-            patch.object(
-                sut,
-                "_send_devices_screen_request",
-                return_value=MagicMock(),
-            ),
-            patch.object(sut, "_parse_devices_response"),
-            patch.object(
-                sut,
-                "_send_onetouch_screen_request",
-                return_value=MagicMock(),
-            ),
-            patch.object(sut, "_parse_onetouch_response"),
-        ):
-            await sut.refresh()
-
-        assert "vsp_pump_1" not in sut.devices
-        assert sut._vsp_discovered is False
 
     async def test_refresh_vsp_pumps_empty_discovery(self) -> None:
         _, sut = _make_iaqua_system()

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -1422,6 +1423,99 @@ class TestIaquaSystem:
 
         assert not any(k.startswith("vsp_pump_") for k in sut.devices)
         assert sut._vsp_discovered is True
+
+    async def test_refresh_vsp_pumps_logs_warning_on_partial_page(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _, sut = _make_iaqua_system()
+        mdl_resp = {
+            "count": 1,
+            "totalCount": 2,
+            "deviceList": [{"id": 5, "name": "ePump 1", "isVSP": "true"}],
+        }
+        with (
+            patch.object(sut, "get_vsp_names", return_value={"vsp_names": []}),
+            patch.object(sut, "get_master_device_list", return_value=mdl_resp),
+            patch.object(
+                sut, "get_vsp_speed", return_value={"vsp_speedInfo": []}
+            ),
+            caplog.at_level(logging.WARNING, logger="iaqualink.systems.iaqua"),
+        ):
+            await sut._refresh_vsp_pumps()
+
+        assert "partial page" in caplog.text
+
+    async def test_refresh_vsp_failure_does_not_disconnect_system(
+        self,
+    ) -> None:
+        _, sut = _make_iaqua_system()
+        sut.data["isVSP"] = "true"
+
+        with (
+            patch.object(
+                sut, "_send_home_screen_request", return_value=MagicMock()
+            ),
+            patch.object(
+                sut, "_parse_home_response", side_effect=_set_online_for(sut)
+            ),
+            patch.object(
+                sut,
+                "_send_devices_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_devices_response"),
+            patch.object(
+                sut,
+                "_send_onetouch_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_onetouch_response"),
+            patch.object(
+                sut,
+                "get_vsp_names",
+                side_effect=AqualinkServiceException("boom"),
+            ),
+        ):
+            await sut.refresh()
+
+        assert sut.status is SystemStatus.ONLINE
+        assert sut._vsp_discovered is False
+
+    async def test_refresh_calls_fetch_speed_on_subsequent_cycle(
+        self,
+    ) -> None:
+        _, sut = _make_iaqua_system()
+        sut.data["isVSP"] = "true"
+        sut._vsp_discovered = True
+        existing = IaquaVSPump(
+            sut, {"name": "vsp_pump_5", "state": "1", "slot_id": "5"}
+        )
+        sut.devices["vsp_pump_5"] = existing
+
+        with (
+            patch.object(
+                sut, "_send_home_screen_request", return_value=MagicMock()
+            ),
+            patch.object(
+                sut, "_parse_home_response", side_effect=_set_online_for(sut)
+            ),
+            patch.object(
+                sut,
+                "_send_devices_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_devices_response"),
+            patch.object(
+                sut,
+                "_send_onetouch_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_onetouch_response"),
+            patch.object(existing, "fetch_speed") as fetch_speed,
+        ):
+            await sut.refresh()
+
+        fetch_speed.assert_called_once()
 
     @patch("httpx.AsyncClient.request")
     async def test_stop_vsp_pump_params(self, mock_request) -> None:

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -21,15 +21,22 @@ from iaqualink.systems.iaqua.device import (
     IaquaHeatPumpAlertSensor,
     IaquaHeatPumpMode,
     IaquaOneTouchSwitch,
+    IaquaPump,
     IaquaSetPoint,
 )
 from iaqualink.systems.iaqua.enums import IaquaSystemType, IaquaTemperatureUnit
 from iaqualink.systems.iaqua.system import (
     IAQUA_COMMAND_ENABLE_DISABLE_HPM,
+    IAQUA_COMMAND_GET_MASTER_DEVICE_LIST,
+    IAQUA_COMMAND_GET_VSP_APPMODELSERIALS,
+    IAQUA_COMMAND_GET_VSP_NAMES,
+    IAQUA_COMMAND_GET_VSP_SPEED,
     IAQUA_COMMAND_SET_ONETOUCH,
+    IAQUA_COMMAND_SET_VSP_SPEED,
     IAQUA_COMMAND_SETPOINT_HPM_TEMP,
     IAQUA_COMMAND_SWITCH_HPM_MODE,
     IAQUA_SESSION_URL,
+    IAQUA_SESSION_V1_URL,
     IaquaSystem,
 )
 
@@ -79,6 +86,14 @@ def _home_response(extra: list[dict]) -> MagicMock:
     r = MagicMock()
     r.json.return_value = message
     return r
+
+
+def _vsp_mock_response(mock_request: MagicMock) -> None:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.reason_phrase = "OK"
+    resp.json.return_value = {}
+    mock_request.return_value = resp
 
 
 class TestIaquaSystem:
@@ -1101,3 +1116,349 @@ class TestIaquaSystem:
             called_params = mock_request.call_args[1]["params"]
             assert called_params["command"] == IAQUA_COMMAND_SETPOINT_HPM_TEMP
             assert called_params["poolchillsetpointtemp"] == "80"
+
+    # --- VSP (variable speed pump) ---
+
+    @patch("httpx.AsyncClient.request")
+    async def test_get_vsp_speed_uses_session_url(self, mock_request) -> None:
+        _, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+
+        await sut.get_vsp_speed(slot_id=5)
+
+        called_url = mock_request.call_args[0][1]
+        assert called_url == IAQUA_SESSION_URL
+        assert called_url != IAQUA_SESSION_V1_URL
+
+    @patch("httpx.AsyncClient.request")
+    async def test_get_vsp_speed_params(self, mock_request) -> None:
+        _, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+
+        await sut.get_vsp_speed(slot_id=5)
+
+        params = mock_request.call_args[1]["params"]
+        assert params["command"] == IAQUA_COMMAND_GET_VSP_SPEED
+        assert params["slot_id"] == "5"
+        assert params["actionID"] == "command"
+        assert params["serial"] == sut.serial
+
+    @patch("httpx.AsyncClient.request")
+    async def test_set_vsp_speed_uses_session_url(self, mock_request) -> None:
+        _, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+
+        await sut.set_vsp_speed(speed_id=4, slot_id=5)
+
+        called_url = mock_request.call_args[0][1]
+        assert called_url == IAQUA_SESSION_URL
+
+    @patch("httpx.AsyncClient.request")
+    async def test_set_vsp_speed_params(self, mock_request) -> None:
+        _, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+
+        await sut.set_vsp_speed(speed_id=4, slot_id=5)
+
+        params = mock_request.call_args[1]["params"]
+        assert params["command"] == IAQUA_COMMAND_SET_VSP_SPEED
+        assert params["slot_id"] == "5"
+        assert params["speed_id"] == "4"
+        assert params["on_off_action"] == "on"
+        assert params["actionID"] == "command"
+        assert params["serial"] == sut.serial
+
+    @patch("httpx.AsyncClient.request")
+    async def test_vsp_request_sends_auth_headers(self, mock_request) -> None:
+        client, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+        client.id_token = "test-id-token"
+
+        await sut.get_vsp_speed(slot_id=1)
+
+        headers = mock_request.call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer test-id-token"
+        assert headers["api_key"] == AQUALINK_API_KEY
+
+    @patch("httpx.AsyncClient.request")
+    async def test_get_vsp_names_params(self, mock_request) -> None:
+        _, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+
+        await sut.get_vsp_names()
+
+        params = mock_request.call_args[1]["params"]
+        assert params["command"] == IAQUA_COMMAND_GET_VSP_NAMES
+        assert params["actionID"] == "command"
+        assert params["serial"] == sut.serial
+
+    @patch("httpx.AsyncClient.request")
+    async def test_get_vsp_appmodelserials_params(self, mock_request) -> None:
+        _, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+
+        await sut.get_vsp_appmodelserials()
+
+        params = mock_request.call_args[1]["params"]
+        assert params["command"] == IAQUA_COMMAND_GET_VSP_APPMODELSERIALS
+        assert params["actionID"] == "command"
+        assert params["serial"] == sut.serial
+
+    async def test_is_vsp_true(self) -> None:
+        _, sut = _make_iaqua_system()
+        sut.data["isVSP"] = "true"
+        assert sut.is_vsp is True
+
+    async def test_is_vsp_false(self) -> None:
+        _, sut = _make_iaqua_system()
+        assert sut.is_vsp is False
+
+    @patch("httpx.AsyncClient.request")
+    async def test_get_master_device_list_uses_session_url(
+        self, mock_request
+    ) -> None:
+        _, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+
+        await sut.get_master_device_list()
+
+        called_url = mock_request.call_args[0][1]
+        assert called_url == IAQUA_SESSION_URL
+        assert called_url != IAQUA_SESSION_V1_URL
+
+    @patch("httpx.AsyncClient.request")
+    async def test_get_master_device_list_params(self, mock_request) -> None:
+        _, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+
+        await sut.get_master_device_list()
+
+        params = mock_request.call_args[1]["params"]
+        assert params["command"] == IAQUA_COMMAND_GET_MASTER_DEVICE_LIST
+        assert params["actionID"] == "command"
+        assert params["serial"] == sut.serial
+
+    async def test_refresh_vsp_pumps_creates_devices(self) -> None:
+        _, sut = _make_iaqua_system()
+        names_resp = {
+            "vsp_names": [
+                {"pumpId": 5, "pumpName": "Main Pump"},
+                {"pumpId": 6, "pumpName": "Spa Pump"},
+            ]
+        }
+        mdl_resp = {
+            "deviceList": [
+                {"id": 5, "name": "ePump 1", "isVSP": "true"},
+                {"id": 6, "name": "ePump 2", "isVSP": "true"},
+                {"id": 7, "name": "Non-VSP", "isVSP": "false"},
+            ]
+        }
+        speed_resp = {
+            "vsp_speedInfo": [
+                {
+                    "speedid": 1,
+                    "speedName": "LO",
+                    "speedvalue": 1500,
+                    "enabled": "false",
+                }
+            ]
+        }
+        with (
+            patch.object(sut, "get_vsp_names", return_value=names_resp),
+            patch.object(sut, "get_master_device_list", return_value=mdl_resp),
+            patch.object(sut, "get_vsp_speed", return_value=speed_resp),
+        ):
+            await sut._refresh_vsp_pumps()
+
+        assert "vsp_pump_5" in sut.devices
+        assert "vsp_pump_6" in sut.devices
+        assert "vsp_pump_7" not in sut.devices
+        pump5 = sut.devices["vsp_pump_5"]
+        assert isinstance(pump5, IaquaPump)
+        assert pump5.slot_id == 5
+        assert pump5.label == "Main Pump"  # from get_vsp_names, not master list
+        assert pump5._speed_presets is not None
+        assert sut._vsp_discovered is True
+
+    async def test_refresh_vsp_pumps_falls_back_to_appmodelserials(
+        self,
+    ) -> None:
+        _, sut = _make_iaqua_system()
+        names_resp = {"vsp_names": [{"pumpId": 5, "pumpName": "Main Pump"}]}
+        mdl_resp = {
+            "deviceList": [{"id": 99, "name": "Other", "isVSP": "false"}]
+        }
+        serials_resp = {
+            "vsp_app_model_serials": [
+                {
+                    "pumpId": 5,
+                    "pumpSerial": "ABC",
+                    "modelName": "ePump",
+                    "modelType": 1,
+                    "appId": 1,
+                    "appName": "iAqualink",
+                }
+            ]
+        }
+        speed_resp: dict[str, list[Any]] = {"vsp_speedInfo": []}
+        with (
+            patch.object(sut, "get_vsp_names", return_value=names_resp),
+            patch.object(sut, "get_master_device_list", return_value=mdl_resp),
+            patch.object(
+                sut, "get_vsp_appmodelserials", return_value=serials_resp
+            ),
+            patch.object(sut, "get_vsp_speed", return_value=speed_resp),
+        ):
+            await sut._refresh_vsp_pumps()
+
+        assert "vsp_pump_5" in sut.devices
+        assert sut.devices["vsp_pump_5"].label == "Main Pump"
+        assert sut._vsp_discovered is True
+
+    async def test_refresh_vsp_pumps_skips_existing(self) -> None:
+        _, sut = _make_iaqua_system()
+        existing = IaquaPump(
+            sut, {"name": "vsp_pump_5", "state": "1", "slot_id": "5"}
+        )
+        sut.devices["vsp_pump_5"] = existing
+        names_resp = {"vsp_names": [{"pumpId": 5, "pumpName": "Main Pump"}]}
+        mdl_resp = {
+            "deviceList": [{"id": 5, "name": "ePump 1", "isVSP": "true"}]
+        }
+        with (
+            patch.object(sut, "get_vsp_names", return_value=names_resp),
+            patch.object(sut, "get_master_device_list", return_value=mdl_resp),
+        ):
+            await sut._refresh_vsp_pumps()
+
+        assert sut.devices["vsp_pump_5"] is existing
+
+    async def test_refresh_with_is_vsp_runs_discovery(self) -> None:
+        _, sut = _make_iaqua_system()
+        sut.data["isVSP"] = "true"
+        names_resp = {"vsp_names": [{"pumpId": 5, "pumpName": "Main Pump"}]}
+        mdl_resp = {
+            "deviceList": [{"id": 5, "name": "ePump 1", "isVSP": "true"}]
+        }
+        with (
+            patch.object(
+                sut, "_send_home_screen_request", return_value=MagicMock()
+            ),
+            patch.object(
+                sut, "_parse_home_response", side_effect=_set_online_for(sut)
+            ),
+            patch.object(
+                sut,
+                "_send_devices_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_devices_response"),
+            patch.object(
+                sut,
+                "_send_onetouch_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_onetouch_response"),
+            patch.object(sut, "get_vsp_names", return_value=names_resp),
+            patch.object(sut, "get_master_device_list", return_value=mdl_resp),
+            patch.object(
+                sut, "get_vsp_speed", return_value={"vsp_speedInfo": []}
+            ),
+        ):
+            await sut.refresh()
+
+        assert "vsp_pump_5" in sut.devices
+        assert isinstance(sut.devices["vsp_pump_5"], IaquaPump)
+        assert sut._vsp_discovered is True
+
+    async def test_vsp_devices_cleared_when_is_vsp_false(self) -> None:
+        _, sut = _make_iaqua_system()
+        sut.devices["vsp_pump_1"] = MagicMock()
+        sut._vsp_discovered = True
+        with (
+            patch.object(
+                sut, "_send_home_screen_request", return_value=MagicMock()
+            ),
+            patch.object(
+                sut, "_parse_home_response", side_effect=_set_online_for(sut)
+            ),
+            patch.object(
+                sut,
+                "_send_devices_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_devices_response"),
+            patch.object(
+                sut,
+                "_send_onetouch_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_onetouch_response"),
+        ):
+            await sut.refresh()
+
+        assert "vsp_pump_1" not in sut.devices
+        assert sut._vsp_discovered is False
+
+    async def test_refresh_vsp_pumps_empty_discovery(self) -> None:
+        _, sut = _make_iaqua_system()
+        with (
+            patch.object(sut, "get_vsp_names", return_value={"vsp_names": []}),
+            patch.object(
+                sut,
+                "get_master_device_list",
+                return_value={"deviceList": []},
+            ),
+            patch.object(
+                sut,
+                "get_vsp_appmodelserials",
+                return_value={"vsp_app_model_serials": []},
+            ),
+        ):
+            await sut._refresh_vsp_pumps()
+
+        assert not any(k.startswith("vsp_pump_") for k in sut.devices)
+        assert sut._vsp_discovered is True
+
+    @patch("httpx.AsyncClient.request")
+    async def test_stop_vsp_pump_params(self, mock_request) -> None:
+        _, sut = _make_iaqua_system()
+        _vsp_mock_response(mock_request)
+
+        await sut.stop_vsp_pump(slot_id=3)
+
+        params = mock_request.call_args[1]["params"]
+        assert params["command"] == IAQUA_COMMAND_SET_VSP_SPEED
+        assert params["slot_id"] == "3"
+        assert params["speed_id"] == "1"
+        assert params["on_off_action"] == "off"
+        assert params["actionID"] == "command"
+        assert params["serial"] == sut.serial
+
+    @patch("httpx.AsyncClient.request")
+    async def test_vsp_request_retries_after_reauth(self, mock_request) -> None:
+        client, sut = _make_iaqua_system()
+        auth_resp = MagicMock()
+        auth_resp.status_code = 200
+        auth_resp.json.return_value = {}
+
+        mock_request.side_effect = [
+            MagicMock(status_code=401),
+            auth_resp,
+        ]
+        client.client_id = "old-session-id"
+        client.id_token = "old-id-token"
+
+        async def fake_refresh() -> None:
+            client.client_id = "new-session-id"
+            client.id_token = "new-id-token"
+
+        with patch.object(
+            client, "_refresh_auth", side_effect=fake_refresh
+        ) as mock_refresh:
+            await sut.get_vsp_speed(slot_id=1)
+
+        retry_kwargs = mock_request.call_args_list[1][1]
+        mock_refresh.assert_awaited_once()
+        assert retry_kwargs["params"]["sessionID"] == "new-session-id"
+        assert retry_kwargs["headers"]["Authorization"] == "Bearer new-id-token"

--- a/tests/systems/iaqua/test_system.py
+++ b/tests/systems/iaqua/test_system.py
@@ -1372,6 +1372,37 @@ class TestIaquaSystem:
         assert isinstance(sut.devices["vsp_pump_5"], IaquaVSPump)
         assert sut._vsp_discovered is True
 
+    async def test_refresh_without_is_vsp_skips_discovery(self) -> None:
+        _, sut = _make_iaqua_system()
+        assert sut.is_vsp is False
+
+        with (
+            patch.object(
+                sut, "_send_home_screen_request", return_value=MagicMock()
+            ),
+            patch.object(
+                sut, "_parse_home_response", side_effect=_set_online_for(sut)
+            ),
+            patch.object(
+                sut,
+                "_send_devices_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_devices_response"),
+            patch.object(
+                sut,
+                "_send_onetouch_screen_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(sut, "_parse_onetouch_response"),
+            patch.object(sut, "get_vsp_names") as get_vsp_names,
+        ):
+            await sut.refresh()
+
+        get_vsp_names.assert_not_called()
+        assert sut._vsp_discovered is False
+        assert not any(k.startswith("vsp_pump_") for k in sut.devices)
+
     async def test_refresh_vsp_pumps_empty_discovery(self) -> None:
         _, sut = _make_iaqua_system()
         with (


### PR DESCRIPTION
## Summary

- Adds `IaquaVSPump` device class backed by `AqualinkFan` base — exposes speed presets (`preset_modes`/`preset_mode`), `set_preset_mode()`, on/off (no percentage/RPM control)
- Pump discovery via `isVSP` flag in the master device list (falls back to `get_vsp_appmodelserials()` if none found) — one-shot per session, guarded by `_vsp_discovered`. Already-discovered pumps get their speed presets refreshed wholesale via `fetch_speed()` on every subsequent `refresh()` cycle, so a partial-echo write can't leave stale local state indefinitely
- VSP refresh is best-effort: a failure in VSP discovery/speed-refresh is logged and skipped rather than flipping the whole system to `DISCONNECTED` — retried on the next `refresh()` cycle
- `get_master_device_list` pagination (`count`/`totalCount`) isn't followed (no documented param to request page 2+), but a partial page now logs a warning so under-discovery is diagnosable
- New system methods: `get_vsp_speed`, `set_vsp_speed`, `stop_vsp_pump`, `get_vsp_names`, `get_vsp_appmodelserials` — all route through the existing `_send_session_request()` (already wrapped in `_send_with_reauth_retry`), same as every other iaqua command
- Wire protocol documented in `docs/reference/systems/iaqua.md` (VSP subsection); design decisions in `docs/implementation/systems/iaqua.md`; API autodoc entry in `docs/api/systems/iaqua.md`

## Test plan

- [x] `uv run pytest` — all tests pass
- [x] `uv run mypy src/` — clean
- [x] `uv run prek run --all-files` — clean
- [x] `IaquaVSPump` covered by `TestIaquaVSPump` (preset fetch/set, slot_id routing, empty-preset contract)
- [x] VSP system methods covered in `TestIaquaSystem` (URL, params, auth headers, reauth, discovery + fallback + skip-existing + empty-discovery, is_vsp gating, periodic speed-refresh, best-effort failure handling, partial-page warning)
- [x] `IaquaVSPump` plugged into the cross-system `AqualinkFan` conformance suite (`tests/conformance/test_fan.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
