### PR TITLE
feat(cli): add get/logout commands, fix device display, add CLI docs

### DIFF
--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -142,6 +142,7 @@ All devices inherit these properties from `AqualinkDevice`:
 | `preset_modes` | `list[str]` | Available preset names |
 | `supports_presets` | `bool` | `True` if preset modes are available |
 | `set_preset_mode(preset_mode)` | async | Activate a preset (validates name) |
+| `percentage` | `int \| None` | Current speed as a percentage (0–100); `None` if unavailable |
 | `supports_percentage` | `bool` | `True` if speed percentage control is available |
 | `set_percentage(percentage)` | async | Set speed 0–100% (validates range) |
 

--- a/docs/getting-started/.nav.yml
+++ b/docs/getting-started/.nav.yml
@@ -1,4 +1,5 @@
 nav:
   - Installation: installation.md
+  - CLI: cli.md
   - Home Assistant: home-assistant.md
   - Programmatic Use: quickstart.md

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -1,0 +1,251 @@
+# CLI Reference
+
+The `iaqualink` command-line client lets you inspect and control your pool systems without writing Python code. It is also useful for scripting and automation.
+
+## Installation
+
+The CLI requires optional dependencies. Install them with the `cli` extra:
+
+```bash
+pip install "iaqualink[cli]"
+```
+
+## Configuration
+
+Credentials can be supplied in three ways (highest priority first):
+
+| Method | How |
+|---|---|
+| CLI flags | `--username USER --password PASS` |
+| Environment variables | `IAQUALINK_USERNAME`, `IAQUALINK_PASSWORD` |
+| Config file | `~/.config/iaqualink/config.yaml` |
+
+Config file format:
+
+```yaml
+username: user@example.com
+password: your_password
+```
+
+The config file and session jar are stored in `~/.config/iaqualink/` on Linux/macOS and in the platform app-data directory on Windows.
+
+## Session Management
+
+After the first successful login the session token is saved to `~/.config/iaqualink/session.json`. Subsequent commands reuse it without reauthenticating. The session is refreshed automatically if it has expired.
+
+To force a fresh login:
+
+```bash
+iaqualink logout
+```
+
+To use a custom session file location:
+
+```bash
+iaqualink --cookie-jar /path/to/session.json status
+```
+
+## Global Flags
+
+These flags apply to every command and must be placed before the command name:
+
+| Flag | Description |
+|---|---|
+| `--debug` | Enable debug logging to stderr |
+| `--version` | Show the installed version and exit |
+| `--capture FILE` | Write all HTTP traffic (redacted) to a JSONL file |
+
+```bash
+iaqualink --debug status
+iaqualink --capture traffic.jsonl status
+```
+
+## Commands
+
+### `list-systems`
+
+List all systems on the account.
+
+```bash
+iaqualink list-systems
+```
+
+Output:
+
+```
+● My Pool (ABC123456) [iaqua] online
+● Spa Controller (XYZ789) [exo] online
+```
+
+---
+
+### `list-devices`
+
+List all devices for a system, grouped by type.
+
+```bash
+iaqualink list-devices
+iaqualink list-devices --system ABC123456
+```
+
+---
+
+### `status`
+
+Show system status with current device states. Without `--system`, shows all systems.
+
+```bash
+iaqualink status
+iaqualink status --system ABC123456
+```
+
+Output:
+
+```
+Systems
+└── ● My Pool (ABC123456) [iaqua] online
+    ├── 🌡️ Climate
+    │   └── Pool Heater [pool_heater]: 78°F → 82°F (on)
+    ├── 💡 Lights
+    │   └── Pool Light [aux_3]: on
+    ├── ⚡ Switches
+    │   └── Spa Jets [aux_1]: off
+    └── 📊 Sensors
+        └── Pool Temp [pool_temp]: 78°F
+```
+
+---
+
+### `get`
+
+Print the current state of a single device. Useful for scripting.
+
+```bash
+iaqualink get pool_temp
+iaqualink get "Pool Temp"
+```
+
+Devices can be identified by key (e.g., `pool_temp`) or label (e.g., `Pool Temp`). Labels are matched case-insensitively.
+
+---
+
+### `turn-on` / `turn-off`
+
+Turn a device on or off. Works with switches, lights, climate zones, and fans/pumps.
+
+```bash
+iaqualink turn-on aux_1
+iaqualink turn-off "Pool Light"
+iaqualink turn-on pool_heater --system ABC123456
+```
+
+---
+
+### `set-temperature`
+
+Set the target temperature on a climate zone (heater/chiller).
+
+```bash
+iaqualink set-temperature pool_heater 82
+iaqualink set-temperature spa_heater 104
+```
+
+The unit (°F or °C) matches the system configuration.
+
+---
+
+### `set-brightness`
+
+Set the brightness of a dimmable light (0–100%).
+
+```bash
+iaqualink set-brightness aux_3 75
+```
+
+Returns an error if the light does not support brightness control.
+
+---
+
+### `set-effect`
+
+Set the color effect on a color light.
+
+```bash
+iaqualink set-effect aux_3 "Alpine White"
+iaqualink set-effect aux_3 "Voodoo Lounge"
+```
+
+Use `status` to see the current effect. Available effects depend on the light model.
+
+---
+
+### `set-speed`
+
+Set the speed of a fan/pump as a percentage (0–100%).
+
+```bash
+iaqualink set-speed pump 65
+```
+
+Returns an error if the device does not support speed control.
+
+---
+
+### `set-preset`
+
+Set a named preset mode on a fan/pump.
+
+```bash
+iaqualink set-preset pump SCHEDULE
+iaqualink set-preset pump CUSTOM
+iaqualink set-preset pump STOP
+```
+
+Available presets depend on the device. Use `status` to see the current preset.
+
+---
+
+### `set-value`
+
+Set a numeric value on a Number device.
+
+```bash
+iaqualink set-value target_chlorine 3.0
+```
+
+The command validates the value against the device's configured minimum, maximum, and step.
+
+---
+
+### `logout`
+
+Remove the saved session and force fresh authentication on the next command.
+
+```bash
+iaqualink logout
+```
+
+## Device Type Reference
+
+The table below shows which commands apply to each device type.
+
+| Device type | `get` | `turn-on/off` | `set-temperature` | `set-brightness` | `set-effect` | `set-speed` | `set-preset` | `set-value` |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Sensor | ✓ | — | — | — | — | — | — | — |
+| Binary Sensor | ✓ | — | — | — | — | — | — | — |
+| Switch | ✓ | ✓ | — | — | — | — | — | — |
+| Light | ✓ | ✓ | — | ✓ (if supported) | ✓ (if supported) | — | — | — |
+| Climate | ✓ | ✓ | ✓ | — | — | — | — | — |
+| Number | ✓ | — | — | — | — | — | — | ✓ |
+| Fan / Pump | ✓ | ✓ (if supported) | — | — | — | ✓ (if supported) | ✓ (if supported) | — |
+
+## Multiple Systems
+
+If your account has more than one system you must specify which one to use with `--system`. The value can be the serial number or the system name:
+
+```bash
+iaqualink status --system ABC123456
+iaqualink turn-on pool_light --system "My Pool"
+```
+
+Without `--system`, commands that operate on a single device will error if multiple systems are found.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -21,16 +21,18 @@ async with AqualinkClient('user@example.com', 'password') as client:
 ### Getting Devices
 
 ```python
+from iaqualink.device import AqualinkSensor, AqualinkSwitch
+
 # Get all devices for a system
 devices = await system.get_devices()
 
 # Access specific devices
 pool_temp = devices.get('pool_temp')
-if pool_temp:
-    print(f"Pool temperature: {pool_temp.state}°F")
+if isinstance(pool_temp, AqualinkSensor):
+    print(f"Pool temperature: {pool_temp.value}°F")
 
 spa_heater = devices.get('spa_heater')
-if spa_heater:
+if isinstance(spa_heater, AqualinkSwitch):
     print(f"Spa heater: {'ON' if spa_heater.is_on else 'OFF'}")
 ```
 
