### PR TITLE
feat: expose public top-level API via iaqualink.__init__

### DIFF
--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -241,7 +241,7 @@ for name, device in devices.items():
     print(f"{name}: {device.label}")
 
 # Filter by type
-from iaqualink.device import AqualinkSensor
+from iaqualink import AqualinkSensor
 sensors = {k: v for k, v in devices.items() if isinstance(v, AqualinkSensor)}
 ```
 

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -46,10 +46,8 @@ AqualinkException (base)
 ### Basic Error Handling
 
 ```python
-from iaqualink import (
-    AqualinkClient,
-    AqualinkException,
-)
+from iaqualink import AqualinkClient
+from iaqualink.exception import AqualinkException
 
 try:
     async with AqualinkClient(username, password) as client:
@@ -64,8 +62,7 @@ System availability is exposed through `system.status` rather than exceptions.
 Check it after `refresh()` before interacting with devices:
 
 ```python
-from iaqualink import AqualinkClient
-from iaqualink.system import SystemStatus
+from iaqualink import AqualinkClient, SystemStatus
 
 async with AqualinkClient(username, password) as client:
     systems = await client.get_systems()
@@ -82,7 +79,7 @@ async with AqualinkClient(username, password) as client:
 
 ```python
 import asyncio
-from iaqualink import AqualinkServiceException
+from iaqualink.exception import AqualinkServiceException
 
 async def refresh_with_retry(system, max_retries=3):
     for attempt in range(max_retries):
@@ -101,7 +98,7 @@ async def refresh_with_retry(system, max_retries=3):
 ### Graceful Degradation
 
 ```python
-from iaqualink.system import SystemStatus
+from iaqualink import SystemStatus
 
 async def get_system_status(system):
     await system.refresh()
@@ -176,7 +173,7 @@ finally:
 ### Catch Specific Exceptions
 
 ```python
-from iaqualink import AqualinkServiceUnauthorizedException, AqualinkServiceException
+from iaqualink.exception import AqualinkServiceUnauthorizedException, AqualinkServiceException
 
 # Good - handle specific errors
 try:

--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -23,7 +23,7 @@ async with AqualinkClient(username, password) as client:
 await system.update()
 
 # Check if online
-from iaqualink.system import SystemStatus
+from iaqualink import SystemStatus
 
 if system.status is SystemStatus.ONLINE:
     print(f"System {system.name} is online")

--- a/docs/contributing/new-system-type.md
+++ b/docs/contributing/new-system-type.md
@@ -41,7 +41,7 @@ Key rules:
 
 ```python
 # src/iaqualink/systems/newsystem/device.py
-from iaqualink.device import AqualinkDevice, AqualinkSwitch, AqualinkThermostat
+from iaqualink.device import AqualinkDevice, AqualinkSwitch, AqualinkClimate
 
 class NewDevice(AqualinkDevice):
     """Base device for new system."""

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -80,7 +80,7 @@ if pool_thermostat:
 await system.update()
 
 # Check if system is online
-from iaqualink.system import SystemStatus
+from iaqualink import SystemStatus
 
 if system.status is SystemStatus.ONLINE:
     print(f"System {system.name} is online")
@@ -110,8 +110,8 @@ async with AqualinkClient('user@example.com', 'password') as client:
 ## Error Handling
 
 ```python
