### PR TITLE
feat(zs500): add ZS500 heat pump support over persistent AWS IoT MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - **iAqua** systems (iaqualink.net API)
   - **eXO** systems (zodiac-io.com API)
   - **i2d** systems — iQPump variable-speed pumps (r-api.iaqualink.net API)
+  - **zs500** systems — ZS500 heat pumps over AWS IoT MQTT (auth via zodiac-io.com, control via AWS IoT; experimental)
 - 🌡️ **Comprehensive Device Support**
   - Temperature sensors (pool, spa, air)
   - Thermostats with adjustable set points
@@ -227,7 +228,7 @@ async with AqualinkClient('user@example.com', 'password') as client:
 The library uses a plugin-style architecture with base classes and system-specific implementations:
 
 - **AqualinkClient** - Authentication and system discovery
-- **AqualinkSystem** - Base class with iAqua, eXO, and i2d implementations
+- **AqualinkSystem** - Base class with iAqua, eXO, i2d, and zs500 implementations
 - **AqualinkDevice** - Device hierarchy with type-specific subclasses
 
 See [CLAUDE.md](CLAUDE.md) for detailed architecture documentation.

--- a/docs/api/systems/.nav.yml
+++ b/docs/api/systems/.nav.yml
@@ -2,3 +2,4 @@ nav:
   - iAqua: iaqua.md
   - eXO: exo.md
   - i2d (iQPump): i2d.md
+  - zs500 (Heat Pump): zs500.md

--- a/docs/api/systems/zs500.md
+++ b/docs/api/systems/zs500.md
@@ -1,0 +1,53 @@
+# zs500 Systems API
+
+zs500 systems are Zodiac ZS500 heat pumps, controlled over a persistent AWS IoT MQTT shadow
+connection (`prod` AWS IoT Core, region `us-east-1`). The `awscrt`/`awsiotsdk` dependencies this
+requires are core dependencies of this library.
+
+**Status: experimental / best-effort** — see [Implementation Notes: zs500](../../implementation/systems/zs500.md)
+for caveats; no physical hardware was available to validate this against.
+
+## Zs500System
+
+::: iaqualink.systems.zs500.system.Zs500System
+
+## Zs500Device
+
+::: iaqualink.systems.zs500.device.Zs500Device
+
+## Zs500Climate
+
+::: iaqualink.systems.zs500.device.Zs500Climate
+
+## Zs500ModeSelect
+
+::: iaqualink.systems.zs500.device.Zs500ModeSelect
+
+## Zs500CoolingSwitch
+
+::: iaqualink.systems.zs500.device.Zs500CoolingSwitch
+
+## Zs500HeatingPrioritySwitch
+
+::: iaqualink.systems.zs500.device.Zs500HeatingPrioritySwitch
+
+## Zs500TemperatureSensor
+
+::: iaqualink.systems.zs500.device.Zs500TemperatureSensor
+
+## Zs500CompressorSpeedSensor
+
+::: iaqualink.systems.zs500.device.Zs500CompressorSpeedSensor
+
+## Zs500StandbyReasonSensor
+
+::: iaqualink.systems.zs500.device.Zs500StandbyReasonSensor
+
+## Zs500ErrorBinarySensor
+
+::: iaqualink.systems.zs500.device.Zs500ErrorBinarySensor
+
+## See Also
+
+- [Protocol Reference: zs500](../../reference/systems/zs500.md)
+- [Implementation Notes: zs500](../../implementation/systems/zs500.md)

--- a/docs/implementation/systems/.nav.yml
+++ b/docs/implementation/systems/.nav.yml
@@ -2,3 +2,4 @@ nav:
   - iAqua: iaqua.md
   - eXO: exo.md
   - i2d (iQPump): i2d.md
+  - zs500 (Heat Pump): zs500.md