@@ -53,42 +55,46 @@ if spa_heater:
 #### Lights
 
 ```python
-# Toggle pool light
+from iaqualink.device import AqualinkLight
+
 pool_light = devices.get('aux_3')
-if pool_light:
-    await pool_light.toggle()
+if isinstance(pool_light, AqualinkLight):
+    await pool_light.turn_on()
 ```
 
 #### Thermostats
 
 ```python
+from iaqualink.device import AqualinkClimate
+
 # Set spa temperature
-spa_thermostat = devices.get('spa_set_point')
-if spa_thermostat:
-    await spa_thermostat.set_temperature(102)
+spa_heater = devices.get('spa_set_point')
+if isinstance(spa_heater, AqualinkClimate):
+    await spa_heater.set_temperature(102)
 
 # Set pool temperature
-pool_thermostat = devices.get('pool_set_point')
-if pool_thermostat:
-    await pool_thermostat.set_temperature(82)
+pool_heater = devices.get('pool_set_point')
+if isinstance(pool_heater, AqualinkClimate):
+    await pool_heater.set_temperature(82)
 ```
 
 ### Monitoring System Status
 
 ```python
-# Update system state
-await system.update()
-
-# Check if system is online
+from iaqualink.device import AqualinkSensor
 from iaqualink.system import SystemStatus
 
+# Refresh system state
+await system.refresh()
+
+# Check if system is online
 if system.status is SystemStatus.ONLINE:
     print(f"System {system.name} is online")
 
     # Get all temperature readings
     for device_name, device in devices.items():
-        if 'temp' in device_name and device.state:
-            print(f"{device.label}: {device.state}°")
+        if isinstance(device, AqualinkSensor) and device.value:
+            print(f"{device.label}: {device.value}")
 ```
 
 ## Working with Multiple Systems