-from iaqualink import (
-    AqualinkClient,
+from iaqualink import AqualinkClient
+from iaqualink.exception import (
     AqualinkServiceException,
     AqualinkServiceUnauthorizedException,
 )

--- a/src/iaqualink/__init__.py
+++ b/src/iaqualink/__init__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from iaqualink.client import AqualinkClient
+from iaqualink.device import (
+    AqualinkBinarySensor,
+    AqualinkClimate,
+    AqualinkDevice,
+    AqualinkFan,
+    AqualinkLight,
+    AqualinkNumber,
+    AqualinkSensor,
+    AqualinkSwitch,
+)
+from iaqualink.system import AqualinkSystem, SystemStatus
+
+__all__ = [
+    # Client
+    "AqualinkClient",
+    # System
+    "AqualinkSystem",
+    "SystemStatus",
+    # Devices
+    "AqualinkDevice",
+    "AqualinkBinarySensor",
+    "AqualinkClimate",
+    "AqualinkFan",
+    "AqualinkLight",
+    "AqualinkNumber",
+    "AqualinkSensor",
+    "AqualinkSwitch",
+]

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ["AqualinkAuthState", "AqualinkClient"]
+
 import asyncio
 import importlib
 import json
@@ -250,7 +252,7 @@ class AqualinkClient:
         if r.status_code != httpx.codes.OK:
             try:
                 _err_body = redact_value(json.loads(r.text))
-            except (json.JSONDecodeError, TypeError):
+            except (json.JSONDecodeError, TypeError):  # fmt: skip
                 _err_body = r.text
             LOGGER.debug("<- body: %s", _err_body)
             m = f"Unexpected response: {r.status_code} {r.reason_phrase}"

--- a/src/iaqualink/device.py
+++ b/src/iaqualink/device.py
@@ -1,5 +1,16 @@
 from __future__ import annotations
 
+__all__ = [
+    "AqualinkBinarySensor",
+    "AqualinkClimate",
+    "AqualinkDevice",
+    "AqualinkFan",
+    "AqualinkLight",
+    "AqualinkNumber",
+    "AqualinkSensor",
+    "AqualinkSwitch",
+]
+
 import logging
 import math
 from abc import ABC, abstractmethod

--- a/src/iaqualink/exception.py
+++ b/src/iaqualink/exception.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+__all__ = [
+    "AqualinkException",
+    "AqualinkInvalidParameterException",
+    "AqualinkOperationNotSupportedException",
+    "AqualinkServiceException",
+    "AqualinkServiceThrottledException",
+    "AqualinkServiceUnauthorizedException",
+    "AqualinkStateUnavailableException",
+]
+
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__all__ = ["AqualinkSystem", "SystemStatus", "UnsupportedSystem"]
+
 import enum
 import logging
 from collections.abc import Awaitable, Callable


### PR DESCRIPTION
## Summary

- `src/iaqualink/__init__.py` was empty; users had to import from internal submodules. This PR populates it so `from iaqualink import AqualinkClient` (and the other public types) just works.
- Adds `__all__` to `client.py`, `system.py`, `device.py`, and `exception.py` to formally document each module's public surface.
- Exceptions are intentionally **not** re-exported from the top-level — they remain in `iaqualink.exception` only.

**Exported at `iaqualink.*`:**

| Symbol | Type |
|--------|------|
| `AqualinkClient` | Client |
| `AqualinkSystem` | System base |
| `SystemStatus` | System status enum |
| `AqualinkDevice` | Device base |
| `AqualinkBinarySensor` | Device base |
| `AqualinkClimate` | Device base |
| `AqualinkFan` | Device base |
| `AqualinkLight` | Device base |
| `AqualinkNumber` | Device base |
| `AqualinkSensor` | Device base |
| `AqualinkSwitch` | Device base |

**Not exported at top-level** (access via submodule): `AqualinkAuthState`, `UnsupportedSystem`, all exceptions.

## Notes

Added `# fmt: skip` on a multi-exception `except` clause in `client.py` to work around a ruff 0.15.8 formatter bug that incorrectly drops the required parentheses from `except (json.JSONDecodeError, TypeError):`, producing invalid Python 3 syntax.

## Test plan

- [ ] `from iaqualink import AqualinkClient, AqualinkSystem, AqualinkDevice, SystemStatus` succeeds
- [ ] `import iaqualink; iaqualink.__all__` lists all 11 symbols
- [ ] `from iaqualink.exception import AqualinkServiceException` still works
- [ ] Existing tests pass

https://claude.ai/code/session_01YN9yzydCGZv6fGUF4Ccnr2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YN9yzydCGZv6fGUF4Ccnr2)_