### PR TITLE
refactor(system): make AqualinkSystem abstract, _refresh abstractmethod

### DIFF
--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -4,6 +4,7 @@ __all__ = ["AqualinkSystem", "SystemStatus", "UnsupportedSystem"]
 
 import enum
 import logging
+from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, ClassVar
 
@@ -37,7 +38,7 @@ class SystemStatus(enum.Enum):
     IN_PROGRESS = enum.auto()
 
 
-class AqualinkSystem:
+class AqualinkSystem(ABC):
     subclasses: ClassVar[dict[str, type[AqualinkSystem]]] = {}
 
     def __init__(self, aqualink: AqualinkClient, data: Payload):
@@ -127,6 +128,7 @@ class AqualinkSystem:
                 type(self).__name__,
             )
 
+    @abstractmethod
     async def _refresh(self) -> None:
         """Fetch and parse the latest state from the API.
 
@@ -144,7 +146,6 @@ class AqualinkSystem:
 
         **All other exceptions** propagate unchanged.
         """
-        raise NotImplementedError
 
 
 class UnsupportedSystem(AqualinkSystem):
@@ -155,6 +156,9 @@ class UnsupportedSystem(AqualinkSystem):
     @property
     def supported(self) -> bool:
         return False
+
+    async def _refresh(self) -> None:
+        pass
 
     async def refresh(self) -> None:
         LOGGER.debug(

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -9,6 +9,11 @@ from iaqualink.client import AqualinkClient
 from iaqualink.system import AqualinkSystem, UnsupportedSystem
 
 
+class _ConcreteSystem(AqualinkSystem):
+    async def _refresh(self) -> None:
+        pass
+
+
 class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         pass
@@ -21,10 +26,10 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
             "device_type": "iaqua",
             "name": "foo",
         }
-        system = AqualinkSystem(aqualink, data)
+        system = _ConcreteSystem(aqualink, data)
         assert (
             repr(system)
-            == f"AqualinkSystem(name='foo', serial='ABCDEFG', data={data})"
+            == f"_ConcreteSystem(name='foo', serial='ABCDEFG', data={data})"
         )
 
     def test_from_data_iaqua(self) -> None:
@@ -42,7 +47,7 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
     async def test_get_devices_needs_update(self) -> None:
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "fake"}
         aqualink = AqualinkClient("user", "pass")
-        system = AqualinkSystem(aqualink, data)
+        system = _ConcreteSystem(aqualink, data)
         system.devices = None
 
         with patch.object(system, "refresh") as mock_refresh:
@@ -52,20 +57,19 @@ class TestAqualinkSystem(unittest.IsolatedAsyncioTestCase):
     async def test_get_devices(self) -> None:
         data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "fake"}
         aqualink = AqualinkClient("user", "pass")
-        system = AqualinkSystem(aqualink, data)
+        system = _ConcreteSystem(aqualink, data)
         system.devices = {"foo": "bar"}
 
         with patch.object(system, "refresh") as mock_refresh:
             await system.get_devices()
             mock_refresh.assert_not_called()
 
-    async def test_refresh_not_implemented(self) -> None:
-        data = {"id": 1, "serial_number": "ABCDEFG", "device_type": "fake"}
-        aqualink = AqualinkClient("user", "pass")
-        system = AqualinkSystem(aqualink, data)
+    def test_subclass_without_refresh_raises_on_instantiation(self) -> None:
+        class IncompleteSystem(AqualinkSystem):
+            pass
 
-        with pytest.raises(NotImplementedError):
-            await system.refresh()
+        with pytest.raises(TypeError):
+            IncompleteSystem(MagicMock(), {})
 
 
 class TestUnsupportedSystem(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- `AqualinkSystem` now inherits from `ABC`
- `_refresh()` decorated with `@abstractmethod` — enforcement moves from call-time (`NotImplementedError`) to class-definition time (`TypeError` on instantiation)
- `UnsupportedSystem` gets a no-op `_refresh()` stub to satisfy the ABC contract (its `refresh()` override never calls it)
- Tests updated: direct `AqualinkSystem` instantiation replaced with `_ConcreteSystem` fixture; `test_refresh_not_implemented` replaced with `test_subclass_without_refresh_raises_on_instantiation`

Mirrors the pattern already used by `AqualinkDevice`.

## Test plan

- [x] `uv run prek run --all-files` — all hooks pass
- [x] `uv run --group test python -m pytest` — 983 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)