--- a/docs/implementation/systems/zs500.md
+++ b/docs/implementation/systems/zs500.md
@@ -1,0 +1,153 @@
+# zs500 Implementation Notes
+
+Implementation details for the zs500 system (`device_type: "zs500"` — Zodiac ZS500 heat pump).
+For the wire-level protocol, see [Protocol Reference: zs500](../../reference/systems/zs500.md).
+
+**Status: experimental / best-effort.** No physical ZS500 unit was available to validate this
+implementation against. It is built directly from decompiled-source protocol research, not from
+observed live traffic. See "Deltas vs Protocol Reference" below for everything that is an
+assumption rather than a confirmed fact.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| `device_type` | `zs500` |
+| Transport | Persistent AWS IoT MQTT shadow connection (`awscrt`/`awsiotsdk`, core dependencies) |
+| MQTT broker | `a1zi08qpbrtjyq-ats.iot.us-east-1.amazonaws.com` (region `us-east-1`), WebSocket + SigV4 |
+| Authentication | Bearer `IdToken` for login/refresh; `credentials` block (AccessKeyId/SecretKey/SessionToken) from the same login/refresh response, used directly as static AWS credentials |
+| Update call | Persistent connection; `refresh()` issues a `$aws/things/{serial}/shadow/get` and awaits the correlated `get/accepted` response |
+| Live updates | Subscribed to `$aws/things/{serial}/shadow/update/documents` for the life of the connection — any shadow change (ours or the device's own) updates `system.devices` immediately, without requiring `refresh()` |
+| Write commands | `$aws/things/{serial}/shadow/update` with `state.desired.equipment.hp_0.{field}` |
+| Python class | `Zs500System` in `src/iaqualink/systems/zs500/system.py` |
+
+## Why MQTT instead of REST
+
+The wire research found that the reference Android app only uses the AWS IoT MQTT shadow for
+live status/control. The REST shadow endpoint (`/devices/v2/{serial}/shadow`) exists but is
+called only during WiFi/BLE provisioning, never from the live home-screen flow — unlike `exo`,
+where REST-instead-of-MQTT is an established, working simplification already used by this
+library. Given that uncertainty, this implementation follows the reference faithfully and uses
+MQTT, at the cost of a new architectural pattern in this codebase (see below) and a much larger
+implementation surface than a REST-polling system would have needed.
+
+## Connection lifecycle
+
+Unlike every other system in this library (all of which are effectively stateless — one HTTP
+request per `refresh()`/command), `Zs500System` holds a **persistent** MQTT connection, opened
+lazily on first use and kept open:
+
+- `_ensure_connected()` builds the connection (fresh `AwsCredentialsProvider` from
+  `aqualink.iot_credentials`, fresh UUID client ID, 60s keepalive, 1s/30s reconnect backoff,
+  20s connection-stability window — all values taken from the reference app's own MQTT
+  configuration) and subscribes to `get/accepted`, `get/rejected`, `update/accepted`,
+  `update/rejected`, and `update/documents` for the device's serial.
+- Every connect (first connect or any future reconnect) re-subscribes to all five topics from
+  scratch. This is deliberately not optimized to skip re-subscribing on a resumed session — MQTT5
+  session-resumption semantics around subscription persistence weren't something we could verify
+  without hardware, so re-subscribing unconditionally (a harmless no-op if the broker did
+  preserve them) was the safer choice.
+- `refresh()` and every write open the connection if needed, then do exactly one
+  publish-and-await-correlated-response cycle, correlated by a fresh UUID `client_token` per
+  operation (matching the per-operation correlation pattern AWS's own `IotShadowClient`
+  provides).
+- The `update/documents` subscription is the live-update channel: its handler parses
+  `event.current.state.reported` and calls the same `_apply_reported_state()` that `refresh()`
+  uses, so `system.devices` reflects state changes (the device's own, or ours) without polling.
+- `AqualinkSystem` gained a no-op `aclose()` hook (every other system inherits the no-op
+  unchanged) so `AqualinkClient.close()`/`__aexit__` can tear down the MQTT connection on
+  shutdown. `AqualinkClient.get_systems()` now also tracks the systems it creates so a second
+  `get_systems()` call closes out any systems it's about to replace, instead of orphaning a live
+  connection silently — a latent gap for any future stateful system, not just this one.
+
+## System Status Lifecycle
+
+`aws.status` is mapped to `SystemStatus` using the exact same table `ExoSystem` uses
+(`connected`/`online`/`offline`/`disconnected`/`unknown`/`service`/`firmware_update`) — see
+Deltas below for why this is inherited rather than independently confirmed.
+
+AWS IoT shadow `rejected` responses carry a `code` field using real HTTP-equivalent status codes
+(this is documented AWS behavior, not specific to this app). This is mapped directly onto the
+existing exception hierarchy so `AqualinkSystem.refresh()`'s template method needed no changes:
+
+| Rejected `code` | Exception | `refresh()` outcome |
+|---|---|---|
+| `401` | `AqualinkServiceUnauthorizedException` | Reauth-retry once (see below), then `DISCONNECTED` if it fails again |
+| `429` | `AqualinkServiceThrottledException` | `UNKNOWN` |
+| anything else / connect failure | `AqualinkServiceException` | `DISCONNECTED` |
+
+### Reauth-retry
+
+A small MQTT-specific reauth-retry wrapper (`Zs500System._call_with_reauth_retry`) mirrors
+`utils/reauth.send_with_reauth_retry`'s "retry once" policy: on `AqualinkServiceUnauthorizedException`,
+disconnect, force `aqualink._logged = False`, call `aqualink._refresh_auth()` (which repopulates
+`iot_credentials` from the refresh response), reconnect, and retry the failed operation exactly
+once. A fresh helper was written rather than reusing `send_with_reauth_retry` directly because
+that helper's type signature is pinned to `httpx.Response`.
+
+Connect-time credential expiry is **not** specially detected — if the MQTT connection itself
+fails (as opposed to a shadow operation being rejected with `code=401` on an already-established
+connection), it's treated as a generic `AqualinkServiceException`, not retried. Distinguishing
+"expired credentials" from "network down" at the CONNACK-failure level would need real
+characterization of CRT error codes against a live broker, which wasn't possible here.
+
+## Device Model
+
+A single shadow object (`equipment.hp_0`, a literal fixed key) is fanned out into nine HA-facing
+devices, since unlike `exo`/`i2d` there's only one underlying equipment object to begin with:
+
+| Class | Synthesized device name | Wire source | HA shape |
+|---|---|---|---|
+| `Zs500Climate` | `climate` | `hp_0.state`, `hp_0.tsp` | `AqualinkClimate` |
+| `Zs500ModeSelect` | `mode` | `hp_0.st` | `AqualinkSelect` (Boost/Silent/Smart) |
+| `Zs500CoolingSwitch` | `cooling` | `hp_0.cl` | `AqualinkSwitch` |
+| `Zs500HeatingPrioritySwitch` | `heating_priority` | `hp_0.hp` | `AqualinkSwitch` |
+| `Zs500TemperatureSensor` | `water_temp` | `hp_0.sns_1` | `AqualinkSensor` |
+| `Zs500TemperatureSensor` | `air_temp` | `hp_0.sns_2` | `AqualinkSensor` |
+| `Zs500CompressorSpeedSensor` | `compressor_speed` | `hp_0.cmprSpd` | `AqualinkSensor` (%) |
+| `Zs500StandbyReasonSensor` | `standby_reason` | `hp_0.reason` | `AqualinkSensor` with `value_enum` |
+| `Zs500ErrorBinarySensor` | `error` | `hp_0.errorCode` | `AqualinkBinarySensor` |
+
+`Zs500Climate.current_temperature` reads its sibling `water_temp` device rather than reaching
+into a nested `sns_1` dict directly — the same cross-device-lookup pattern `ExoClimate` uses for
+its own water-temperature sensor (`self.system.devices["sns_3"]`). This also sidesteps a real
+typing trap: `DeviceData` is `dict[str, str]` project-wide even though the actual wire values are
+a JSON mix of str/int/nested-dict; every system reads through `str()`/`int()`/`float()` casts
+(see `i2d`'s device module) and avoids storing nested dicts as a `DeviceData` value at all, rather
+than fighting the static type. zs500 follows the same convention.
+
+`sns_1`/`sns_2` are identified by their fixed key name (water vs. air respectively, per the
+protocol reference), not by inspecting their own `type` sub-field, whose wire values weren't
+catalogued in the reference source.
+
+## Deltas vs Protocol Reference
+
+| # | Observed/documented reference | Current Python (`Zs500System`) |
+|---|---|---|
+| 1 | `aws.status` wire string values for ZS500 specifically were not confirmed in source (no string comparison against it found in the HPM/ZS500 code paths read) | Reuses `exo`'s status-mapping table verbatim, since both share the same shadow `aws` block shape. Unconfirmed for ZS500 specifically. |
+| 2 | REST shadow endpoints (`/devices/v2/{serial}/shadow`, `systemSetup`, `/ota`) exist and are documented in the protocol reference | Not implemented at all in this PR — out of scope; MQTT covers the full read/write surface needed for HA integration. Could be added later as plain REST calls if there's a reason to. |
+| 3 | AWS IoT shadow update publish: the reference's own request model declares `clientToken`/`deviceId` wrapper fields, but no call site was found that ever populates them (so the reference likely sends a bare `{"state":{"desired":{...}}}`, same as `exo`) | Uses `awsiotsdk`'s `IotShadowClient`, which *does* attach `client_token`/`thing_name` for accept/reject correlation. This is real, AWS-documented shadow protocol behavior independent of what the reference app happens to send — not a wire-compatibility risk either way. |
+| 4 | No persistent-connection precedent exists elsewhere in this library; every other system is a stateless request/response per `refresh()`/command | `Zs500System` holds a persistent connection by design (see "Connection lifecycle" above) — a deliberate choice, not a wire requirement, made to support live push updates and reduce the number of round-trips needed to observe state changes while validating this against real hardware. |
+| 5 | MQTT5 subscription persistence across a broker-side session resumption was not characterized | Always re-subscribes to all five shadow topics on every connect, including reconnects — a safe, idempotent default rather than relying on unverified session-resumption behavior. |
+| 6 | Aux configuration (`systemSetup?key=service`, used for both aux config and service info despite the query key) and OTA status are documented as real wire endpoints | Not implemented — out of scope for this PR (see #2). |
+| 7 | Temperature ×10 scaling, 15–32°C bounds, `st`/`state`/`reason` enum values | Implemented as documented, no divergence. |
+| 8 | The reference doc's topic table lists only `get`, `get/accepted`, `update`, and `update/accepted` — the topics actually traced to a decompiled call site | Also subscribes to `get/rejected`, `update/rejected` (for error-code correlation — see "System Status Lifecycle" above) and `update/documents` (the live-update channel). These are standard, AWS-documented Device Shadow service topics exposed generically by `awsiotsdk`'s `IotShadowClient`, not reverse-engineered from the app — additive, not wire-incompatible. |
+
+## Testing
+
+zs500 commands go over MQTT, not `httpx`, and the project's `tests/conformance/*` suite
+parametrizes every generic contract test (`test_switch.py`, `test_climate.py`, `test_system.py`,
+etc.) against `respx_mock.calls` — i.e. it assumes HTTP. None of zs500's factories participate
+there; `tests/systems/zs500/factories.py` declares every `zs500_<type>_factories` list empty, per
+the harness's convention for unused fixture types. Correctness is covered instead by a bespoke
+suite in `tests/systems/zs500/` using a `FakeShadowClient` test double
+(`tests/systems/zs500/conftest.py`) that stands in for `awsiotsdk`'s real shadow client and
+auto-replies on the matching accepted/rejected topic using the caller's own `client_token` —
+this is a real, explicit cost of choosing MQTT over REST, not an oversight.
+
+## See Also
+
+- [Protocol Reference: zs500](../../reference/systems/zs500.md) — wire-level spec
+- [API Reference: zs500](../../api/systems/zs500.md) — class and method docs
+- [Implementation Notes: eXO](exo.md) — the closest sibling system (same shadow/`aws` block
+  shape, same MQTT-in-reference-vs-Python-implementation trade-off, opposite choice made)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@
     - **iAqua** systems (iaqualink.net API)
     - **eXO** systems (zodiac-io.com API)
     - **i2d** systems — iQPump variable-speed pumps (r-api.iaqualink.net API)
+    - **zs500** systems — ZS500 heat pumps over AWS IoT MQTT (auth via zodiac-io.com, control via AWS IoT; experimental)
 - **Comprehensive Device Support**
     - Temperature sensors (pool, spa, air)
     - Thermostats with adjustable set points

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -49,6 +49,13 @@ Content-Type: application/json
 | `userPoolOAuth.AccessToken` | string | Cognito access token (not used by this library) |
 | `userPoolOAuth.ExpiresIn` | integer | IdToken TTL in seconds (typically 3600) |
 | `userPoolOAuth.TokenType` | string | Always `"Bearer"` |
+| `credentials.AccessKeyId` | string | Temporary AWS access key — used for SigV4-signing the AWS IoT MQTT WebSocket connection (zs500) |
+| `credentials.SecretKey` | string | Temporary AWS secret key, paired with `AccessKeyId` |
+| `credentials.SessionToken` | string | AWS session token, paired with `AccessKeyId`/`SecretKey` |
+| `credentials.Expiration` | string | Credential expiry timestamp — not independently tracked by the reference app; it re-derives fresh credentials on every login/refresh instead |
+| `credentials.IdentityId` | string | AWS Cognito identity ID associated with the issued credentials |
+
+No separate AWS Cognito Identity Pool exchange call was observed — the server performs that exchange itself and returns ready-to-use temporary AWS credentials directly in the login/refresh response body.
 
 ### Token Refresh
 

--- a/docs/reference/systems/.nav.yml
+++ b/docs/reference/systems/.nav.yml
@@ -2,3 +2,4 @@ nav:
   - iAqua: iaqua.md
   - eXO: exo.md
   - i2d (iQPump): i2d.md
+  - zs500 (Heat Pump): zs500.md

--- a/docs/reference/systems/zs500.md
+++ b/docs/reference/systems/zs500.md
@@ -49,7 +49,7 @@ See [client.md](../client.md) for the full login/refresh flow (`POST /users/v1/l
 | `GET` | `/devices/v2/{serial}/ota` | Read OTA job status | `authorization` header | — |
 | `GET` | `http://192.168.0.1/serialnumber/read` | Read serial number directly from device AP (provisioning only, no auth) | none | — |
 
-**Important correction vs. earlier drafts of this document:** the aux-configuration read/write calls (`getHpmGetAuxConfiguration` / `postHpmSetAuxConfiguration` in the reference) construct their URL from the *same* config-relative path as the service-info calls (`/devices/v2/{serial}/systemSetup`) and append the literal query string `?key=service` — **not** `?key=auxConfig`. This was verified directly against the request-builder call sites in the reference network client; it may be an app-side naming/copy artifact, but it is what is actually sent on the wire by this app version. There is no separate `?key=auxConfig` request observed anywhere in the reference.
+**Important correction vs. earlier drafts of this document:** the aux-configuration read/write calls construct their URL from the *same* config-relative path as the service-info calls (`/devices/v2/{serial}/systemSetup`) and append the literal query string `?key=service` — **not** `?key=auxConfig`. This was verified directly against the request-builder call sites in the reference network client; it may be an app-side naming/copy artifact, but it is what is actually sent on the wire by this app version. There is no separate `?key=auxConfig` request observed anywhere in the reference.
 
 There is also a v1 path `/devices/v1/{serial}/systemSetup?key=aux` defined in the production endpoint configuration table (config key `filteration_pump_aux_set_up`), but no call site invoking it was found wired to any HPM/ZS500 view-model in this app version — it is configured but appears unused for this device type. Treat it as "configured, not observed in use."
 
@@ -127,7 +127,7 @@ The shadow GET/POST and aux GET/POST calls above (the four that hit `/devices/v2
 
 #### `equipment.hp_0` — heat pump core state
 
-The equipment key is the literal fixed string `hp_0` (not a dynamic/serial-derived key) — confirmed directly from the reference model's `@SerializedName("hp_0")` annotation.
+The equipment key is the literal fixed string `hp_0` (not a dynamic/serial-derived key) — confirmed directly from the reference model's wire field mapping.
 
 | Field | Type | Description |
 |---|---|---|
@@ -141,7 +141,7 @@ The equipment key is the literal fixed string `hp_0` (not a dynamic/serial-deriv
 | `sns_1` | object | Sensor 1 reading (pool/water temperature in the home-screen flow) — see sensor object below |
 | `sns_2` | object | Sensor 2 reading (air temperature in the home-screen flow) — see sensor object below |
 | `hs` | string | Field present in model; semantics not characterized in reference |
-| `Ip` | string | IP address. Field name uses uppercase `I` — confirmed from `@SerializedName("Ip")` |
+| `Ip` | string | IP address. Field name uses uppercase `I` — confirmed directly from the reference model's wire field mapping |
 | `md` | string | Model identifier string — known values not catalogued in reference |
 | `reason` | integer | Standby reason code (see enum table) |
 | `sn` | string | Serial number |
@@ -205,7 +205,7 @@ The equipment key is the literal fixed string `hp_0` (not a dynamic/serial-deriv
 
 ## Temperature Encoding
 
-**This is device-type-gated, not a blanket "HPM family" behavior.** The reference UI code divides `tsp` (setpoint), `sns_1.value` (pool/water temperature), and `sns_2.value` (air temperature) by 10 **only when the device type string is ZS500** (`isHpmZs500Device == true`). For non-ZS500 HPM devices, the same wire fields are used unscaled (no division). The write path mirrors this: the setpoint is multiplied by 10 before being posted **only** for ZS500.
+**This is device-type-gated, not a blanket "HPM family" behavior.** The reference UI code divides `tsp` (setpoint), `sns_1.value` (pool/water temperature), and `sns_2.value` (air temperature) by 10 **only when the device type string is ZS500**. For non-ZS500 HPM devices, the same wire fields are used unscaled (no division). The write path mirrors this: the setpoint is multiplied by 10 before being posted **only** for ZS500.
 
 Confirmed bounds (from the UI's allowed-range check, same min/max for slider clamp regardless of device type): minimum 15.0, maximum 32.0, in the unit the UI displays (post-scaling for ZS500 — i.e. 15.0–32.0 represents °C after the ÷10 step, corresponding to wire values 150.0–320.0 for ZS500 specifically). Whether the device always reports in this encoding regardless of a user's configured display unit (°C vs °F) was not observed in the reference — no unit-conversion logic was found in the HPM/ZS500 view-model code.
 
@@ -249,7 +249,7 @@ All of the following are confirmed directly from named integer/string constants 
 | 7 | Remote contact off |
 | 8 | Compressor buffer |
 
-Reference UI note: standby-reason display is normally gated on firmware version (parsed from `vr`, requires the firmware's embedded version digits to be `>= 41`) for plain HPM devices, but this gate is **bypassed** (reason is always shown) when the device is ZS500 — confirmed directly from the conditional `(firmwareDigits >= 41) || isHpmZs500Device`.
+Reference UI note: standby-reason display is normally gated on firmware version (parsed from `vr`, requires the firmware's embedded version digits to be `>= 41`) for plain HPM devices, but this gate is **bypassed** (reason is always shown) when the device is ZS500 — confirmed directly from the reference's display-gating logic.
 
 Reasons `2` (too hot/too cold) and `5` (defrosting) are remapped to display as standby `status == 1` in the UI regardless of the raw `status` value — an app-side display quirk, not a separate wire enum.
 
@@ -259,7 +259,7 @@ Reasons `2` (too hot/too cold) and `5` (defrosting) are remapped to display as s
 | `"FP"` | Aux enabled (forced pump) |
 | `"UNK"` | Aux disabled |
 
-**Error code (`errorCode`)** — string. `"0"` means no active error. The reference UI formats single-digit codes as `E0{code}` and multi-digit codes as `E{code}` but does not catalogue specific non-zero code meanings anywhere in the HPM/ZS500 source. Error display itself (showing the error banner) is also gated on `isHpmZs500Device` — i.e. even though the `errorCode`/`errorTime` fields exist generically on `hp_0`, the reference UI only surfaces them for ZS500 devices in the home screen.
+**Error code (`errorCode`)** — string. `"0"` means no active error. The reference UI formats single-digit codes as `E0{code}` and multi-digit codes as `E{code}` but does not catalogue specific non-zero code meanings anywhere in the HPM/ZS500 source. Error display itself (showing the error banner) is also device-type-gated — i.e. even though the `errorCode`/`errorTime` fields exist generically on `hp_0`, the reference UI only surfaces them for ZS500 devices in the home screen.
 
 ---
 

--- a/docs/reference/systems/zs500.md
+++ b/docs/reference/systems/zs500.md
@@ -1,0 +1,388 @@
+# zs500 — ZS500 Heat Pump Protocol
+
+**Python system name:** `"zs500"`
+**Wire device type:** `"zs500"`
+**Protocol family:** AWS IoT Device Shadow (MQTT in reference; no evidence of REST shadow polling for routine status/control)
+**Auth:** See [client.md](../client.md)
+
+---
+
+## Overview
+
+The ZS500 heat pump shares its entire reference (Android app) implementation with the generic "HPM" (Heat Pump Module) device family. There is no ZS500-specific model class, view, or view-model in the reference app — `"hpm"` and `"zs500"` are two distinct wire `device_type` strings that are both routed to the same shared model and handler code. The only places the app distinguishes ZS500 from generic HPM are:
+
+- A device-type string check (`deviceType` containing `"zs500"`, case-insensitive) that gates UI-visible behavior: showing the "Smart" mode option, dividing certain sensor/setpoint values by 10 before display, and showing standby-reason text regardless of firmware version.
+- A dedicated BLE GATT device type/UUID set used during WiFi provisioning (shared verbatim with one other device type in the app, see BLE section).
+
+All routine status reads and control writes for the home screen and equipment settings go over the **AWS IoT MQTT shadow** — the app subscribes to and publishes on a per-serial shadow topic. A small number of **REST endpoints on the shadow host** exist and are used only in two narrow situations: (1) during WiFi/BLE provisioning, before the device has an active MQTT session, to confirm the device has come online and to read/write its aux configuration; and (2) for service-contact info (`systemSetup`) and OTA status polling, both of which are simple synchronous calls unrelated to live equipment state. No REST shadow polling loop was observed for ordinary "get current status" use during normal operation — that path is MQTT-only in the reference.
+
+---
+
+## Base URLs and Hosts
+
+| Host | Used for |
+|---|---|
+| `prod.zodiac-io.com` | Shadow REST endpoints (provisioning-time only), `systemSetup`, OTA status |
+| `a1zi08qpbrtjyq-ats.iot.us-east-1.amazonaws.com` | AWS IoT MQTT broker — primary transport for live status and control |
+| `http://192.168.0.1` | Direct local-network calls to the heat pump's onboard AP during WiFi provisioning (serial number read) |
+
+---
+
+## Auth Flow
+
+See [client.md](../client.md) for the full login/refresh flow (`POST /users/v1/login`, `POST /users/v1/refresh` on `prod.zodiac-io.com`) and `userPoolOAuth.IdToken` usage. ZS500/HPM REST calls carry the IdToken in an `authorization` (or, on some call sites, `Authorization`) header — casing varies per endpoint, see the header table below. MQTT uses short-lived Cognito credentials obtained through the same authenticated session, exchanged for AWS IoT access as described generically in client.md's auth section.
+
+---
+
+## Endpoint Inventory (REST, provisioning/ancillary use only)
+
+| Method | Path | Purpose | Auth | Key params |
+|---|---|---|---|---|
+| `GET` | `/devices/v2/{serial}/shadow` | Read full shadow (provisioning-time connectivity check) | `authorization: {IdToken}` header | `signature` query param (HMAC, see below) |
+| `POST` | `/devices/v2/{serial}/shadow` | Write desired state (provisioning-time only call site observed) | `authorization: {IdToken}` header | Body: `{clientToken, deviceId, state: {desired: {...}}}` |
+| `GET` | `/devices/v2/{serial}/shadow` (aux variant) | Read aux/filtration-pump shadow sub-state | `authorization: {IdToken}` header | `signature` query param |
+| `POST` | `/devices/v2/{serial}/shadow` (aux variant) | Write aux/filtration-pump shadow sub-state | `authorization: {IdToken}` header | Body: `{state: {...}}` |
+| `GET` | `/devices/v2/{serial}/systemSetup?key=service` | Read service/contact info | `api_key` header + `authorization`/`Authorization` header | — |
+| `POST` | `/devices/v2/{serial}/systemSetup?key=service` | Write service/contact info | `api_key` header + `authorization` header | Body: `{name, phone, web, email}` |
+| `GET` | `/devices/v2/{serial}/systemSetup?key=service` | Read aux configuration | `api_key` header + `authorization` header | — |
+| `POST` | `/devices/v2/{serial}/systemSetup?key=service` | Write aux configuration | `api_key` header + `authorization` header | Body: `{"ty": "<string>"}` |
+| `GET` | `/devices/v2/{serial}/ota` | Read OTA job status | `authorization` header | — |
+| `GET` | `http://192.168.0.1/serialnumber/read` | Read serial number directly from device AP (provisioning only, no auth) | none | — |
+
+**Important correction vs. earlier drafts of this document:** the aux-configuration read/write calls (`getHpmGetAuxConfiguration` / `postHpmSetAuxConfiguration` in the reference) construct their URL from the *same* config-relative path as the service-info calls (`/devices/v2/{serial}/systemSetup`) and append the literal query string `?key=service` — **not** `?key=auxConfig`. This was verified directly against the request-builder call sites in the reference network client; it may be an app-side naming/copy artifact, but it is what is actually sent on the wire by this app version. There is no separate `?key=auxConfig` request observed anywhere in the reference.
+
+There is also a v1 path `/devices/v1/{serial}/systemSetup?key=aux` defined in the production endpoint configuration table (config key `filteration_pump_aux_set_up`), but no call site invoking it was found wired to any HPM/ZS500 view-model in this app version — it is configured but appears unused for this device type. Treat it as "configured, not observed in use."
+
+The shadow GET/POST and aux GET/POST calls above (the four that hit `/devices/v2/{serial}/shadow`) are invoked **only** from WiFi-provisioning and aux-setup-during-provisioning view-models in the reference — not from the live home-screen status/control flow, which uses MQTT exclusively (see Real-Time Transport below).
+
+---
+
+## Request/Response Field Reference
+
+### Shadow envelope
+
+```json
+{
+  "deviceId": "<serial>",
+  "state": {
+    "reported": { ... },
+    "desired": { ... }
+  },
+  "ts": 0
+}
+```
+
+### Write request body (`POST .../shadow`)
+
+| Field | Type | Description |
+|---|---|---|
+| `clientToken` | string | Caller-generated correlation token |
+| `deviceId` | string | Device serial |
+| `state.desired` | object | Desired-state delta; only changed fields need to be included |
+
+`state.desired` mirrors the `reported.equipment` shape below — i.e. desired writes are nested as `{"equipment": {"hp_0": {...}}}`.
+
+### `state.reported` field reference
+
+#### `hmi` — human-machine interface / firmware metadata
+
+| Field | Type | Description |
+|---|---|---|
+| `hmi.ff.fn` | string | Front-face firmware file name |
+| `hmi.ff.ts` | integer | Front-face timestamp |
+| `hmi.ff.pg.bd` | integer | Sub-field, purpose not observed in reference |
+| `hmi.ff.pg.fs` | integer | Sub-field, purpose not observed in reference |
+| `hmi.ff.pg.ts` | long | Sub-field, purpose not observed in reference |
+| `hmi.ff.pg.te` | long | Sub-field, purpose not observed in reference |
+| `hmi.fw.fn` | string | Firmware file name |
+| `hmi.fw.vr` | string | Firmware version |
+
+#### `aws` — AWS connectivity status
+
+| Field | Type | Description |
+|---|---|---|
+| `aws.session_id` | string | AWS session identifier |
+| `aws.status` | string | Connectivity status string (observed values not catalogued beyond "connected"/"disconnected" naming convention used elsewhere in this app; exact ZS500 wire strings not confirmed in source) |
+| `aws.timestamp` | long | Last contact timestamp |
+
+#### `debug` — diagnostic counters (keys contain literal spaces; quote exactly when parsing)
+
+| Field (wire key) | Type | Description |
+|---|---|---|
+| `Last error` | integer | Last error code |
+| `MQTT connection` | integer | MQTT connection counter/flag |
+| `MQTT disconnection total` | integer | Total MQTT disconnections |
+| `Nb_Fail_Publish_MSG` | integer | Failed publish count |
+| `Nb reboot du to MQTT issue` | integer | Reboots due to MQTT issues |
+| `Nb_Success_Pub_MSG` | integer | Successful publish count |
+| `Nb_Success_Sub_Receive` | integer | Successful subscribe-receive count |
+| `OTA fail` | integer | OTA failure count |
+| `OTA fail by disconnection` | integer | OTA failures caused by disconnection |
+| `OTA fail global` | integer | Global OTA failure count |
+| `OTA State` | integer | OTA state code |
+| `OTA success` | integer | OTA success count |
+| `RSSI` | integer | WiFi signal strength |
+| `Still alive` | integer | Heartbeat counter |
+| `Version Firmware` | string | Firmware version string |
+
+#### `equipment.hp_0` — heat pump core state
+
+The equipment key is the literal fixed string `hp_0` (not a dynamic/serial-derived key) — confirmed directly from the reference model's `@SerializedName("hp_0")` annotation.
+
+| Field | Type | Description |
+|---|---|---|
+| `cl` | integer | Cooling enabled (0/1) |
+| `cmprSpd` | integer | Compressor speed, percent (0–100) |
+| `errorCode` | string | Error code; `"0"` = no error |
+| `errorTime` | string | Error timestamp |
+| `et` | string | Equipment type string — known values not catalogued in reference |
+| `fan` | integer | Fan field; reference UI treats `0` as off and any nonzero value as running, but does not otherwise interpret the value (RPM vs. boolean not distinguished in source) |
+| `hp` | integer | Heating priority (0/1) |
+| `sns_1` | object | Sensor 1 reading (pool/water temperature in the home-screen flow) — see sensor object below |
+| `sns_2` | object | Sensor 2 reading (air temperature in the home-screen flow) — see sensor object below |
+| `hs` | string | Field present in model; semantics not characterized in reference |
+| `Ip` | string | IP address. Field name uses uppercase `I` — confirmed from `@SerializedName("Ip")` |
+| `md` | string | Model identifier string — known values not catalogued in reference |
+| `reason` | integer | Standby reason code (see enum table) |
+| `sn` | string | Serial number |
+| `st` | integer | Mode (see enum table) |
+| `state` | integer | Operating state (see enum table) |
+| `status` | integer | Status field; value range/semantics not fully characterized beyond its use as an "is the unit idle" gate (`state == 0 || status == 0`) in the reference UI |
+| `ts` | string | Timestamp |
+| `tsp` | double | Setpoint. Wire encoding depends on device type — see Temperature Encoding below |
+| `ty` | string | Device type identifier string at the equipment level |
+| `vr` | string | Firmware version |
+
+#### Sensor object (`sns_1`, `sns_2`)
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | Sensor type string — values not catalogued in reference |
+| `state` | string | Sensor state string — values not catalogued in reference |
+| `value` | double | Sensor reading. Wire encoding depends on device type — see Temperature Encoding below |
+
+#### Top-level `ty`
+
+| Field | Type | Description |
+|---|---|---|
+| `ty` | string | Device-type string reported at the top level of `state.reported`, alongside `hmi`, `aws`, `debug`, `equipment` |
+
+#### Aux configuration (`systemSetup?key=service` GET/POST body, used for aux config despite the query key)
+
+| Field | Type | Description |
+|---|---|---|
+| `ty` | string | `"FP"` = aux enabled (forced pump; reference constant name implies this also locks heating priority on), `"UNK"` = aux disabled |
+
+#### Service information (`systemSetup?key=service` GET/POST body)
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Service contact name |
+| `phone` | string | Service contact phone |
+| `web` | string | Service contact website |
+| `email` | string | Service contact email |
+
+#### OTA status (`GET .../ota` response)
+
+| Field | Type | Description |
+|---|---|---|
+| `deviceId` | string | Device serial |
+| `jobId` | string | OTA job identifier |
+| `progress` | string | Progress indicator |
+| `retryAttempted` | integer | Retry attempts so far |
+| `retryLeft` | integer | Retries remaining |
+| `status` | string | Job status string — values not catalogued in reference |
+
+#### Local serial-number read (`GET http://192.168.0.1/serialnumber/read`)
+
+| Field | Type | Description |
+|---|---|---|
+| `requestID` | string | Request correlation id |
+| `serialnumber.operation` | string | Operation string |
+| `serialnumber.value` | string | Serial number value |
+
+---
+
+## Temperature Encoding
+
+**This is device-type-gated, not a blanket "HPM family" behavior.** The reference UI code divides `tsp` (setpoint), `sns_1.value` (pool/water temperature), and `sns_2.value` (air temperature) by 10 **only when the device type string is ZS500** (`isHpmZs500Device == true`). For non-ZS500 HPM devices, the same wire fields are used unscaled (no division). The write path mirrors this: the setpoint is multiplied by 10 before being posted **only** for ZS500.
+
+Confirmed bounds (from the UI's allowed-range check, same min/max for slider clamp regardless of device type): minimum 15.0, maximum 32.0, in the unit the UI displays (post-scaling for ZS500 — i.e. 15.0–32.0 represents °C after the ÷10 step, corresponding to wire values 150.0–320.0 for ZS500 specifically). Whether the device always reports in this encoding regardless of a user's configured display unit (°C vs °F) was not observed in the reference — no unit-conversion logic was found in the HPM/ZS500 view-model code.
+
+---
+
+## Compressor Speed Display
+
+`cmprSpd` is not divided/scaled — it is used directly as a percentage (0–100). Reference UI thresholds for visual indicator segments: `> 75` = all three segments lit, `51–75` = two segments, `1–50` = one segment, `<= 0` = no segments lit.
+
+---
+
+## Enum Wire Values
+
+All of the following are confirmed directly from named integer/string constants in the reference source.
+
+**Mode (`st`)** — integer:
+| Value | Meaning |
+|---|---|
+| 0 | Boost |
+| 1 | Silent |
+| 2 | Smart — UI only exposes this option when the device type string contains `"zs500"` (case-insensitive); not shown for plain HPM |
+
+**Operating state (`state`)** — integer:
+| Value | Meaning |
+|---|---|
+| 0 | Off |
+| 1 | Standby |
+| 2 | Heat |
+| 3 | Cool |
+
+**Standby reason (`reason`)** — integer, relevant when `state == 1`:
+| Value | Meaning |
+|---|---|
+| 0 | None |
+| 1 | No water flow |
+| 2 | Too hot or too cold (outside temperature out of operating range) |
+| 3 | Temperature buffer |
+| 4 | Cool mode disabled |
+| 5 | Defrosting |
+| 6 | Starting or stopping cycle |
+| 7 | Remote contact off |
+| 8 | Compressor buffer |
+
+Reference UI note: standby-reason display is normally gated on firmware version (parsed from `vr`, requires the firmware's embedded version digits to be `>= 41`) for plain HPM devices, but this gate is **bypassed** (reason is always shown) when the device is ZS500 — confirmed directly from the conditional `(firmwareDigits >= 41) || isHpmZs500Device`.
+
+Reasons `2` (too hot/too cold) and `5` (defrosting) are remapped to display as standby `status == 1` in the UI regardless of the raw `status` value — an app-side display quirk, not a separate wire enum.
+
+**Aux configuration (`ty`)** — string:
+| Value | Meaning |
+|---|---|
+| `"FP"` | Aux enabled (forced pump) |
+| `"UNK"` | Aux disabled |
+
+**Error code (`errorCode`)** — string. `"0"` means no active error. The reference UI formats single-digit codes as `E0{code}` and multi-digit codes as `E{code}` but does not catalogue specific non-zero code meanings anywhere in the HPM/ZS500 source. Error display itself (showing the error banner) is also gated on `isHpmZs500Device` — i.e. even though the `errorCode`/`errorTime` fields exist generically on `hp_0`, the reference UI only surfaces them for ZS500 devices in the home screen.
+
+---
+
+## Required Headers
+
+Header casing varies by call site in the reference and is reproduced here exactly as found:
+
+| Endpoint | Header | Value |
+|---|---|---|
+| Shadow GET (`/shadow`) | `authorization` (lowercase) | `{IdToken}` |
+| Shadow POST (`/shadow`) | `authorization` (lowercase) | `{IdToken}` |
+| Aux shadow GET/POST (`/shadow`) | `authorization` (lowercase) | `{IdToken}` |
+| `systemSetup` GET (aux config) | `api_key` + `authorization` (lowercase) | API key; `{IdToken}` |
+| `systemSetup` GET (service info) | `api_key` + `Authorization` (capital A) | API key; `{IdToken}` |
+| `systemSetup` POST (aux config) | `api_key` + `authorization` (lowercase) | API key; `{IdToken}` |
+| `systemSetup` POST (service info) | `api_key` + `authorization` (lowercase) | API key; `{IdToken}` |
+| OTA status GET | `authorization` (lowercase) | `{IdToken}` |
+| Aux shadow POST | `Content-Type: text/plain` | (declared on the request despite a JSON object body) |
+| `systemSetup` GET/POST (both variants) | `Content-Type: application/json` | — |
+| Shadow GET/POST, OTA GET | `Accept: application/json` | — |
+
+The `Content-Type: text/plain` on the aux shadow POST is reproduced as found in the reference's request interface declaration; the actual request body sent is a serialized JSON object, so this is very likely a labeling inconsistency in the reference app rather than a meaningful wire content-type — but it is what the reference declares.
+
+---
+
+## Signature / HMAC Mechanics (`signature` query parameter)
+
+Confirmed directly from the reference signing helper:
+
+- **Algorithm:** HMAC-SHA1.
+- **Key:** a per-environment API secret key (the same secret used for other signed endpoints across the app; not specific to ZS500).
+- **Canonical string:** `{first_argument}.toUpperCase() + "," + {second_argument}`, with no additional query-parameter segment appended when no extra params are supplied (the helper supports appending sorted `key=value&...` pairs after a second comma, but the two ZS500/HPM call sites observed pass an empty map).
+- **Output encoding:** lowercase **hexadecimal** digest string (not Base64).
+
+At the two confirmed ZS500/HPM call sites (WiFi-provisioning shadow-status check, and provisioning aux-details fetch), the arguments passed are:
+- First argument: the device serial number.
+- Second argument: the numeric user ID (`String.valueOf(userId)`), **not** an HTTP method name or timestamp.
+
+So concretely: `signature = hex(HMAC-SHA1(key = api_secret_key, message = "{SERIAL_UPPERCASE},{userId}"))`.
+
+This differs from a generic "HTTP method + URL + query params" signing scheme that exists elsewhere in the app's signing helper (used by other endpoints) — the ZS500/HPM shadow-signature call sites specifically use `serial` and `userId` as the two components, with an empty extra-params map.
+
+---
+
+## Timeouts and Retry Behavior
+
+No ZS500/HPM-specific timeout or retry configuration was found; the app's shared OkHttp client configuration applies (see [client.md](../client.md) for the shared HTTP client timeouts). No retry-on-failure logic specific to these endpoints was observed in the reference.
+
+---
+
+## Error Handling and Status Codes
+
+No ZS500/HPM-specific HTTP status-code handling beyond the shared network client's generic success/failure callback split was found. The reference's `errorCode` field on `hp_0` is the device-level error surface (distinct from HTTP-level errors) and is interpreted as "no error" only when its string value is exactly `"0"`.
+
+---
+
+## Real-Time Transport (MQTT)
+
+The reference Android app's primary and (for live status/control) **only observed transport** for ZS500/HPM is the AWS IoT device shadow over MQTT, using the same broker, topic structure, and credential model as the rest of the app's MQTT-based device types (matching the pattern documented for EXO in this repo's `exo.md`, but without any REST polling fallback for routine status — that fallback role is filled here only by the narrow provisioning-time REST calls listed above).
+
+**MQTT broker:** `a1zi08qpbrtjyq-ats.iot.us-east-1.amazonaws.com`
+
+**Topic patterns** (serial-scoped):
+
+| Operation | Topic |
+|---|---|
+| Request full shadow | `$aws/things/{serial}/shadow/get` (publish, empty payload) |
+| Receive full shadow | `$aws/things/{serial}/shadow/get/accepted` (subscribe) |
+| Subscribe to delta updates | `$aws/things/{serial}/shadow/update/accepted` (subscribe) |
+| Post desired state | `$aws/things/{serial}/shadow/update` (publish; payload is the same `{clientToken, deviceId, state: {desired: {...}}}` shape used by the REST write) |
+
+**Device-type routing:** the reference's central MQTT message router dispatches incoming shadow messages by the connected device's `device_type` string. Both `"hpm"` and `"zs500"` device types are routed to the same shared shadow-state handler/model — there is no separate ZS500 message handler. This was confirmed directly from the router's device-type-to-handler mapping table, where the `HPM` and `ZS500` device-type constants both map to the identical handler index.
+
+**Credentials:** short-lived Cognito session credentials obtained through the authenticated user session (consistent with the generic AWS IoT auth pattern used by other device types in this app — see client.md for the shared login/token flow that ultimately provisions these).
+
+---
+
+## BLE Provisioning
+
+BLE is used only for initial WiFi/network provisioning, not for ongoing communication — confirmed by the absence of any GATT read/write call sites in the home-screen or equipment-control view-models.
+
+The reference defines a distinct named UUID set for the ZS500 device type, but these UUID values are **byte-for-byte identical** to a second device-type constant set in the same file (used for the app's robot-cleaner ("vortrax") BLE provisioning flow) — this is shared generic BLE provisioning infrastructure reused across device types, not unique-per-device hardware identifiers, despite having ZS500-specific constant names.
+
+| UUID role | Value |
+|---|---|
+| Profile/Service (advertised) | `e355482b-45d9-c3a4-4d40-fee77d6f77f2` |
+| Service (GATT) | `0ad5190e-640d-4e05-9e47-2d2bb36c51e7` |
+| RX (app writes) | `f5cfc940-4341-4a3e-87f8-30c903d4dc96` |
+| TX (app subscribes/notifies) | `0fb6258a-9206-4923-9a2d-1d2ad6ee7adb` |
+
+**Frame format** (confirmed directly from the frame-builder helper):
+
+```
+"*@" + LENGTH_HEX(4 hex digits, uppercase) + ONES_COMPLEMENT_OF_LENGTH_HEX(4 hex digits, uppercase) + PAYLOAD + CRC16(4 hex digits, uppercase)
+```
+
+- `LENGTH_HEX` is the hex representation of the payload string's character length (not byte length), zero-padded to 4 digits.
+- The ones-complement step converts the length hex to a 16-bit binary string and flips each bit, then converts back to a zero-padded 4-digit hex string.
+- `CRC16` is computed over the entire frame *up to but not including* the CRC itself (i.e. over `"*@" + lengthHex + complementHex + payload`), using a standard CRC-16/ARC-style table-driven algorithm (initial value 0, table-based, polynomial consistent with CRC-16/ARC), rendered as 4-digit uppercase hex.
+
+**Provisioning payloads** (sent as the `PAYLOAD` portion of the frame above):
+
+| Purpose | Payload |
+|---|---|
+| Request serial number | `{"state":{"sn":1}}` |
+| Request SSID list | `{"state":{"ssid":1}}` |
+| Send WiFi credentials | `{"state":{"wi":{"sd":"{ssid}","pw":"{password}"}}}` |
+
+**Acknowledgement marker:** `$!##` — sent by the device to acknowledge receipt of a frame; the app checks incoming notification payloads against this exact literal.
+
+---
+
+## Not Observed / Needs Verification
+
+The following items could not be confirmed from the decompiled reference source and should not be assumed:
+
+1. Exact `aws.status` wire string values for ZS500 specifically (e.g. whether it is literally `"connected"`/`"disconnected"`) — the field exists but no string-literal comparison against it was found in the HPM/ZS500 code paths read.
+2. `hs` field semantics on `hp_0`.
+3. `hmi.ff.pg` sub-field (`bd`, `fs`, `ts`, `te`) purposes.
+4. Whether `sns_1`/`sns_2` `type`/`state` use standardized enumerations, and what their wire values are.
+5. Whether `fan` is an RPM value or a boolean-like flag — the UI only checks zero vs. nonzero.
+6. Catalogued `errorCode` string values and their meanings beyond `"0"` = no error.
+7. Catalogued `et` (equipment type) and `md` (model) field values.
+8. Whether the device ever reports temperatures in a unit other than the implied default (no unit-conversion logic was found for HPM/ZS500).
+9. Exact `status` field value range/semantics on `hp_0` beyond its use as an idle/zero gate.
+10. Whether ZS500 supports a REST-only (non-MQTT) operating mode in any other client/environment — only the Android reference app's call sites were examined.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
 ]
 dependencies = [
     "httpx[http2]>=0.27.0",
+    "awscrt>=0.34.1",
+    "awsiotsdk>=1.30.0",
 ]
 dynamic = [
     "version",

--- a/src/iaqualink/client.py
+++ b/src/iaqualink/client.py
@@ -46,6 +46,7 @@ for module_name in (
     "iaqualink.systems.exo.system",
     "iaqualink.systems.i2d.system",
     "iaqualink.systems.iaqua.system",
+    "iaqualink.systems.zs500.system",
 ):
     importlib.import_module(module_name)
 
@@ -130,12 +131,16 @@ class AqualinkClient:
         self.id_token = ""
         self.refresh_token = ""
         self.country = ""
+        self.iot_credentials: dict[str, str] | None = None
         self._refresh_lock = asyncio.Lock()
 
         self._last_refresh = 0
         # Populated after get_systems() returns. Requests made before that point
         # (login, device-list) will contain unmasked serials in debug-log URLs.
         self._log_serials: set[str] = set()
+        # Tracks systems returned by get_systems() so close() can release any
+        # held connections (e.g. a persistent MQTT session) on shutdown.
+        self._systems: dict[str, AqualinkSystem] = {}
 
     @property
     def logged(self) -> bool:
@@ -170,6 +175,10 @@ class AqualinkClient:
         self._logged = True
 
     async def close(self) -> None:
+        for system in self._systems.values():
+            await system.aclose()
+        self._systems = {}
+
         if self._must_close_client is False:
             return
 
@@ -343,6 +352,7 @@ class AqualinkClient:
         self.id_token = ""
         self.refresh_token = ""
         self.country = ""
+        self.iot_credentials = None
         self._logged = False
 
     def _apply_login_data(
@@ -360,6 +370,7 @@ class AqualinkClient:
             "RefreshToken", refresh_token_fallback
         )
         self.country = (data.get("country") or "us").lower()
+        self.iot_credentials = data.get("credentials")
         self._logged = True
 
     async def _send_systems_request(self) -> httpx.Response:
@@ -398,6 +409,23 @@ class AqualinkClient:
         LOGGER.debug("Systems body: %s", redact_value(data))
         LOGGER.debug("get_systems: %d system(s) discovered", len(data))
 
-        systems = [AqualinkSystem.from_data(self, x) for x in data]
-        self._log_serials.update(s.serial for s in systems if s.serial)
-        return {x.serial: x for x in systems}
+        # Reuse existing system instances when serial + device_type are
+        # unchanged, rather than rebuilding from scratch every call — a
+        # system can hold state (e.g. zs500's persistent MQTT connection)
+        # that a needless rebuild would silently drop and reconnect.
+        new_systems: dict[str, AqualinkSystem] = {}
+        for x in data:
+            serial = x.get("serial_number", "")
+            existing = self._systems.get(serial)
+            if existing is not None and existing.type == x.get("device_type"):
+                existing.data = x
+                new_systems[serial] = existing
+            else:
+                new_systems[serial] = AqualinkSystem.from_data(self, x)
+        self._log_serials.update(serial for serial in new_systems if serial)
+
+        for serial, old_system in self._systems.items():
+            if new_systems.get(serial) is not old_system:
+                await old_system.aclose()
+        self._systems = new_systems
+        return new_systems

--- a/src/iaqualink/const.py
+++ b/src/iaqualink/const.py
@@ -7,5 +7,8 @@ AQUALINK_LOGIN_URL = "https://prod.zodiac-io.com/users/v1/login"
 AQUALINK_REFRESH_URL = "https://prod.zodiac-io.com/users/v1/refresh"
 AQUALINK_DEVICES_URL = "https://r-api.iaqualink.net/v2/devices.json"
 
+AQUALINK_AWS_IOT_ENDPOINT = "a1zi08qpbrtjyq-ats.iot.us-east-1.amazonaws.com"
+AQUALINK_AWS_IOT_REGION = "us-east-1"
+
 KEEPALIVE_EXPIRY = 30
 DEFAULT_REQUEST_TIMEOUT = 10.0

--- a/src/iaqualink/system.py
+++ b/src/iaqualink/system.py
@@ -91,6 +91,14 @@ class AqualinkSystem(ABC):
             await self.refresh()
         return self.devices
 
+    async def aclose(self) -> None:
+        """Release any held connection/transport resources.
+
+        No-op by default. Systems that hold a persistent connection (e.g. a
+        long-lived MQTT session) override this to tear it down. Called by
+        :meth:`AqualinkClient.close` for every system it created.
+        """
+
     async def _send_with_reauth_retry(
         self,
         request_factory: Callable[[], Awaitable[httpx.Response]],

--- a/src/iaqualink/systems/zs500/__init__.py
+++ b/src/iaqualink/systems/zs500/__init__.py
@@ -1,0 +1,3 @@
+from iaqualink.systems.zs500 import device, system
+
+__all__ = ["device", "system"]

--- a/src/iaqualink/systems/zs500/device.py
+++ b/src/iaqualink/systems/zs500/device.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import logging
+from enum import Enum, IntEnum, unique
+from typing import TYPE_CHECKING
+
+from iaqualink.device import (
+    AqualinkBinarySensor,
+    AqualinkClimate,
+    AqualinkDevice,
+    AqualinkSelect,
+    AqualinkSensor,
+    AqualinkSwitch,
+)
+
+# DeviceData is dict[str, str] for the whole codebase even though the actual
+# values on the wire are a JSON mix of str/int/dict — every system reads
+# through str()/int()/float() casts rather than relying on the static type.
+# See src/iaqualink/systems/i2d/device.py for the established convention.
+
+if TYPE_CHECKING:
+    from iaqualink.systems.zs500.system import Zs500System
+    from iaqualink.typing import DeviceData
+
+LOGGER = logging.getLogger("iaqualink.systems.zs500")
+
+# Wire temperatures (tsp, sns_1.value, sns_2.value) are the actual value x10.
+ZS500_TEMP_SCALE = 10
+ZS500_TEMP_CELSIUS_LOW = 15
+ZS500_TEMP_CELSIUS_HIGH = 32
+
+
+@unique
+class Zs500Mode(IntEnum):
+    BOOST = 0
+    SILENT = 1
+    SMART = 2
+
+
+@unique
+class Zs500StandbyReason(Enum):
+    """String-valued so it round-trips through AqualinkSensor.value (str)."""
+
+    NONE = "0"
+    NO_WATER_FLOW = "1"
+    TEMP_OUT_OF_RANGE = "2"
+    TEMPERATURE_BUFFER = "3"
+    COOL_MODE_DISABLED = "4"
+    DEFROSTING = "5"
+    STARTING_OR_STOPPING = "6"
+    REMOTE_CONTACT_OFF = "7"
+    COMPRESSOR_BUFFER = "8"
+
+
+class Zs500Device(AqualinkDevice):
+    def __init__(self, system: Zs500System, data: DeviceData):
+        super().__init__(system, data)
+
+        # This silences mypy errors due to AqualinkDevice type annotations.
+        self.system: Zs500System = system
+
+    @property
+    def name(self) -> str:
+        return self.data["name"]
+
+    @property
+    def label(self) -> str:
+        return " ".join(x.capitalize() for x in self.name.split("_"))
+
+    @property
+    def manufacturer(self) -> str:
+        return "Zodiac"
+
+    @property
+    def model(self) -> str:
+        return self.__class__.__name__.replace("Zs500", "")
+
+    @classmethod
+    def from_data(cls, system: Zs500System, data: DeviceData) -> Zs500Device:
+        class_: type[Zs500Device]
+
+        name = data["name"]
+        if name == "climate":
+            class_ = Zs500Climate
+        elif name == "mode":
+            class_ = Zs500ModeSelect
+        elif name == "cooling":
+            class_ = Zs500CoolingSwitch
+        elif name == "heating_priority":
+            class_ = Zs500HeatingPrioritySwitch
+        elif name in ("water_temp", "air_temp"):
+            class_ = Zs500TemperatureSensor
+        elif name == "compressor_speed":
+            class_ = Zs500CompressorSpeedSensor
+        elif name == "standby_reason":
+            class_ = Zs500StandbyReasonSensor
+        elif name == "error":
+            class_ = Zs500ErrorBinarySensor
+        else:
+            raise ValueError(f"Unknown zs500 device name: {name!r}")
+
+        return class_(system, data)
+
+
+class Zs500Climate(Zs500Device, AqualinkClimate):
+    """The `hp_0` heat pump core — on/off, mode, and temperature control."""
+
+    @property
+    def is_on(self) -> bool:
+        return int(self.data.get("state") or 0) > 0
+
+    async def turn_on(self) -> None:
+        if not self.is_on:
+            # 1 = Standby; the device picks Heat/Cool on its own from there.
+            await self.system.set_desired({"state": 1})
+
+    async def turn_off(self) -> None:
+        if self.is_on:
+            await self.system.set_desired({"state": 0})
+
+    @property
+    def temperature_unit(self) -> str:
+        return self.system.temp_unit
+
+    @property
+    def current_temperature(self) -> str | None:
+        # Water temperature is reported as its own sibling device (sns_1) —
+        # same cross-reference pattern as ExoClimate's sensor lookup.
+        sensor = self.system.devices.get("water_temp")
+        if isinstance(sensor, AqualinkSensor):
+            return sensor.value
+        return None
+
+    @property
+    def target_temperature(self) -> str | None:
+        tsp = self.data.get("tsp")
+        if tsp is None:
+            return None
+        return str(round(float(tsp) / ZS500_TEMP_SCALE, 1))
+
+    @property
+    def min_temp(self) -> int:
+        return ZS500_TEMP_CELSIUS_LOW
+
+    @property
+    def max_temp(self) -> int:
+        return ZS500_TEMP_CELSIUS_HIGH
+
+    async def _set_temperature(self, temperature: int) -> None:
+        await self.system.set_desired({"tsp": temperature * ZS500_TEMP_SCALE})
+
+
+class Zs500ModeSelect(Zs500Device, AqualinkSelect):
+    """Boost / Silent / Smart (`st`)."""
+
+    @property
+    def current_option(self) -> str | None:
+        st = self.data.get("st")
+        if st is None:
+            return None
+        try:
+            return Zs500Mode(int(st)).name.capitalize()
+        except ValueError:
+            return None
+
+    @property
+    def options(self) -> list[str]:
+        return [m.name.capitalize() for m in Zs500Mode]
+
+    async def _select_option(self, option: str) -> None:
+        mode = Zs500Mode[option.upper()]
+        await self.system.set_desired({"st": mode.value})
+
+
+class Zs500Switch(Zs500Device, AqualinkSwitch):
+    """Abstract: a single boolean field under `hp_0`."""
+
+    _field: str
+
+    @property
+    def is_on(self) -> bool:
+        return int(self.data.get(self._field) or 0) > 0
+
+    async def turn_on(self) -> None:
+        if not self.is_on:
+            await self.system.set_desired({self._field: 1})
+
+    async def turn_off(self) -> None:
+        if self.is_on:
+            await self.system.set_desired({self._field: 0})
+
+
+class Zs500CoolingSwitch(Zs500Switch):
+    _field = "cl"
+
+
+class Zs500HeatingPrioritySwitch(Zs500Switch):
+    _field = "hp"
+
+
+class Zs500Sensor(Zs500Device, AqualinkSensor):
+    """Abstract base for read-only hp_0-derived sensors."""
+
+
+class Zs500TemperatureSensor(Zs500Sensor):
+    @property
+    def value(self) -> str:
+        raw = self.data.get("value")
+        if raw is None:
+            return ""
+        return str(round(float(raw) / ZS500_TEMP_SCALE, 1))
+
+    @property
+    def unit_of_measurement(self) -> str | None:
+        return self.system.temp_unit
+
+
+class Zs500CompressorSpeedSensor(Zs500Sensor):
+    @property
+    def value(self) -> str:
+        return str(self.data.get("cmprSpd") or 0)
+
+    @property
+    def unit_of_measurement(self) -> str | None:
+        return "%"
+
+
+class Zs500StandbyReasonSensor(Zs500Sensor):
+    @property
+    def value(self) -> str:
+        return str(self.data.get("reason") or 0)
+
+    @property
+    def value_enum(self) -> type[Enum] | None:
+        return Zs500StandbyReason
+
+
+class Zs500ErrorBinarySensor(Zs500Device, AqualinkBinarySensor):
+    """True when `errorCode` is anything other than `"0"`."""
+
+    @property
+    def is_on(self) -> bool:
+        return (self.data.get("errorCode") or "0") != "0"

--- a/src/iaqualink/systems/zs500/system.py
+++ b/src/iaqualink/systems/zs500/system.py
@@ -6,6 +6,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, TypeVar
 
+import httpx
 from awscrt import auth, mqtt5
 from awsiot import iotshadow, mqtt5_client_builder
 
@@ -57,9 +58,9 @@ _MIN_CONNECTED_TIME_TO_RESET_RECONNECT_DELAY_MS = 20000
 def _error_for_rejected(response: Any) -> AqualinkServiceException:
     code = getattr(response, "code", None)
     message = getattr(response, "message", None) or "Shadow operation rejected"
-    if code == 401:
+    if code == httpx.codes.UNAUTHORIZED:
         return AqualinkServiceUnauthorizedException(message)
-    if code == 429:
+    if code == httpx.codes.TOO_MANY_REQUESTS:
         return AqualinkServiceThrottledException(message)
     return AqualinkServiceException(f"{message} (code={code})")
 

--- a/src/iaqualink/systems/zs500/system.py
+++ b/src/iaqualink/systems/zs500/system.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from awscrt import auth, mqtt5
+from awsiot import iotshadow, mqtt5_client_builder
+
+from iaqualink.const import AQUALINK_AWS_IOT_ENDPOINT, AQUALINK_AWS_IOT_REGION
+from iaqualink.exception import (
+    AqualinkServiceException,
+    AqualinkServiceThrottledException,
+    AqualinkServiceUnauthorizedException,
+)
+from iaqualink.system import AqualinkSystem, SystemStatus
+from iaqualink.systems.zs500.device import Zs500Device
+from iaqualink.utils.redact import mask_serial, redact_value
+
+if TYPE_CHECKING:
+    from iaqualink.client import AqualinkClient
+    from iaqualink.typing import Payload
+
+LOGGER = logging.getLogger("iaqualink.systems.zs500")
+
+T = TypeVar("T")
+
+# aws.status wire values for ZS500 were not independently confirmed in the
+# reference source (see docs/reference/systems/zs500.md). Reusing eXO's
+# mapping table since both device types share the same shadow "aws" block —
+# see "Deltas vs Protocol Reference" in the implementation notes.
+_ZS500_STATUS_MAP: dict[str, SystemStatus] = {
+    "connected": SystemStatus.CONNECTED,
+    "online": SystemStatus.ONLINE,
+    "offline": SystemStatus.OFFLINE,
+    "disconnected": SystemStatus.DISCONNECTED,
+    "unknown": SystemStatus.UNKNOWN,
+    "service": SystemStatus.SERVICE,
+    "firmware_update": SystemStatus.FIRMWARE_UPDATE,
+}
+
+_CONNECT_TIMEOUT = 10.0
+_SUBSCRIBE_TIMEOUT = 10.0
+_OPERATION_TIMEOUT = 10.0
+_DISCONNECT_TIMEOUT = 5.0
+
+# MQTT connection parameters, taken from the reference app's own AWS IoT
+# client configuration (decomp-confirmed, see docs/reference/systems/zs500.md).
+_KEEPALIVE_INTERVAL_SEC = 60
+_MIN_RECONNECT_DELAY_MS = 1000
+_MAX_RECONNECT_DELAY_MS = 30000
+_MIN_CONNECTED_TIME_TO_RESET_RECONNECT_DELAY_MS = 20000
+
+
+def _error_for_rejected(response: Any) -> AqualinkServiceException:
+    code = getattr(response, "code", None)
+    message = getattr(response, "message", None) or "Shadow operation rejected"
+    if code == 401:
+        return AqualinkServiceUnauthorizedException(message)
+    if code == 429:
+        return AqualinkServiceThrottledException(message)
+    return AqualinkServiceException(f"{message} (code={code})")
+
+
+class Zs500System(AqualinkSystem):
+    NAME = "zs500"
+
+    def __init__(self, aqualink: AqualinkClient, data: Payload):
+        super().__init__(aqualink, data)
+        self.temp_unit = "C"
+
+        self._mqtt: mqtt5.Client | None = None
+        self._shadow: iotshadow.IotShadowClient | None = None
+        self._stopped: asyncio.Future[None] | None = None
+        self._connect_lock = asyncio.Lock()
+        self._pending: dict[str, asyncio.Future[Any]] = {}
+
+    def __repr__(self) -> str:
+        attrs = ["name", "serial", "data"]
+        attrs = [f"{i}={getattr(self, i)!r}" for i in attrs]
+        return f"{self.__class__.__name__}({' '.join(attrs)})"
+
+    # -- connection lifecycle -------------------------------------------------
+
+    async def _ensure_connected(self) -> iotshadow.IotShadowClient:
+        async with self._connect_lock:
+            if self._shadow is not None:
+                return self._shadow
+
+            credentials = self.aqualink.iot_credentials
+            if not credentials:
+                raise AqualinkServiceUnauthorizedException(
+                    "No AWS IoT credentials available; login or refresh first."
+                )
+
+            loop = asyncio.get_running_loop()
+            connected: asyncio.Future[None] = loop.create_future()
+            stopped: asyncio.Future[None] = loop.create_future()
+
+            credentials_provider = auth.AwsCredentialsProvider.new_static(
+                credentials["AccessKeyId"],
+                credentials["SecretKey"],
+                credentials.get("SessionToken"),
+            )
+
+            def _on_success(_data: Any) -> None:
+                loop.call_soon_threadsafe(_resolve, connected, None, None)
+
+            def _on_failure(data: Any) -> None:
+                exc = getattr(data, "exception", None)
+                if not isinstance(exc, BaseException):
+                    exc = AqualinkServiceException("MQTT connection failed")
+                loop.call_soon_threadsafe(_resolve, connected, None, exc)
+
+            def _on_stopped(_data: Any) -> None:
+                loop.call_soon_threadsafe(_resolve, stopped, None, None)
+
+            mqtt = mqtt5_client_builder.websockets_with_default_aws_signing(
+                endpoint=AQUALINK_AWS_IOT_ENDPOINT,
+                region=AQUALINK_AWS_IOT_REGION,
+                credentials_provider=credentials_provider,
+                client_id=str(uuid.uuid4()),
+                keep_alive_interval_sec=_KEEPALIVE_INTERVAL_SEC,
+                min_reconnect_delay_ms=_MIN_RECONNECT_DELAY_MS,
+                max_reconnect_delay_ms=_MAX_RECONNECT_DELAY_MS,
+                min_connected_time_to_reset_reconnect_delay_ms=_MIN_CONNECTED_TIME_TO_RESET_RECONNECT_DELAY_MS,
+                on_lifecycle_connection_success=_on_success,
+                on_lifecycle_connection_failure=_on_failure,
+                on_lifecycle_stopped=_on_stopped,
+            )
+            mqtt.start()
+
+            try:
+                await asyncio.wait_for(connected, timeout=_CONNECT_TIMEOUT)
+            except Exception as e:
+                mqtt.stop()
+                raise AqualinkServiceException(
+                    f"MQTT connection failed: {e}"
+                ) from e
+
+            shadow = iotshadow.IotShadowClient(mqtt)
+            try:
+                await self._subscribe_all(shadow)
+            except Exception as e:
+                mqtt.stop()
+                raise AqualinkServiceException(
+                    f"MQTT subscribe failed: {e}"
+                ) from e
+
+            self._mqtt = mqtt
+            self._shadow = shadow
+            self._stopped = stopped
+            return shadow
+
+    async def _subscribe_all(self, shadow: iotshadow.IotShadowClient) -> None:
+        loop = asyncio.get_running_loop()
+
+        def _on_accept(response: Any) -> None:
+            loop.call_soon_threadsafe(
+                self._resolve_pending, response.client_token, response, None
+            )
+
+        def _on_reject(response: Any) -> None:
+            loop.call_soon_threadsafe(
+                self._resolve_pending,
+                response.client_token,
+                None,
+                _error_for_rejected(response),
+            )
+
+        def _on_push(event: iotshadow.ShadowUpdatedEvent) -> None:
+            current = event.current
+            state = current.state if current is not None else None
+            reported = state.reported if state is not None else None
+            loop.call_soon_threadsafe(
+                self._apply_reported_state, reported or {}
+            )
+
+        subscriptions = [
+            shadow.subscribe_to_get_shadow_accepted(
+                request=iotshadow.GetShadowSubscriptionRequest(
+                    thing_name=self.serial
+                ),
+                qos=mqtt5.QoS.AT_LEAST_ONCE,
+                callback=_on_accept,
+            ),
+            shadow.subscribe_to_get_shadow_rejected(
+                request=iotshadow.GetShadowSubscriptionRequest(
+                    thing_name=self.serial
+                ),
+                qos=mqtt5.QoS.AT_LEAST_ONCE,
+                callback=_on_reject,
+            ),
+            shadow.subscribe_to_update_shadow_accepted(
+                request=iotshadow.UpdateShadowSubscriptionRequest(
+                    thing_name=self.serial
+                ),
+                qos=mqtt5.QoS.AT_LEAST_ONCE,
+                callback=_on_accept,
+            ),
+            shadow.subscribe_to_update_shadow_rejected(
+                request=iotshadow.UpdateShadowSubscriptionRequest(
+                    thing_name=self.serial
+                ),
+                qos=mqtt5.QoS.AT_LEAST_ONCE,
+                callback=_on_reject,
+            ),
+            shadow.subscribe_to_shadow_updated_events(
+                request=iotshadow.ShadowUpdatedSubscriptionRequest(
+                    thing_name=self.serial
+                ),
+                qos=mqtt5.QoS.AT_LEAST_ONCE,
+                callback=_on_push,
+            ),
+        ]
+        await asyncio.wait_for(
+            asyncio.gather(
+                *(
+                    asyncio.wrap_future(future)
+                    for future, _topic in subscriptions
+                )
+            ),
+            timeout=_SUBSCRIBE_TIMEOUT,
+        )
+
+    async def _disconnect(self) -> None:
+        async with self._connect_lock:
+            mqtt = self._mqtt
+            stopped = self._stopped
+            self._mqtt = None
+            self._shadow = None
+            self._stopped = None
+
+            if mqtt is None:
+                return
+
+            mqtt.stop()
+            if stopped is not None:
+                try:
+                    await asyncio.wait_for(stopped, timeout=_DISCONNECT_TIMEOUT)
+                except Exception:
+                    LOGGER.debug(
+                        "MQTT client for %s did not confirm stop within %ss",
+                        mask_serial(self.serial),
+                        _DISCONNECT_TIMEOUT,
+                    )
+
+    async def aclose(self) -> None:
+        await self._disconnect()
+
+    # -- request/response correlation -----------------------------------------
+
+    def _resolve_pending(
+        self, token: str | None, result: Any, exc: BaseException | None
+    ) -> None:
+        fut = self._pending.get(token) if token else None
+        if fut is None or fut.done():
+            return
+        if exc is not None:
+            fut.set_exception(exc)
+        else:
+            fut.set_result(result)
+
+    async def _call_with_reauth_retry(
+        self, operation: Callable[[], Awaitable[T]]
+    ) -> T:
+        try:
+            return await operation()
+        except AqualinkServiceUnauthorizedException:
+            await self._disconnect()
+            self.aqualink._logged = False  # noqa: SLF001
+            await self.aqualink._refresh_auth()  # noqa: SLF001
+            return await operation()
+
+    # -- shadow get/update -----------------------------------------------------
+
+    async def _refresh(self) -> None:
+        await self._call_with_reauth_retry(self._shadow_get)
+
+    async def _shadow_get(self) -> None:
+        shadow = await self._ensure_connected()
+
+        token = str(uuid.uuid4())
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[Any] = loop.create_future()
+        self._pending[token] = fut
+        try:
+            try:
+                publish_future = shadow.publish_get_shadow(
+                    request=iotshadow.GetShadowRequest(
+                        thing_name=self.serial, client_token=token
+                    ),
+                    qos=mqtt5.QoS.AT_LEAST_ONCE,
+                )
+                await asyncio.wrap_future(publish_future)
+                response = await asyncio.wait_for(
+                    fut, timeout=_OPERATION_TIMEOUT
+                )
+            except AqualinkServiceException:
+                raise
+            except Exception as e:
+                # Most likely a concurrent aclose()/reconnect tore down the
+                # connection out from under this in-flight operation.
+                raise AqualinkServiceException(
+                    f"zs500 shadow get failed: {e}"
+                ) from e
+        finally:
+            self._pending.pop(token, None)
+
+        reported = response.state.reported if response.state else None
+        self._apply_reported_state(reported or {})
+
+    async def set_desired(self, hp_0_delta: Payload) -> None:
+        """Publish a desired-state delta for the `equipment.hp_0` object.
+
+        Only the changed fields need to be included.
+        """
+        await self._call_with_reauth_retry(
+            lambda: self._shadow_update(hp_0_delta)
+        )
+
+    async def _shadow_update(self, hp_0_delta: dict[str, Any]) -> None:
+        shadow = await self._ensure_connected()
+
+        token = str(uuid.uuid4())
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[Any] = loop.create_future()
+        self._pending[token] = fut
+        try:
+            try:
+                publish_future = shadow.publish_update_shadow(
+                    request=iotshadow.UpdateShadowRequest(
+                        thing_name=self.serial,
+                        client_token=token,
+                        state=iotshadow.ShadowState(
+                            desired={"equipment": {"hp_0": hp_0_delta}}
+                        ),
+                    ),
+                    qos=mqtt5.QoS.AT_LEAST_ONCE,
+                )
+                await asyncio.wrap_future(publish_future)
+                await asyncio.wait_for(fut, timeout=_OPERATION_TIMEOUT)
+            except AqualinkServiceException:
+                raise
+            except Exception as e:
+                raise AqualinkServiceException(
+                    f"zs500 shadow update failed: {e}"
+                ) from e
+        finally:
+            self._pending.pop(token, None)
+
+    # -- parsing -----------------------------------------------------------
+
+    def _apply_reported_state(self, reported: dict[str, Any]) -> None:
+        LOGGER.debug("Shadow reported: %s", redact_value(reported))
+
+        # reported["aws"] can be missing, an explicit null, or a dict on the
+        # wire — `or {}` collapses all three to a safe default before .get().
+        raw_status: Any = (reported.get("aws") or {}).get("status")
+        if raw_status in (None, ""):
+            self.status = SystemStatus.UNKNOWN
+        else:
+            mapped = _ZS500_STATUS_MAP.get(raw_status)
+            if mapped is None:
+                LOGGER.warning(
+                    "Unknown aws.status %r for system %s (%s); treating as Unknown.",
+                    raw_status,
+                    mask_serial(self.serial),
+                    self.type,
+                )
+                self.status = SystemStatus.UNKNOWN
+            else:
+                self.status = mapped
+        LOGGER.debug(
+            "Shadow parsed: serial=%s status=%s",
+            mask_serial(self.serial),
+            self.status.name,
+        )
+
+        hp_0: Any = (reported.get("equipment") or {}).get("hp_0")
+        if not hp_0:
+            return
+
+        devices: dict[str, dict[str, Any]] = {
+            "climate": {
+                "name": "climate",
+                "state": hp_0.get("state", 0),
+                "tsp": hp_0.get("tsp", 0),
+            },
+            "mode": {"name": "mode", "st": hp_0.get("st", 0)},
+            "cooling": {"name": "cooling", "cl": hp_0.get("cl", 0)},
+            "heating_priority": {
+                "name": "heating_priority",
+                "hp": hp_0.get("hp", 0),
+            },
+            "compressor_speed": {
+                "name": "compressor_speed",
+                "cmprSpd": hp_0.get("cmprSpd", 0),
+            },
+            "standby_reason": {
+                "name": "standby_reason",
+                "reason": hp_0.get("reason", 0),
+            },
+            "error": {
+                "name": "error",
+                "errorCode": hp_0.get("errorCode") or "0",
+                "errorTime": hp_0.get("errorTime"),
+            },
+        }
+        if "sns_1" in hp_0:
+            devices["water_temp"] = {"name": "water_temp", **hp_0["sns_1"]}
+        if "sns_2" in hp_0:
+            devices["air_temp"] = {"name": "air_temp", **hp_0["sns_2"]}
+
+        for key, value in devices.items():
+            if key in self.devices:
+                self.devices[key].data = value
+            else:
+                self.devices[key] = Zs500Device.from_data(self, value)
+
+
+def _resolve(
+    fut: asyncio.Future[Any], result: Any, exc: BaseException | None
+) -> None:
+    if fut.done():
+        return
+    if exc is not None:
+        fut.set_exception(exc)
+    else:
+        fut.set_result(result)

--- a/tests/systems/zs500/conftest.py
+++ b/tests/systems/zs500/conftest.py
@@ -1,0 +1,232 @@
+"""Test harness for zs500's MQTT shadow transport.
+
+The conformance suite (tests/conformance/*) mocks httpx via respx and assumes
+every system command/refresh goes over HTTP. zs500 goes over MQTT instead, so
+none of its factories participate there (see factories.py) — this harness is
+the bespoke substitute, faking the awsiotsdk shadow client directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import Future as CFuture
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from awsiot import iotshadow
+
+from iaqualink.client import AqualinkClient
+from iaqualink.system import AqualinkSystem
+from iaqualink.systems.zs500.system import Zs500System
+
+ZS500_SYSTEM_DATA: dict[str, Any] = {
+    "id": 1,
+    "serial_number": "SN123456",
+    "device_type": "zs500",
+    "name": "Pool Heat Pump",
+}
+
+
+def _done_future(result: Any) -> CFuture:
+    f: CFuture = CFuture()
+    f.set_result(result)
+    return f
+
+
+def _failing_future(exc: BaseException) -> CFuture:
+    f: CFuture = CFuture()
+    f.set_exception(exc)
+    return f
+
+
+class FakeShadowClient:
+    """Stand-in for awsiot.iotshadow.IotShadowClient.
+
+    Records every publish and auto-replies on the matching accepted/rejected
+    topic using whichever client_token the caller sent, mirroring how AWS IoT
+    correlates shadow operations in practice.
+    """
+
+    def __init__(self) -> None:
+        self.published_gets: list[str | None] = []
+        self.published_updates: list[dict[str, Any]] = []
+        self._get_accept: Any = None
+        self._get_reject: Any = None
+        self._update_accept: Any = None
+        self._update_reject: Any = None
+        self._push: Any = None
+
+        self.get_response: dict[str, Any] = {}
+        self.get_reject_code: int | None = None
+        self.update_reject_code: int | None = None
+        # When set, publish_get_shadow/publish_update_shadow accept the
+        # publish but never call either the accept or reject callback —
+        # simulates an operation that times out waiting for a response.
+        self.silent: bool = False
+        # When set, the first subscribe_to_* call fails — simulates a
+        # subscribe failure right after a successful connect.
+        self.subscribe_fails: bool = False
+
+    # -- subscribe_to_* (returns (Future, topic), per awsiotsdk convention) --
+
+    def subscribe_to_get_shadow_accepted(
+        self, *, request: Any, qos: Any, callback: Any
+    ) -> Any:
+        self._get_accept = callback
+        if self.subscribe_fails:
+            return (
+                _failing_future(RuntimeError("simulated subscribe failure")),
+                "get/accepted",
+            )
+        return _done_future(0), "get/accepted"
+
+    def subscribe_to_get_shadow_rejected(
+        self, *, request: Any, qos: Any, callback: Any
+    ) -> Any:
+        self._get_reject = callback
+        return _done_future(0), "get/rejected"
+
+    def subscribe_to_update_shadow_accepted(
+        self, *, request: Any, qos: Any, callback: Any
+    ) -> Any:
+        self._update_accept = callback
+        return _done_future(0), "update/accepted"
+
+    def subscribe_to_update_shadow_rejected(
+        self, *, request: Any, qos: Any, callback: Any
+    ) -> Any:
+        self._update_reject = callback
+        return _done_future(0), "update/rejected"
+
+    def subscribe_to_shadow_updated_events(
+        self, *, request: Any, qos: Any, callback: Any
+    ) -> Any:
+        self._push = callback
+        return _done_future(0), "update/documents"
+
+    # -- publish_* (returns just a Future, per awsiotsdk convention) --
+
+    def publish_get_shadow(self, *, request: Any, qos: Any) -> Any:
+        self.published_gets.append(request.client_token)
+        if self.silent:
+            return _done_future(None)
+        loop = asyncio.get_running_loop()
+        if self.get_reject_code is not None:
+            response = iotshadow.ErrorResponse(
+                client_token=request.client_token,
+                code=self.get_reject_code,
+                message="rejected",
+            )
+            loop.call_soon(self._get_reject, response)
+        else:
+            response = iotshadow.GetShadowResponse(
+                client_token=request.client_token,
+                state=iotshadow.ShadowState(reported=self.get_response),
+            )
+            loop.call_soon(self._get_accept, response)
+        return _done_future(None)
+
+    def publish_update_shadow(self, *, request: Any, qos: Any) -> Any:
+        self.published_updates.append(request.state.desired)
+        if self.silent:
+            return _done_future(None)
+        loop = asyncio.get_running_loop()
+        if self.update_reject_code is not None:
+            response = iotshadow.ErrorResponse(
+                client_token=request.client_token,
+                code=self.update_reject_code,
+                message="rejected",
+            )
+            loop.call_soon(self._update_reject, response)
+        else:
+            response = iotshadow.UpdateShadowResponse(
+                client_token=request.client_token
+            )
+            loop.call_soon(self._update_accept, response)
+        return _done_future(None)
+
+    # -- test helper: simulate a device-initiated (or anyone-initiated) push --
+
+    def push(self, reported: dict[str, Any]) -> None:
+        event = iotshadow.ShadowUpdatedEvent(
+            current=iotshadow.ShadowUpdatedSnapshot(
+                state=iotshadow.ShadowState(reported=reported)
+            )
+        )
+        assert self._push is not None, "not subscribed yet"
+        self._push(event)
+
+
+class ConnectControl:
+    """Mutable connect-outcome knob, read fresh on every connect attempt —
+    lets a test flip `connect_succeeds` between calls to exercise both a
+    failed first connect and a successful reconnect."""
+
+    def __init__(self) -> None:
+        self.connect_succeeds = True
+
+
+def _make_builder(mqtt_mock: MagicMock, control: ConnectControl) -> Any:
+    def _builder(**kwargs: Any) -> MagicMock:
+        on_stopped = kwargs.get("on_lifecycle_stopped")
+
+        def _stop(*_args: Any, **_kwargs: Any) -> None:
+            if on_stopped is not None:
+                asyncio.get_running_loop().call_soon(on_stopped, MagicMock())
+
+        mqtt_mock.stop.side_effect = _stop
+
+        if control.connect_succeeds:
+            kwargs["on_lifecycle_connection_success"](MagicMock())
+        else:
+            failure = MagicMock(
+                exception=AssertionError("simulated connect failure")
+            )
+            kwargs["on_lifecycle_connection_failure"](failure)
+        return mqtt_mock
+
+    return _builder
+
+
+@dataclass
+class Zs500Harness:
+    """Bundles a Zs500System with its faked MQTT transport for assertions."""
+
+    system: Zs500System
+    shadow: FakeShadowClient
+    mqtt: MagicMock
+    connect_control: ConnectControl
+
+
+@pytest.fixture
+def zs500_harness(monkeypatch: pytest.MonkeyPatch) -> Zs500Harness:
+    client = AqualinkClient("foo", "bar")
+    client.iot_credentials = {
+        "AccessKeyId": "AKIDEXAMPLE",
+        "SecretKey": "SECRETEXAMPLE",
+        "SessionToken": "TOKENEXAMPLE",
+    }
+    system = AqualinkSystem.from_data(client, data=ZS500_SYSTEM_DATA)
+    assert isinstance(system, Zs500System)
+
+    mqtt_mock = MagicMock()
+    fake_shadow = FakeShadowClient()
+    connect_control = ConnectControl()
+
+    monkeypatch.setattr(
+        "iaqualink.systems.zs500.system.mqtt5_client_builder.websockets_with_default_aws_signing",
+        _make_builder(mqtt_mock, connect_control),
+    )
+    monkeypatch.setattr(
+        "iaqualink.systems.zs500.system.iotshadow.IotShadowClient",
+        lambda _mqtt: fake_shadow,
+    )
+
+    return Zs500Harness(
+        system=system,
+        shadow=fake_shadow,
+        mqtt=mqtt_mock,
+        connect_control=connect_control,
+    )

--- a/tests/systems/zs500/factories.py
+++ b/tests/systems/zs500/factories.py
@@ -1,0 +1,27 @@
+"""zs500 conformance-fixture declarations.
+
+zs500 commands go over a persistent MQTT shadow connection rather than
+httpx, and the conformance suite (tests/conformance/*) only mocks httpx via
+respx — every generic contract test there asserts against
+``respx_mock.calls``, which would always be empty for zs500. So none of
+zs500's factories participate; all lists are declared empty per the
+discovery convention (see tests/conformance/conftest.py), and correctness is
+covered instead by the bespoke tests in this directory (test_system.py,
+test_device.py) using the FakeShadowClient harness in conftest.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+zs500_device_factories: list[tuple[str, Callable[[], Any]]] = []
+zs500_sensor_factories: list[tuple[str, Callable[[], Any]]] = []
+zs500_binary_sensor_factories: list[tuple[str, Callable[[], Any]]] = []
+zs500_switch_factories: list[tuple[str, Callable[[], Any]]] = []
+zs500_light_factories: list[tuple[str, Callable[[], Any]]] = []
+zs500_climate_factories: list[tuple[str, Callable[[], Any]]] = []
+zs500_number_factories: list[tuple[str, Callable[[], Any]]] = []
+zs500_select_factories: list[tuple[str, Callable[[], Any]]] = []
+zs500_fan_factories: list[tuple[str, Callable[[], Any]]] = []
+zs500_system_factories: list[tuple[str, Callable[[], Any]]] = []

--- a/tests/systems/zs500/test_device.py
+++ b/tests/systems/zs500/test_device.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from iaqualink.client import AqualinkClient
+from iaqualink.exception import AqualinkInvalidParameterException
+from iaqualink.systems.zs500.device import (
+    ZS500_TEMP_CELSIUS_HIGH,
+    ZS500_TEMP_CELSIUS_LOW,
+    Zs500Climate,
+    Zs500CompressorSpeedSensor,
+    Zs500CoolingSwitch,
+    Zs500Device,
+    Zs500ErrorBinarySensor,
+    Zs500HeatingPrioritySwitch,
+    Zs500ModeSelect,
+    Zs500StandbyReasonSensor,
+    Zs500TemperatureSensor,
+)
+from iaqualink.systems.zs500.system import Zs500System
+
+
+def make_system() -> Zs500System:
+    client = AqualinkClient("foo", "bar")
+    data: dict[str, Any] = {
+        "id": 1,
+        "serial_number": "SN123456",
+        "device_type": "zs500",
+        "name": "Pool Heat Pump",
+    }
+    return Zs500System(client, data=data)
+
+
+def from_data(system: Zs500System, data: dict[str, Any]) -> Zs500Device:
+    return Zs500Device.from_data(system, data)
+
+
+def make_climate(
+    system: Zs500System, *, state: int, tsp: int = 250
+) -> Zs500Climate:
+    data: dict[str, Any] = {"name": "climate", "state": state, "tsp": tsp}
+    return cast(Zs500Climate, from_data(system, data))
+
+
+def make_mode(system: Zs500System, *, st: int) -> Zs500ModeSelect:
+    data: dict[str, Any] = {"name": "mode", "st": st}
+    return cast(Zs500ModeSelect, from_data(system, data))
+
+
+def make_cooling(system: Zs500System, *, cl: int) -> Zs500CoolingSwitch:
+    data: dict[str, Any] = {"name": "cooling", "cl": cl}
+    return cast(Zs500CoolingSwitch, from_data(system, data))
+
+
+def make_heating_priority(
+    system: Zs500System, *, hp: int
+) -> Zs500HeatingPrioritySwitch:
+    data: dict[str, Any] = {"name": "heating_priority", "hp": hp}
+    return cast(Zs500HeatingPrioritySwitch, from_data(system, data))
+
+
+def make_temperature_sensor(
+    system: Zs500System, *, name: str, value: int | None
+) -> Zs500TemperatureSensor:
+    data: dict[str, Any] = {"name": name}
+    if value is not None:
+        data["value"] = value
+    return cast(Zs500TemperatureSensor, from_data(system, data))
+
+
+def make_compressor_speed(
+    system: Zs500System, *, cmpr_spd: int
+) -> Zs500CompressorSpeedSensor:
+    data: dict[str, Any] = {"name": "compressor_speed", "cmprSpd": cmpr_spd}
+    return cast(Zs500CompressorSpeedSensor, from_data(system, data))
+
+
+def make_standby_reason(
+    system: Zs500System, *, reason: int | None
+) -> Zs500StandbyReasonSensor:
+    data: dict[str, Any] = {"name": "standby_reason"}
+    if reason is not None:
+        data["reason"] = reason
+    return cast(Zs500StandbyReasonSensor, from_data(system, data))
+
+
+def make_error(
+    system: Zs500System, *, error_code: str | None
+) -> Zs500ErrorBinarySensor:
+    data: dict[str, Any] = {"name": "error"}
+    if error_code is not None:
+        data["errorCode"] = error_code
+    return cast(Zs500ErrorBinarySensor, from_data(system, data))
+
+
+class TestZs500DeviceFromData:
+    @pytest.mark.parametrize(
+        ("name", "expected_class"),
+        [
+            ("climate", Zs500Climate),
+            ("mode", Zs500ModeSelect),
+            ("cooling", Zs500CoolingSwitch),
+            ("heating_priority", Zs500HeatingPrioritySwitch),
+            ("water_temp", Zs500TemperatureSensor),
+            ("air_temp", Zs500TemperatureSensor),
+            ("compressor_speed", Zs500CompressorSpeedSensor),
+            ("standby_reason", Zs500StandbyReasonSensor),
+            ("error", Zs500ErrorBinarySensor),
+        ],
+    )
+    def test_dispatch(self, name: str, expected_class: type) -> None:
+        system = make_system()
+        dev = from_data(system, {"name": name})
+        assert isinstance(dev, expected_class)
+
+    def test_unknown_name_raises(self) -> None:
+        system = make_system()
+        with pytest.raises(ValueError, match="Unknown zs500 device name"):
+            from_data(system, {"name": "bogus"})
+
+    def test_manufacturer_and_model(self) -> None:
+        system = make_system()
+        dev = make_cooling(system, cl=0)
+        assert dev.manufacturer == "Zodiac"
+        assert dev.model == "CoolingSwitch"
+
+    def test_label(self) -> None:
+        system = make_system()
+        dev = make_heating_priority(system, hp=0)
+        assert dev.label == "Heating Priority"
+
+
+class TestZs500Climate:
+    def test_is_on_true(self) -> None:
+        system = make_system()
+        assert make_climate(system, state=2).is_on is True
+
+    def test_is_on_false(self) -> None:
+        system = make_system()
+        assert make_climate(system, state=0).is_on is False
+
+    def test_temperature_unit(self) -> None:
+        system = make_system()
+        assert make_climate(system, state=2).temperature_unit == "C"
+
+    def test_current_temperature_none_without_sibling(self) -> None:
+        system = make_system()
+        climate = make_climate(system, state=2)
+        assert climate.current_temperature is None
+
+    def test_current_temperature_from_sibling(self) -> None:
+        system = make_system()
+        climate = make_climate(system, state=2)
+        system.devices["water_temp"] = make_temperature_sensor(
+            system, name="water_temp", value=230
+        )
+        assert climate.current_temperature == "23.0"
+
+    def test_target_temperature(self) -> None:
+        system = make_system()
+        assert (
+            make_climate(system, state=2, tsp=250).target_temperature == "25.0"
+        )
+
+    def test_min_max_temp(self) -> None:
+        system = make_system()
+        climate = make_climate(system, state=2)
+        assert climate.min_temp == ZS500_TEMP_CELSIUS_LOW
+        assert climate.max_temp == ZS500_TEMP_CELSIUS_HIGH
+
+    async def test_turn_on_payload(self) -> None:
+        system = make_system()
+        climate = make_climate(system, state=0)
+        with patch.object(system, "set_desired", new=AsyncMock()) as mock_set:
+            await climate.turn_on()
+        mock_set.assert_awaited_once_with({"state": 1})
+
+    async def test_turn_on_noop(self) -> None:
+        system = make_system()
+        climate = make_climate(system, state=2)
+        with patch.object(system, "set_desired", new=AsyncMock()) as mock_set:
+            await climate.turn_on()
+        mock_set.assert_not_awaited()
+
+    async def test_turn_off_payload(self) -> None:
+        system = make_system()
+        climate = make_climate(system, state=2)
+        with patch.object(system, "set_desired", new=AsyncMock()) as mock_set:
+            await climate.turn_off()
+        mock_set.assert_awaited_once_with({"state": 0})
+
+    async def test_set_temperature_payload(self) -> None:
+        system = make_system()
+        climate = make_climate(system, state=2)
+        with patch.object(system, "set_desired", new=AsyncMock()) as mock_set:
+            await climate.set_temperature(30)
+        mock_set.assert_awaited_once_with({"tsp": 300})
+
+    async def test_set_temperature_too_low(self) -> None:
+        system = make_system()
+        climate = make_climate(system, state=2)
+        with pytest.raises(AqualinkInvalidParameterException):
+            await climate.set_temperature(ZS500_TEMP_CELSIUS_LOW - 1)
+
+    async def test_set_temperature_too_high(self) -> None:
+        system = make_system()
+        climate = make_climate(system, state=2)
+        with pytest.raises(AqualinkInvalidParameterException):
+            await climate.set_temperature(ZS500_TEMP_CELSIUS_HIGH + 1)
+
+
+class TestZs500ModeSelect:
+    def test_current_option(self) -> None:
+        system = make_system()
+        assert make_mode(system, st=2).current_option == "Smart"
+
+    def test_options(self) -> None:
+        system = make_system()
+        assert make_mode(system, st=0).options == ["Boost", "Silent", "Smart"]
+
+    async def test_select_option_payload(self) -> None:
+        system = make_system()
+        mode = make_mode(system, st=0)
+        with patch.object(system, "set_desired", new=AsyncMock()) as mock_set:
+            await mode.select_option("Silent")
+        mock_set.assert_awaited_once_with({"st": 1})
+
+    async def test_select_invalid_option_raises(self) -> None:
+        system = make_system()
+        mode = make_mode(system, st=0)
+        with pytest.raises(AqualinkInvalidParameterException):
+            await mode.select_option("Eco")
+
+
+class TestZs500CoolingSwitch:
+    def test_is_on_false(self) -> None:
+        system = make_system()
+        assert make_cooling(system, cl=0).is_on is False
+
+    def test_is_on_true(self) -> None:
+        system = make_system()
+        assert make_cooling(system, cl=1).is_on is True
+
+    async def test_turn_on_payload(self) -> None:
+        system = make_system()
+        sw = make_cooling(system, cl=0)
+        with patch.object(system, "set_desired", new=AsyncMock()) as mock_set:
+            await sw.turn_on()
+        mock_set.assert_awaited_once_with({"cl": 1})
+
+    async def test_turn_off_payload(self) -> None:
+        system = make_system()
+        sw = make_cooling(system, cl=1)
+        with patch.object(system, "set_desired", new=AsyncMock()) as mock_set:
+            await sw.turn_off()
+        mock_set.assert_awaited_once_with({"cl": 0})
+
+
+class TestZs500HeatingPrioritySwitch:
+    def test_is_on_false(self) -> None:
+        system = make_system()
+        assert make_heating_priority(system, hp=0).is_on is False
+
+    def test_is_on_true(self) -> None:
+        system = make_system()
+        assert make_heating_priority(system, hp=1).is_on is True
+
+    async def test_turn_on_payload(self) -> None:
+        system = make_system()
+        sw = make_heating_priority(system, hp=0)
+        with patch.object(system, "set_desired", new=AsyncMock()) as mock_set:
+            await sw.turn_on()
+        mock_set.assert_awaited_once_with({"hp": 1})
+
+    async def test_turn_off_payload(self) -> None:
+        system = make_system()
+        sw = make_heating_priority(system, hp=1)
+        with patch.object(system, "set_desired", new=AsyncMock()) as mock_set:
+            await sw.turn_off()
+        mock_set.assert_awaited_once_with({"hp": 0})
+
+
+class TestZs500Sensors:
+    def test_temperature_sensor_value(self) -> None:
+        system = make_system()
+        dev = make_temperature_sensor(system, name="water_temp", value=230)
+        assert dev.value == "23.0"
+        assert dev.unit_of_measurement == "C"
+
+    def test_temperature_sensor_missing_value(self) -> None:
+        system = make_system()
+        dev = make_temperature_sensor(system, name="air_temp", value=None)
+        assert dev.value == ""
+
+    def test_compressor_speed_sensor(self) -> None:
+        system = make_system()
+        dev = make_compressor_speed(system, cmpr_spd=62)
+        assert dev.value == "62"
+        assert dev.unit_of_measurement == "%"
+
+    def test_standby_reason_sensor_translation(self) -> None:
+        system = make_system()
+        dev = make_standby_reason(system, reason=3)
+        assert dev.value == "3"
+        assert dev.value_translated == "TEMPERATURE_BUFFER"
+
+    def test_standby_reason_sensor_default(self) -> None:
+        system = make_system()
+        dev = make_standby_reason(system, reason=None)
+        assert dev.value == "0"
+        assert dev.value_translated == "NONE"
+
+
+class TestZs500ErrorBinarySensor:
+    def test_is_on_false_when_no_error(self) -> None:
+        system = make_system()
+        assert make_error(system, error_code="0").is_on is False
+
+    def test_is_on_true_when_error_present(self) -> None:
+        system = make_system()
+        assert make_error(system, error_code="12").is_on is True
+
+    def test_is_on_false_when_field_missing(self) -> None:
+        system = make_system()
+        assert make_error(system, error_code=None).is_on is False

--- a/tests/systems/zs500/test_system.py
+++ b/tests/systems/zs500/test_system.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from iaqualink.exception import (
+    AqualinkServiceException,
+    AqualinkServiceThrottledException,
+    AqualinkServiceUnauthorizedException,
+)
+from iaqualink.system import SystemStatus
+from iaqualink.systems.zs500.device import Zs500Climate, Zs500TemperatureSensor
+
+from .conftest import Zs500Harness
+
+_REPORTED_CONNECTED: dict[str, Any] = {
+    "aws": {"status": "connected"},
+    "equipment": {
+        "hp_0": {
+            "cl": 1,
+            "cmprSpd": 62,
+            "errorCode": "0",
+            "hp": 0,
+            "reason": 0,
+            "sns_1": {"value": 230},
+            "sns_2": {"value": 187},
+            "st": 2,
+            "state": 2,
+            "tsp": 250,
+        }
+    },
+}
+
+
+def _climate(harness: Zs500Harness) -> Zs500Climate:
+    return cast(Zs500Climate, harness.system.devices["climate"])
+
+
+def _water_temp(harness: Zs500Harness) -> Zs500TemperatureSensor:
+    return cast(Zs500TemperatureSensor, harness.system.devices["water_temp"])
+
+
+class TestZs500SystemRefresh:
+    async def test_refresh_parses_devices(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_response = _REPORTED_CONNECTED
+        await zs500_harness.system.refresh()
+
+        assert zs500_harness.system.status is SystemStatus.CONNECTED
+        assert set(zs500_harness.system.devices) == {
+            "climate",
+            "mode",
+            "cooling",
+            "heating_priority",
+            "compressor_speed",
+            "standby_reason",
+            "error",
+            "water_temp",
+            "air_temp",
+        }
+        assert _climate(zs500_harness).target_temperature == "25.0"
+
+    async def test_refresh_missing_aws_status_is_unknown(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_response = {"equipment": {}}
+        await zs500_harness.system.refresh()
+        assert zs500_harness.system.status is SystemStatus.UNKNOWN
+
+    async def test_refresh_unrecognized_status_is_unknown(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_response = {
+            "aws": {"status": "something_new"},
+            "equipment": {},
+        }
+        await zs500_harness.system.refresh()
+        assert zs500_harness.system.status is SystemStatus.UNKNOWN
+
+    async def test_refresh_no_equipment_keeps_devices_empty(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_response = {"aws": {"status": "connected"}}
+        await zs500_harness.system.refresh()
+        assert zs500_harness.system.devices == {}
+
+
+class TestZs500SystemErrorMapping:
+    async def test_get_rejected_401_triggers_reauth_then_succeeds(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        shadow = zs500_harness.shadow
+        shadow.get_reject_code = 401
+        shadow.get_response = _REPORTED_CONNECTED
+
+        async def fake_refresh_auth() -> None:
+            shadow.get_reject_code = None  # "new token" works on retry
+
+        with patch.object(
+            zs500_harness.system.aqualink,
+            "_refresh_auth",
+            new=AsyncMock(side_effect=fake_refresh_auth),
+        ) as mock_refresh:
+            await zs500_harness.system.refresh()
+            mock_refresh.assert_awaited_once()
+
+        assert zs500_harness.system.status is SystemStatus.CONNECTED
+
+    async def test_get_rejected_401_twice_raises(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_reject_code = 401
+
+        with (
+            patch.object(
+                zs500_harness.system.aqualink, "_refresh_auth", new=AsyncMock()
+            ),
+            pytest.raises(AqualinkServiceUnauthorizedException),
+        ):
+            await zs500_harness.system.refresh()
+
+        assert zs500_harness.system.status is SystemStatus.DISCONNECTED
+
+    async def test_get_rejected_429_raises_throttled(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_reject_code = 429
+
+        with pytest.raises(AqualinkServiceThrottledException):
+            await zs500_harness.system.refresh()
+
+        assert zs500_harness.system.status is SystemStatus.UNKNOWN
+
+    async def test_get_rejected_other_code_raises_service_exception(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_reject_code = 500
+
+        with pytest.raises(AqualinkServiceException):
+            await zs500_harness.system.refresh()
+
+        assert zs500_harness.system.status is SystemStatus.DISCONNECTED
+
+    async def test_no_credentials_raises_unauthorized(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.system.aqualink.iot_credentials = None
+
+        with (
+            patch.object(
+                zs500_harness.system.aqualink, "_refresh_auth", new=AsyncMock()
+            ),
+            pytest.raises(AqualinkServiceUnauthorizedException),
+        ):
+            await zs500_harness.system.refresh()
+
+
+class TestZs500SystemPushUpdates:
+    async def test_push_update_applies_without_refresh(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_response = _REPORTED_CONNECTED
+        await zs500_harness.system.refresh()
+        assert _climate(zs500_harness).target_temperature == "25.0"
+
+        pushed: dict[str, Any] = {
+            "aws": {"status": "connected"},
+            "equipment": {
+                "hp_0": {
+                    "cl": 0,
+                    "cmprSpd": 0,
+                    "errorCode": "0",
+                    "hp": 0,
+                    "reason": 0,
+                    "sns_1": {"value": 260},
+                    "sns_2": {"value": 190},
+                    "st": 1,
+                    "state": 3,
+                    "tsp": 280,
+                }
+            },
+        }
+        zs500_harness.shadow.push(pushed)
+        await asyncio.sleep(0)
+
+        assert _climate(zs500_harness).target_temperature == "28.0"
+        assert _water_temp(zs500_harness).value == "26.0"
+
+
+class TestZs500SystemSetDesired:
+    async def test_set_desired_nests_under_equipment_hp_0(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        await zs500_harness.system.set_desired({"cl": 1})
+
+        assert zs500_harness.shadow.published_updates[-1] == {
+            "equipment": {"hp_0": {"cl": 1}}
+        }
+
+
+class TestZs500SystemLifecycle:
+    async def test_aclose_stops_mqtt_and_clears_state(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_response = _REPORTED_CONNECTED
+        await zs500_harness.system.refresh()
+        assert zs500_harness.system._mqtt is not None  # noqa: SLF001
+
+        await zs500_harness.system.aclose()
+
+        assert zs500_harness.mqtt.stop.called
+        assert zs500_harness.system._mqtt is None  # noqa: SLF001
+        assert zs500_harness.system._shadow is None  # noqa: SLF001
+
+    async def test_aclose_before_connect_is_a_noop(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        await zs500_harness.system.aclose()  # must not raise / hang
+
+    async def test_reconnects_after_aclose(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_response = _REPORTED_CONNECTED
+        await zs500_harness.system.refresh()
+        await zs500_harness.system.aclose()
+
+        # A fresh refresh after aclose() must reconnect rather than reuse
+        # the torn-down connection.
+        await zs500_harness.system.refresh()
+
+        assert zs500_harness.system._mqtt is not None  # noqa: SLF001
+        assert zs500_harness.system.status is SystemStatus.CONNECTED
+
+    def test_repr(self, zs500_harness: Zs500Harness) -> None:
+        r = repr(zs500_harness.system)
+        assert zs500_harness.system.serial in r
+        assert zs500_harness.system.name in r
+
+
+class TestZs500SystemConnectionFailures:
+    async def test_connect_failure_raises_service_exception(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.connect_control.connect_succeeds = False
+
+        with pytest.raises(AqualinkServiceException):
+            await zs500_harness.system.refresh()
+
+        assert zs500_harness.system.status is SystemStatus.DISCONNECTED
+        assert zs500_harness.system._mqtt is None  # noqa: SLF001
+
+    async def test_connect_succeeds_after_earlier_failure(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.connect_control.connect_succeeds = False
+        with pytest.raises(AqualinkServiceException):
+            await zs500_harness.system.refresh()
+
+        zs500_harness.connect_control.connect_succeeds = True
+        zs500_harness.shadow.get_response = _REPORTED_CONNECTED
+        await zs500_harness.system.refresh()
+
+        assert zs500_harness.system.status is SystemStatus.CONNECTED
+
+    async def test_subscribe_failure_raises_service_exception(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.subscribe_fails = True
+
+        with pytest.raises(AqualinkServiceException):
+            await zs500_harness.system.refresh()
+
+        assert zs500_harness.system.status is SystemStatus.DISCONNECTED
+        assert zs500_harness.system._mqtt is None  # noqa: SLF001
+        assert zs500_harness.mqtt.stop.called
+
+    async def test_operation_timeout_raises_service_exception(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.silent = True  # accept/reject never arrives
+
+        with (
+            patch("iaqualink.systems.zs500.system._OPERATION_TIMEOUT", 0.05),
+            pytest.raises(AqualinkServiceException),
+        ):
+            await zs500_harness.system.refresh()
+
+        assert zs500_harness.system.status is SystemStatus.DISCONNECTED
+
+
+class TestZs500SystemConcurrency:
+    """Exercises the _connect_lock guard around _ensure_connected/_disconnect."""
+
+    async def test_concurrent_refresh_calls_share_one_connection(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_response = _REPORTED_CONNECTED
+
+        await asyncio.gather(
+            zs500_harness.system.refresh(),
+            zs500_harness.system.refresh(),
+        )
+
+        # mqtt5_client_builder is invoked once per connect; concurrent
+        # callers must share the single connection rather than racing to
+        # build two.
+        assert zs500_harness.mqtt.start.call_count == 1
+
+    async def test_aclose_during_in_flight_refresh_does_not_crash(
+        self, zs500_harness: Zs500Harness
+    ) -> None:
+        zs500_harness.shadow.get_response = _REPORTED_CONNECTED
+
+        results = await asyncio.gather(
+            zs500_harness.system.refresh(),
+            zs500_harness.system.aclose(),
+            return_exceptions=True,
+        )
+
+        # Either outcome (refresh wins the race and completes, or aclose
+        # tears the connection down first and refresh raises a proper
+        # AqualinkServiceException) is acceptable — what must never happen
+        # is an unguarded AttributeError from a None shadow/mqtt client.
+        for result in results:
+            if isinstance(result, BaseException):
+                assert isinstance(result, AqualinkServiceException)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ import asyncio
 import hashlib
 import hmac
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -354,6 +354,82 @@ class TestAqualinkClient:
         systems = await client.get_systems()
         assert len(systems) == 1
         assert isinstance(next(iter(systems.values())), UnsupportedSystem)
+
+    @patch("httpx.AsyncClient.request")
+    async def test_get_systems_reuses_unchanged_system(
+        self, mock_request
+    ) -> None:
+        client = _make_client()
+        mock_request.return_value.status_code = 200
+        mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
+        await client.login()
+
+        mock_request.return_value.json.return_value = [
+            {"device_type": "foo", "serial_number": "SN123456"}
+        ]
+
+        first = await client.get_systems()
+        second = await client.get_systems()
+
+        assert first["SN123456"] is second["SN123456"]
+
+    @patch("httpx.AsyncClient.request")
+    async def test_get_systems_replaces_changed_device_type(
+        self, mock_request
+    ) -> None:
+        client = _make_client()
+        mock_request.return_value.status_code = 200
+        mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
+        await client.login()
+
+        mock_request.return_value.json.return_value = [
+            {"device_type": "foo", "serial_number": "SN123456"}
+        ]
+        first = await client.get_systems()
+
+        mock_request.return_value.json.return_value = [
+            {"device_type": "bar", "serial_number": "SN123456"}
+        ]
+        second = await client.get_systems()
+
+        assert first["SN123456"] is not second["SN123456"]
+
+    @patch("httpx.AsyncClient.request")
+    async def test_get_systems_closes_systems_it_drops(
+        self, mock_request
+    ) -> None:
+        client = _make_client()
+        mock_request.return_value.status_code = 200
+        mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
+        await client.login()
+
+        mock_request.return_value.json.return_value = [
+            {"device_type": "foo", "serial_number": "SN123456"}
+        ]
+        first = await client.get_systems()
+        old_system = first["SN123456"]
+
+        with patch.object(old_system, "aclose", new=AsyncMock()) as mock_aclose:
+            mock_request.return_value.json.return_value = []
+            await client.get_systems()
+            mock_aclose.assert_awaited_once()
+
+    @patch("httpx.AsyncClient.request")
+    async def test_close_closes_tracked_systems(self, mock_request) -> None:
+        client = _make_client()
+        mock_request.return_value.status_code = 200
+        mock_request.return_value.json = MagicMock(return_value=LOGIN_DATA)
+        await client.login()
+
+        mock_request.return_value.json.return_value = [
+            {"device_type": "foo", "serial_number": "SN123456"}
+        ]
+        systems = await client.get_systems()
+        system = systems["SN123456"]
+
+        with patch.object(system, "aclose", new=AsyncMock()) as mock_aclose:
+            await client.close()
+            mock_aclose.assert_awaited_once()
 
     @patch("httpx.AsyncClient.request")
     async def test_systems_request(self, mock_request) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -75,6 +75,45 @@ wheels = [
 ]
 
 [[package]]
+name = "awscrt"
+version = "0.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/33/ed6d3c91d7b136a91eeea3bea1023e818f5f99d4fcbd8956c645a2dc6006/awscrt-0.34.1.tar.gz", hash = "sha256:a3ae8e35c3a3eefdb2a15859887a05b926d0456d21ccba1b49861cfe46bcc8c2", size = 36975094, upload-time = "2026-06-04T19:03:14.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/34/5737d2c0d1288caa76cb8ae867d4c09a86e31fc03e4f5a9e595308763415/awscrt-0.34.1-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:c7c9c2ef4ec0db16d871fa099158b0617b1b8aa53335b73a88830a6630945c5a", size = 5089351, upload-time = "2026-06-04T19:02:11.912Z" },
+    { url = "https://files.pythonhosted.org/packages/68/0b/79c55c606d83308cfa6d78528497ab72a170494a196261d23bd92ac733e8/awscrt-0.34.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cc7b55bcc719c2ecf6876b8c13a4808a8dda3b19b8936329c711072adc35053c", size = 3919082, upload-time = "2026-06-04T19:02:14.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/aa/494385f153a90e734ac04597e1c69ca6f66d8579bb0383f6fc8c5aa126d6/awscrt-0.34.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c696acaa421e74d7dd44962099099ae967c64c8491f797fe1ec7c32fea1c113", size = 4209970, upload-time = "2026-06-04T19:02:15.698Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/93/e63b09fbdef626e19edfe1bf28ac037153270bceee24327756c83c53c940/awscrt-0.34.1-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:4ab254a7761bb80594eba4ecdae65ba55608dad7ae08f5c0e6876cdf339e8ffe", size = 3827246, upload-time = "2026-06-04T19:02:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/43/edc9a8704f84aaffc3471b69d8da565fa834e8a7f565ced659a78373eaf4/awscrt-0.34.1-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:48b24b3b3de9c3392238181f4529b8d3511fee695f1852807849042681bb4922", size = 4066655, upload-time = "2026-06-04T19:02:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e7/6c49160a8cc84c438cac59c2bd52f80eaf6db05da036495133349b68a351/awscrt-0.34.1-cp311-abi3-win32.whl", hash = "sha256:8356df183947a02a015b8b77ee69a1b24bddf2177db93fb063e6215265ecc33a", size = 4089039, upload-time = "2026-06-04T19:02:20.023Z" },
+    { url = "https://files.pythonhosted.org/packages/74/49/8ae6a3bb2aa32e17c3b8e7ad14f9666edfa924052c22e0098ca525b110c9/awscrt-0.34.1-cp311-abi3-win_amd64.whl", hash = "sha256:40326b5fadafe679c0729f622c4a56cbcb5e91f1b0d2b84fc95f016427b11214", size = 4251132, upload-time = "2026-06-04T19:02:21.308Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d4/dd647d569189bc97f5110339f7ec8ee669d135408c3e2207ce74f951f284/awscrt-0.34.1-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:3750622e9efa1af389a619573a93cf1f7e816454edbdd9c922ba78e6c292668c", size = 5088559, upload-time = "2026-06-04T19:02:22.937Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/6ae127a3ca3ac9e7e4bd2c351be78856d0fe4b9a094cf9163e5f9ba30d76/awscrt-0.34.1-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6eccf12282f773f2d29ef0bb16c3b973976c578ea617d84a8c1d523509d2b5a4", size = 3909549, upload-time = "2026-06-04T19:02:24.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/8f/93df8d004dee2afb938111de203e4534101326c1affc1452eb8d6fb73da9/awscrt-0.34.1-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a39a0c2fed3b7354053b70a4a62428fa40834c9e9ac8570c8b39d3868645bc7", size = 4202624, upload-time = "2026-06-04T19:02:26.003Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f0/b0d96a536c582724aa5ebcfbe03a0c0283adb9379a31465076b8988416cd/awscrt-0.34.1-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:775405da040f8f5223870c389e6b37ad2909849d76a1f028fc713ad1c07889f8", size = 3818941, upload-time = "2026-06-04T19:02:27.398Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/16/92c10101b3f4c10e8d8d6b3ce8b6bd1254cff4c1925244c4e872026c17a4/awscrt-0.34.1-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:d88cc48538efabbf2b6643c13a8b63a758dcf40eeb0405f6ba4066ae4d361866", size = 4061435, upload-time = "2026-06-04T19:02:28.824Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cf/9f1610d5a4d8ed6c5062fea66d9c5bfda6fa354690b6c2121966b1be24b5/awscrt-0.34.1-cp313-abi3-win32.whl", hash = "sha256:534e0d9b415c50395b0602bb5bbc3b506fc36184859d4b6de18642384e46cb17", size = 4087600, upload-time = "2026-06-04T19:02:30.431Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0f/5ac6d4b372cddc9dee02892e2a0ed676fe099d1740b2e5de253f6d9d4825/awscrt-0.34.1-cp313-abi3-win_amd64.whl", hash = "sha256:c680afe517ca09846d6b2abeeb44d37b935f575013afa34d8295fee95cce0b78", size = 4245466, upload-time = "2026-06-04T19:02:31.918Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d7/40d6eba06ae5e4bb2e68125009a701a6f74159b96c921cc0998050c76cc4/awscrt-0.34.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e519f4ba6622a9f5d745e2f49268690f3fac7bad7655911458c80e1cc30bd108", size = 5097638, upload-time = "2026-06-04T19:02:41.438Z" },
+    { url = "https://files.pythonhosted.org/packages/22/14/3ddc4d76ca23c892ca82926d73575913377bf59a31a8b20d4c0c329a6a85/awscrt-0.34.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:185f3e899a24961a1bd6e203a0fdeab6a06a972ddf4a4e3a32b20e31705edd95", size = 4039424, upload-time = "2026-06-04T19:02:42.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/954ac7be390d04160c8570810faeb9512447422752cac2bb277cbb62ab49/awscrt-0.34.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ce386fdaf86f07122305a14a84f5c592b7010d7032c6b5a7dcbf4a72b2704998", size = 4328101, upload-time = "2026-06-04T19:02:44.349Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/b0/bd30e6cca8a9b696866dffb587ac1d5bb09dcba2b62941063b02a7b747ae/awscrt-0.34.1-cp314-cp314t-win32.whl", hash = "sha256:dc68aefe66cd419c3d2a0fa0ecaeb9b72d882ad08f752767dc85740052bbf212", size = 4223490, upload-time = "2026-06-04T19:02:45.687Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f5/4cce09065b37c775ab22dc9f179e03704f3bb9bb5a44cae6bc70b849596d/awscrt-0.34.1-cp314-cp314t-win_amd64.whl", hash = "sha256:1421ee18988c946bb058819b69707c85aca0de395520fcbf1ef9ace0b9e96c62", size = 4400512, upload-time = "2026-06-04T19:02:47.242Z" },
+]
+
+[[package]]
+name = "awsiotsdk"
+version = "1.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/02/7340313e57aa69180deb8c6f4c7ea9887609d2012c22fc4e05d08d20e5e9/awsiotsdk-1.30.0.tar.gz", hash = "sha256:3407abdbcb6718010784bda00860c90e0c4400be1d7f511c6802e4a37861e8b7", size = 93414, upload-time = "2026-06-11T18:26:56.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/cb/3df545b6812c53b89eab27a7b57eeb3344bc3ee70a50fbf948f88a7c1ff8/awsiotsdk-1.30.0-py3-none-any.whl", hash = "sha256:64e45f1d4e6c224a96f5b2178ee166212416cd066300a77507761b87db18736c", size = 81098, upload-time = "2026-06-11T18:26:55.804Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -314,6 +353,8 @@ wheels = [
 name = "iaqualink"
 source = { editable = "." }
 dependencies = [
+    { name = "awscrt" },
+    { name = "awsiotsdk" },
     { name = "httpx", extra = ["http2"] },
 ]
 
@@ -355,6 +396,8 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "awscrt", specifier = ">=0.34.1" },
+    { name = "awsiotsdk", specifier = ">=1.30.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.0" },
     { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0.2" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0" },


### PR DESCRIPTION
## Summary

- Adds a new `zs500` system type for the Zodiac ZS500 heat pump. Protocol research (decompiled-source analysis, see `docs/reference/systems/zs500.md`) found the reference app uses AWS IoT MQTT exclusively for live status/control — the REST shadow endpoint is provisioning-only — so this implements a **persistent MQTT shadow connection with live push updates** rather than HTTP polling like the other systems.
- `AqualinkSystem` gains an `aclose()` hook (no-op for every other system) and `AqualinkClient` now tracks systems it creates so `close()`/`__aexit__` tears down a held connection on shutdown; `get_systems()` reuses unchanged system instances instead of reconnecting on every call.
- `awscrt`/`awsiotsdk` are core dependencies.
- **Experimental**: no physical ZS500 unit was available to validate against. Known assumptions/deltas vs. the protocol reference are documented in `docs/implementation/systems/zs500.md`.

An earlier attempt at this existed in #61, but predates the current device hierarchy, `SystemStatus`/`refresh()` contract, and conformance test harness — not built on directly, though its MQTT/credential plumbing was a useful reference.

## Test plan

- [x] `uv run prek run --show-diff-on-failure --color=always --all-files`
- [x] `uv run pytest` — 1172 passed, 13 skipped (zs500 has zero conformance-suite coverage by design since that suite is HTTP/respx-only; covered instead by a bespoke `FakeShadowClient`-based suite in `tests/systems/zs500/`, including connection-failure, timeout, and concurrency tests)
- [x] `uv run mypy src/`
- [x] Confirmed `import iaqualink` still works cleanly
- [ ] No real-hardware validation possible — flagged as best-effort/experimental in the implementation notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)