@@ -127,6 +133,7 @@ except AqualinkServiceException as e:
 
 ## Next Steps
 
+- [CLI Reference](cli.md) — command-line client for scripting and quick control
 - [API Reference](../api/client.md) — `AqualinkClient` class reference
 - [Architecture](../contributing/architecture.md) — system/device hierarchy and data flow
 - [Protocol Reference](../reference/client.md) — wire-level auth and endpoint details

--- a/docs/implementation/systems/i2d.md
+++ b/docs/implementation/systems/i2d.md
@@ -66,7 +66,9 @@ RPM numbers (except `globalrpmmin`/`globalrpmmax`) use `globalrpmmin`/`globalrpm
 - Non-SVRS products: 600 RPM
 - SVRS products (0F/18): 1050 RPM
 
-Speed percentage mapping: `set_speed_percentage(0–100)` normalises to the hardware RPM range, rounded to the nearest 25 RPM.
+Speed percentage read: `I2dFan.percentage` computes `round((rpm - rpm_min) / (rpm_max - rpm_min) * 100)` from `customspeedrpm` and the global RPM bounds. Returns `None` if `customspeedrpm` is absent or bounds are degenerate (`rpm_max <= rpm_min`).
+
+Speed percentage write: `set_percentage(0–100)` normalises to the hardware RPM range, rounded to the nearest 25 RPM.
 
 ### Period/timer numbers
 

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -311,7 +311,7 @@ def _format_device_line(device_name: str, device: AqualinkDevice) -> Text:
         on_off = "on" if device.is_on else "off"
         cur = device.current_temperature
         tgt = device.target_temperature
-        unit = device.temperature_unit
+        unit = f"°{device.temperature_unit}"
         if cur is not None and tgt is not None:
             state_str = f"{cur}{unit} → {tgt}{unit} ({on_off})"
         elif cur is not None:
@@ -749,7 +749,7 @@ async def _set_temperature(
     t.append("Set ")
     t.append(device.label, style="bold")
     t.append(f" [{device_name}]", style="dim")
-    t.append(f" to {temperature}{device.temperature_unit} on ")
+    t.append(f" to {temperature}°{device.temperature_unit} on ")
     t.append_text(_format_system_line(system))
     return t
 

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -295,16 +295,31 @@ def _format_device_line(device_name: str, device: AqualinkDevice) -> Text:
         state_str: str | None = device.value
         translated: str | None = device.value_translated
     elif isinstance(device, AqualinkFan):
-        if device.supports_presets:
-            state_str = device.preset_mode
-        elif device.supports_turn_on or device.supports_turn_off:
-            state_str = "on" if device.is_on else "off"
+        parts: list[str] = []
+        if device.supports_presets and device.preset_mode:
+            parts.append(device.preset_mode)
+        if device.supports_percentage:
+            pct = device.percentage
+            if pct is not None:
+                parts.append(f"{pct}%")
+        if not parts:
+            if device.supports_turn_on or device.supports_turn_off:
+                parts.append("on" if device.is_on else "off")
+        state_str = " / ".join(parts) if parts else None
+        translated = None
+    elif isinstance(device, AqualinkClimate):
+        on_off = "on" if device.is_on else "off"
+        cur = device.current_temperature
+        tgt = device.target_temperature
+        unit = device.temperature_unit
+        if cur is not None and tgt is not None:
+            state_str = f"{cur}{unit} → {tgt}{unit} ({on_off})"
         else:
-            state_str = None
+            state_str = on_off
         translated = None
     elif isinstance(
         device,
-        (AqualinkSwitch, AqualinkBinarySensor, AqualinkLight, AqualinkClimate),
+        (AqualinkSwitch, AqualinkBinarySensor, AqualinkLight),
     ):
         state_str = "on" if device.is_on else "off"
         translated = None
@@ -312,7 +327,7 @@ def _format_device_line(device_name: str, device: AqualinkDevice) -> Text:
         cv = device.current_value
         if cv is not None:
             unit = device.unit_of_measurement
-            state_str = f"{int(cv)} {unit}" if unit else str(int(cv))
+            state_str = f"{cv:g} {unit}" if unit else f"{cv:g}"
         else:
             state_str = None
         translated = None
@@ -1030,3 +1045,47 @@ def set_value(
             _set_number_value(credentials, system, device, value, cookie_jar)
         )
     )
+
+
+async def _get_device_state(
+    credentials: Credentials,
+    system_selector: str | None,
+    device_selector: str,
+    cookie_jar: Path,
+) -> Text:
+    systems = await _fetch_systems(credentials, cookie_jar)
+    system = _resolve_system(systems, system_selector)
+    devices = await _load_devices_for_system(system)
+    device_name, device = _resolve_device(devices, device_selector)
+    _save_session_jar(cookie_jar, system.aqualink.auth_state)
+    return _format_device_line(device_name, device)
+
+
+@app.command("get")
+def get(
+    device: DeviceArgument,
+    username: UsernameOption = None,
+    password: PasswordOption = None,
+    config: ConfigOption = DEFAULT_CONFIG_PATH,
+    system: SystemOption = None,
+    cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
+) -> None:
+    """Print the current state of a single device."""
+    credentials = _resolve_credentials(username, password, config)
+    _console.print(
+        _run_async(_get_device_state(credentials, system, device, cookie_jar))
+    )
+
+
+@app.command("logout")
+def logout(
+    cookie_jar: CookieJarOption = DEFAULT_COOKIE_JAR,
+) -> None:
+    """Remove the saved session cookie jar and force fresh authentication."""
+    if cookie_jar.exists():
+        cookie_jar.unlink()
+        _console.print(
+            f"[bold green]✓[/bold green] Removed session jar {cookie_jar}"
+        )
+    else:
+        _console.print(f"[dim]No session jar found at {cookie_jar}[/dim]")

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -314,6 +314,8 @@ def _format_device_line(device_name: str, device: AqualinkDevice) -> Text:
         unit = device.temperature_unit
         if cur is not None and tgt is not None:
             state_str = f"{cur}{unit} → {tgt}{unit} ({on_off})"
+        elif cur is not None:
+            state_str = f"{cur}{unit} ({on_off})"
         else:
             state_str = on_off
         translated = None

--- a/src/iaqualink/cli/app.py
+++ b/src/iaqualink/cli/app.py
@@ -308,16 +308,18 @@ def _format_device_line(device_name: str, device: AqualinkDevice) -> Text:
         state_str = " / ".join(parts) if parts else None
         translated = None
     elif isinstance(device, AqualinkClimate):
-        on_off = "on" if device.is_on else "off"
-        cur = device.current_temperature
-        tgt = device.target_temperature
-        unit = f"°{device.temperature_unit}"
-        if cur is not None and tgt is not None:
-            state_str = f"{cur}{unit} → {tgt}{unit} ({on_off})"
-        elif cur is not None:
-            state_str = f"{cur}{unit} ({on_off})"
+        if device.is_on:
+            cur = device.current_temperature
+            tgt = device.target_temperature
+            unit = f"°{device.temperature_unit}"
+            if cur is not None and tgt is not None:
+                state_str = f"{cur}{unit} → {tgt}{unit} (on)"
+            elif cur is not None:
+                state_str = f"{cur}{unit} (on)"
+            else:
+                state_str = "on"
         else:
-            state_str = on_off
+            state_str = "off"
         translated = None
     elif isinstance(
         device,

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -215,13 +215,13 @@ class AqualinkClimate(AqualinkDevice):
 
     @property
     @abstractmethod
-    def current_temperature(self) -> str:
-        """Current measured temperature."""
+    def current_temperature(self) -> str | None:
+        """Current measured temperature, or None if unavailable."""
 
     @property
     @abstractmethod
-    def target_temperature(self) -> str:
-        """Desired set-point temperature."""
+    def target_temperature(self) -> str | None:
+        """Desired set-point temperature, or None if unavailable."""
 
     @property
     @abstractmethod

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -369,6 +369,11 @@ class AqualinkFan(AqualinkDevice):
     def supports_percentage(self) -> bool:
         return False
 
+    @property
+    def percentage(self) -> int | None:
+        """Current speed as a percentage (0–100), or None if unknown."""
+        return None
+
     async def _set_percentage(self, percentage: int) -> None:
         """Send the speed percentage to the device."""
         raise NotImplementedError

--- a/src/iaqualink/systems/i2d/device.py
+++ b/src/iaqualink/systems/i2d/device.py
@@ -212,6 +212,15 @@ class I2dFan(I2dDevice, AqualinkFan):
     def supports_percentage(self) -> bool:
         return True
 
+    @property
+    def percentage(self) -> int | None:
+        rpm = self.custom_speed_rpm
+        rpm_min = self.rpm_min or _RPM_HARDWARE_MIN_DEFAULT
+        rpm_max = self.rpm_max or _RPM_HARDWARE_MAX
+        if rpm is None or rpm_max <= rpm_min:
+            return None
+        return round((rpm - rpm_min) / (rpm_max - rpm_min) * 100)
+
     async def _set_percentage(self, percentage: int) -> None:
         rpm_min = self.rpm_min or _RPM_HARDWARE_MIN_DEFAULT
         rpm_max = self.rpm_max or _RPM_HARDWARE_MAX

--- a/src/iaqualink/systems/i2d/device.py
+++ b/src/iaqualink/systems/i2d/device.py
@@ -219,7 +219,9 @@ class I2dFan(I2dDevice, AqualinkFan):
         rpm_max = self.rpm_max or _RPM_HARDWARE_MAX
         if rpm is None or rpm_max <= rpm_min:
             return None
-        return round((rpm - rpm_min) / (rpm_max - rpm_min) * 100)
+        return max(
+            0, min(100, round((rpm - rpm_min) / (rpm_max - rpm_min) * 100))
+        )
 
     async def _set_percentage(self, percentage: int) -> None:
         rpm_min = self.rpm_min or _RPM_HARDWARE_MIN_DEFAULT

--- a/src/iaqualink/systems/iaqua/device.py
+++ b/src/iaqualink/systems/iaqua/device.py
@@ -418,8 +418,9 @@ class IaquaClimate(IaquaSwitch, AqualinkClimate):
         return cast(IaquaSensor, self.system.devices[f"{self._type}_temp"])
 
     @property
-    def current_temperature(self) -> str:
-        return self._sensor.value
+    def current_temperature(self) -> str | None:
+        value = self._sensor.value
+        return value if value else None
 
     @property
     def target_temperature(self) -> str:

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -226,6 +226,7 @@ def make_fan(
     supports_turn_on: bool = False,
     supports_turn_off: bool = False,
     supports_percentage: bool = False,
+    percentage: int | None = None,
     supports_presets: bool = False,
     presets: list[str] | None = None,
     preset_mode: str | None = None,
@@ -237,6 +238,7 @@ def make_fan(
     m.supports_turn_on = supports_turn_on
     m.supports_turn_off = supports_turn_off
     m.supports_percentage = supports_percentage
+    m.percentage = percentage
     m.supports_presets = supports_presets
     m.preset_modes = presets or []
     m.preset_mode = preset_mode
@@ -265,7 +267,7 @@ def make_climate(
     label: str = "Heater",
     *,
     is_on: bool = True,
-    temperature_unit: str = "°F",
+    temperature_unit: str = "F",
     min_temp: int = 40,
     max_temp: int = 104,
     current_temperature: int | None = None,

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -265,9 +265,11 @@ def make_climate(
     label: str = "Heater",
     *,
     is_on: bool = True,
-    temperature_unit: str = "F",
+    temperature_unit: str = "°F",
     min_temp: int = 40,
     max_temp: int = 104,
+    current_temperature: int | None = None,
+    target_temperature: int | None = None,
 ) -> AqualinkClimate:
     m = create_autospec(AqualinkClimate, instance=True)
     m.label = m.name = label
@@ -276,4 +278,6 @@ def make_climate(
     m.temperature_unit = temperature_unit
     m.min_temp = min_temp
     m.max_temp = max_temp
+    m.current_temperature = current_temperature
+    m.target_temperature = target_temperature
     return m

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -270,8 +270,8 @@ def make_climate(
     temperature_unit: str = "F",
     min_temp: int = 40,
     max_temp: int = 104,
-    current_temperature: int | None = None,
-    target_temperature: int | None = None,
+    current_temperature: str | None = None,
+    target_temperature: str | None = None,
 ) -> AqualinkClimate:
     m = create_autospec(AqualinkClimate, instance=True)
     m.label = m.name = label

--- a/tests/cli/test_climate.py
+++ b/tests/cli/test_climate.py
@@ -30,6 +30,15 @@ def test_format_device_line_climate_cur_only_shows_cur() -> None:
     assert "on" in text.plain
 
 
+def test_format_device_line_climate_off_hides_temps() -> None:
+    thermostat = make_climate(
+        current_temperature="86", target_temperature="86", is_on=False
+    )
+    text = cli_module._format_device_line("heater", thermostat)
+    assert "off" in text.plain
+    assert "86" not in text.plain
+
+
 def test_format_device_line_climate_without_temps_shows_on_off() -> None:
     thermostat = make_climate(is_on=False)
     text = cli_module._format_device_line("heater", thermostat)

--- a/tests/cli/test_climate.py
+++ b/tests/cli/test_climate.py
@@ -23,6 +23,13 @@ def test_format_device_line_climate_with_temps() -> None:
     assert "on" in text.plain
 
 
+def test_format_device_line_climate_cur_only_shows_cur() -> None:
+    thermostat = make_climate(current_temperature=78, is_on=True)
+    text = cli_module._format_device_line("heater", thermostat)
+    assert "78" in text.plain
+    assert "on" in text.plain
+
+
 def test_format_device_line_climate_without_temps_shows_on_off() -> None:
     thermostat = make_climate(is_on=False)
     text = cli_module._format_device_line("heater", thermostat)

--- a/tests/cli/test_climate.py
+++ b/tests/cli/test_climate.py
@@ -3,12 +3,30 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import iaqualink.cli.app as cli_module
+
 from .conftest import (
     FakeClient,
     FakeSystemWithAqualink,
     invoke_with_jar,
     make_climate,
 )
+
+
+def test_format_device_line_climate_with_temps() -> None:
+    thermostat = make_climate(
+        current_temperature=78, target_temperature=82, is_on=True
+    )
+    text = cli_module._format_device_line("heater", thermostat)
+    assert "78" in text.plain
+    assert "82" in text.plain
+    assert "on" in text.plain
+
+
+def test_format_device_line_climate_without_temps_shows_on_off() -> None:
+    thermostat = make_climate(is_on=False)
+    text = cli_module._format_device_line("heater", thermostat)
+    assert "off" in text.plain
 
 
 def test_set_temperature_saves_jar_after_command(tmp_path: Path) -> None:

--- a/tests/cli/test_climate.py
+++ b/tests/cli/test_climate.py
@@ -15,18 +15,18 @@ from .conftest import (
 
 def test_format_device_line_climate_with_temps() -> None:
     thermostat = make_climate(
-        current_temperature=78, target_temperature=82, is_on=True
+        current_temperature="78", target_temperature="82", is_on=True
     )
     text = cli_module._format_device_line("heater", thermostat)
-    assert "78" in text.plain
-    assert "82" in text.plain
+    assert "78°F" in text.plain
+    assert "82°F" in text.plain
     assert "on" in text.plain
 
 
 def test_format_device_line_climate_cur_only_shows_cur() -> None:
-    thermostat = make_climate(current_temperature=78, is_on=True)
+    thermostat = make_climate(current_temperature="78", is_on=True)
     text = cli_module._format_device_line("heater", thermostat)
-    assert "78" in text.plain
+    assert "78°F" in text.plain
     assert "on" in text.plain
 
 

--- a/tests/cli/test_fan.py
+++ b/tests/cli/test_fan.py
@@ -47,6 +47,20 @@ def test_format_device_line_fan_no_controls_shows_dim() -> None:
     assert ": " not in text.plain
 
 
+def test_format_device_line_fan_preset_and_percentage() -> None:
+    fan = make_fan(
+        "VSP",
+        supports_presets=True,
+        presets=["CUSTOM"],
+        preset_mode="CUSTOM",
+        supports_percentage=True,
+        percentage=65,
+    )
+    text = cli_module._format_device_line("vsp", fan)
+    assert "CUSTOM" in text.plain
+    assert "65%" in text.plain
+
+
 # ---------------------------------------------------------------------------
 # turn-on / turn-off
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_session.py
+++ b/tests/cli/test_session.py
@@ -14,6 +14,7 @@ from .conftest import (
     FakeSystemWithAqualink,
     app,
     invoke_with_jar,
+    make_switch,
     make_unsupported_system,
     render_plain,
 )
@@ -217,3 +218,57 @@ def test_status_saves_jar_after_device_load(tmp_path: Path) -> None:
     assert result.exit_code == 0
     data = json.loads(cookie_jar.read_text())
     assert data["client_id"] == "post-device-session"
+
+
+# ---------------------------------------------------------------------------
+# get command
+# ---------------------------------------------------------------------------
+
+
+def test_get_device_prints_state(tmp_path: Path) -> None:
+    switch = make_switch("Filter", is_on=True)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"filter": switch})
+        }
+    )
+    result, _ = invoke_with_jar(tmp_path, "get", "filter")
+    assert result.exit_code == 0
+    assert "Filter" in result.output
+
+
+def test_get_device_saves_jar(tmp_path: Path) -> None:
+    switch = make_switch("Filter", is_on=True)
+    FakeClient.systems_factory = staticmethod(
+        lambda: {
+            "SN001": FakeSystemWithAqualink("SN001", "Pool", {"filter": switch})
+        }
+    )
+    result, cookie_jar = invoke_with_jar(tmp_path, "get", "filter")
+    assert result.exit_code == 0
+    data = json.loads(cookie_jar.read_text())
+    assert data["client_id"] == "post-device-session"
+
+
+# ---------------------------------------------------------------------------
+# logout command
+# ---------------------------------------------------------------------------
+
+
+def test_logout_removes_existing_jar(tmp_path: Path) -> None:
+    cookie_jar = tmp_path / "session.json"
+    cookie_jar.write_text("{}")
+    result = CliRunner().invoke(
+        app, ["logout", "--cookie-jar", str(cookie_jar)]
+    )
+    assert result.exit_code == 0
+    assert not cookie_jar.exists()
+
+
+def test_logout_missing_jar_prints_message(tmp_path: Path) -> None:
+    cookie_jar = tmp_path / "session.json"
+    result = CliRunner().invoke(
+        app, ["logout", "--cookie-jar", str(cookie_jar)]
+    )
+    assert result.exit_code == 0
+    assert "No session jar found" in result.output

--- a/tests/systems/i2d/__snapshots__/test_parsing.ambr
+++ b/tests/systems/i2d/__snapshots__/test_parsing.ambr
@@ -4,6 +4,7 @@
     'ABC123': dict({
       'is_on': True,
       'label': 'IQPump',
+      'percentage': 32,
       'preset_mode': 'SCHEDULE',
       'preset_modes': list([
         'SCHEDULE',

--- a/tests/systems/i2d/test_device.py
+++ b/tests/systems/i2d/test_device.py
@@ -157,6 +157,66 @@ class TestI2dFanContract(TestBaseFan):
         self.respx_calls = respx_mock.calls[:]
 
 
+def _make_fan_with_data(data: dict) -> I2dFan:
+    system = I2dSystem.from_data(MagicMock(), _CONTRACT_SYSTEM_DATA)
+    return I2dFan(system, data)
+
+
+class TestI2dFanPercentage(unittest.IsolatedAsyncioTestCase):
+    def test_mid_range(self) -> None:
+        fan = _make_fan_with_data(
+            {
+                "customspeedrpm": "1500",
+                "globalrpmmin": "600",
+                "globalrpmmax": "3450",
+            }
+        )
+        assert fan.percentage == 32  # (1500-600)/(3450-600)*100 = 31.57 → 32
+
+    def test_at_min(self) -> None:
+        fan = _make_fan_with_data(
+            {
+                "customspeedrpm": "600",
+                "globalrpmmin": "600",
+                "globalrpmmax": "3450",
+            }
+        )
+        assert fan.percentage == 0
+
+    def test_at_max(self) -> None:
+        fan = _make_fan_with_data(
+            {
+                "customspeedrpm": "3450",
+                "globalrpmmin": "600",
+                "globalrpmmax": "3450",
+            }
+        )
+        assert fan.percentage == 100
+
+    def test_none_when_rpm_missing(self) -> None:
+        fan = _make_fan_with_data(
+            {"globalrpmmin": "600", "globalrpmmax": "3450"}
+        )
+        assert fan.percentage is None
+
+    def test_none_when_min_equals_max(self) -> None:
+        fan = _make_fan_with_data(
+            {
+                "customspeedrpm": "1500",
+                "globalrpmmin": "1500",
+                "globalrpmmax": "1500",
+            }
+        )
+        assert fan.percentage is None
+
+    def test_uses_hardware_default_min_when_key_absent(self) -> None:
+        # rpm_min defaults to _RPM_HARDWARE_MIN_DEFAULT (600) when globalrpmmin absent
+        fan = _make_fan_with_data(
+            {"customspeedrpm": "600", "globalrpmmax": "3450"}
+        )
+        assert fan.percentage == 0
+
+
 def _make_sensor(
     data: dict,
     key: str = "speed",

--- a/tests/systems/i2d/test_device.py
+++ b/tests/systems/i2d/test_device.py
@@ -216,6 +216,26 @@ class TestI2dFanPercentage(unittest.IsolatedAsyncioTestCase):
         )
         assert fan.percentage == 0
 
+    def test_clamped_to_100_when_rpm_above_max(self) -> None:
+        fan = _make_fan_with_data(
+            {
+                "customspeedrpm": "4000",
+                "globalrpmmin": "600",
+                "globalrpmmax": "3450",
+            }
+        )
+        assert fan.percentage == 100
+
+    def test_clamped_to_0_when_rpm_below_min(self) -> None:
+        fan = _make_fan_with_data(
+            {
+                "customspeedrpm": "100",
+                "globalrpmmin": "600",
+                "globalrpmmax": "3450",
+            }
+        )
+        assert fan.percentage == 0
+
 
 def _make_sensor(
     data: dict,

--- a/tests/systems/iaqua/__snapshots__/test_parsing.ambr
+++ b/tests/systems/iaqua/__snapshots__/test_parsing.ambr
@@ -261,7 +261,7 @@
       'value_translated': None,
     }),
     'spa_set_point': dict({
-      'current_temperature': '',
+      'current_temperature': None,
       'is_on': False,
       'label': 'Spa Set Point',
       'target_temperature': '54',
@@ -379,7 +379,7 @@
       'value_translated': None,
     }),
     'spa_set_point': dict({
-      'current_temperature': '',
+      'current_temperature': None,
       'is_on': False,
       'label': 'Spa Set Point',
       'target_temperature': '54',


### PR DESCRIPTION
## Summary

- Add `get DEVICE` command — single-device state read, scripting-friendly
- Add `logout` command — removes session jar, forces fresh auth on next run
- Fix Climate display: now shows `78°F → 82°F (on)` instead of just `on`
- Fix Fan display: shows preset + speed % together (e.g. `CUSTOM / 65%`)
- Fix Number display: use `:g` format instead of `int()` to preserve floats
- Add `percentage` getter to `AqualinkFan` base class; override in `I2dFan` to compute from `custom_speed_rpm`
- New `docs/getting-started/cli.md` — full CLI user guide (installation, config, session management, all commands, device-type reference table)
- Fix stale API in `quickstart.md`: `.state` → `.value`, `.toggle()` → `.turn_on()`, `system.update()` → `system.refresh()`

## Test plan

- [ ] `uv run prek run --all-files` passes
- [ ] `uv run pytest` passes (901 tests)
- [ ] `uv run mypy src/` passes
- [ ] Manual: `iaqualink status` shows temp info for climate devices
- [ ] Manual: `iaqualink get <device>` prints single device line
- [ ] Manual: `iaqualink logout` removes session jar

🤖 Generated with [Claude Code](https://claude.com/claude-code)